### PR TITLE
SmartSPIM Acquisition Example

### DIFF
--- a/examples/smartspim_acquisition.json
+++ b/examples/smartspim_acquisition.json
@@ -1,0 +1,2727 @@
+{
+   "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/imaging/acquisition.py",
+   "schema_version": "0.4.1",
+   "experimenter_full_name": "Erica Peterson",
+   "subject_id": "651286",
+   "instrument_id": "SmartSPIM01",
+   "session_start_time": "2023-02-09T18:44:28",
+   "session_end_time": "2023-02-10T12:42:09",
+   "tiles": [
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  48276.0,
+                  42518.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_488_Em525/482760/482760425180/",
+         "channel": {
+            "channel_name": "488.0",
+            "laser_wavelength": 488,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 45.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 0
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  48276.0,
+                  42518.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_561_Em600/482760/482760425180/",
+         "channel": {
+            "channel_name": "561.0",
+            "laser_wavelength": 561,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 22.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 1
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  48276.0,
+                  42518.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_647_Em690/482760/482760425180/",
+         "channel": {
+            "channel_name": "647.0",
+            "laser_wavelength": 647,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 87.5,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 2
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  51516.0,
+                  42518.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_488_Em525/515160/515160425180/",
+         "channel": {
+            "channel_name": "488.0",
+            "laser_wavelength": 488,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 45.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 0
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  51516.0,
+                  42518.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_561_Em600/515160/515160425180/",
+         "channel": {
+            "channel_name": "561.0",
+            "laser_wavelength": 561,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 22.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 1
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  51516.0,
+                  42518.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_647_Em690/515160/515160425180/",
+         "channel": {
+            "channel_name": "647.0",
+            "laser_wavelength": 647,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 87.5,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 2
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  54756.0,
+                  42518.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_488_Em525/547560/547560425180/",
+         "channel": {
+            "channel_name": "488.0",
+            "laser_wavelength": 488,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 45.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 0
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  54756.0,
+                  42518.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_561_Em600/547560/547560425180/",
+         "channel": {
+            "channel_name": "561.0",
+            "laser_wavelength": 561,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 22.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 1
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  54756.0,
+                  42518.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_647_Em690/547560/547560425180/",
+         "channel": {
+            "channel_name": "647.0",
+            "laser_wavelength": 647,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 87.5,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 2
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  57996.0,
+                  42518.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_488_Em525/579960/579960425180/",
+         "channel": {
+            "channel_name": "488.0",
+            "laser_wavelength": 488,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 45.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 0
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  57996.0,
+                  42518.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_561_Em600/579960/579960425180/",
+         "channel": {
+            "channel_name": "561.0",
+            "laser_wavelength": 561,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 22.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 1
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  57996.0,
+                  42518.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_647_Em690/579960/579960425180/",
+         "channel": {
+            "channel_name": "647.0",
+            "laser_wavelength": 647,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 87.5,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 2
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  48276.0,
+                  45110.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_488_Em525/482760/482760451100/",
+         "channel": {
+            "channel_name": "488.0",
+            "laser_wavelength": 488,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 45.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 0
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  48276.0,
+                  45110.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_561_Em600/482760/482760451100/",
+         "channel": {
+            "channel_name": "561.0",
+            "laser_wavelength": 561,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 22.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 1
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  48276.0,
+                  45110.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_647_Em690/482760/482760451100/",
+         "channel": {
+            "channel_name": "647.0",
+            "laser_wavelength": 647,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 87.5,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 2
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  51516.0,
+                  45110.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_488_Em525/515160/515160451100/",
+         "channel": {
+            "channel_name": "488.0",
+            "laser_wavelength": 488,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 45.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 0
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  51516.0,
+                  45110.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_561_Em600/515160/515160451100/",
+         "channel": {
+            "channel_name": "561.0",
+            "laser_wavelength": 561,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 22.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 1
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  51516.0,
+                  45110.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_647_Em690/515160/515160451100/",
+         "channel": {
+            "channel_name": "647.0",
+            "laser_wavelength": 647,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 87.5,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 2
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  54756.0,
+                  45110.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_488_Em525/547560/547560451100/",
+         "channel": {
+            "channel_name": "488.0",
+            "laser_wavelength": 488,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 45.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 0
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  54756.0,
+                  45110.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_561_Em600/547560/547560451100/",
+         "channel": {
+            "channel_name": "561.0",
+            "laser_wavelength": 561,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 22.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 1
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  54756.0,
+                  45110.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_647_Em690/547560/547560451100/",
+         "channel": {
+            "channel_name": "647.0",
+            "laser_wavelength": 647,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 87.5,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 2
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  57996.0,
+                  45110.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_488_Em525/579960/579960451100/",
+         "channel": {
+            "channel_name": "488.0",
+            "laser_wavelength": 488,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 45.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 0
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  57996.0,
+                  45110.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_561_Em600/579960/579960451100/",
+         "channel": {
+            "channel_name": "561.0",
+            "laser_wavelength": 561,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 22.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 1
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  57996.0,
+                  45110.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_647_Em690/579960/579960451100/",
+         "channel": {
+            "channel_name": "647.0",
+            "laser_wavelength": 647,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 87.5,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 2
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  48276.0,
+                  47702.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_488_Em525/482760/482760477020/",
+         "channel": {
+            "channel_name": "488.0",
+            "laser_wavelength": 488,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 45.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 0
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  48276.0,
+                  47702.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_561_Em600/482760/482760477020/",
+         "channel": {
+            "channel_name": "561.0",
+            "laser_wavelength": 561,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 22.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 1
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  48276.0,
+                  47702.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_647_Em690/482760/482760477020/",
+         "channel": {
+            "channel_name": "647.0",
+            "laser_wavelength": 647,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 87.5,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 2
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  51516.0,
+                  47702.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_488_Em525/515160/515160477020/",
+         "channel": {
+            "channel_name": "488.0",
+            "laser_wavelength": 488,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 45.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 0
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  51516.0,
+                  47702.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_561_Em600/515160/515160477020/",
+         "channel": {
+            "channel_name": "561.0",
+            "laser_wavelength": 561,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 22.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 1
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  51516.0,
+                  47702.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_647_Em690/515160/515160477020/",
+         "channel": {
+            "channel_name": "647.0",
+            "laser_wavelength": 647,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 87.5,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 2
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  54756.0,
+                  47702.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_488_Em525/547560/547560477020/",
+         "channel": {
+            "channel_name": "488.0",
+            "laser_wavelength": 488,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 45.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 0
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  54756.0,
+                  47702.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_561_Em600/547560/547560477020/",
+         "channel": {
+            "channel_name": "561.0",
+            "laser_wavelength": 561,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 22.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 1
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  54756.0,
+                  47702.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_647_Em690/547560/547560477020/",
+         "channel": {
+            "channel_name": "647.0",
+            "laser_wavelength": 647,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 87.5,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 2
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  57996.0,
+                  47702.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_488_Em525/579960/579960477020/",
+         "channel": {
+            "channel_name": "488.0",
+            "laser_wavelength": 488,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 45.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 0
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  57996.0,
+                  47702.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_561_Em600/579960/579960477020/",
+         "channel": {
+            "channel_name": "561.0",
+            "laser_wavelength": 561,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 22.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 1
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  57996.0,
+                  47702.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_647_Em690/579960/579960477020/",
+         "channel": {
+            "channel_name": "647.0",
+            "laser_wavelength": 647,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 87.5,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 2
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  48276.0,
+                  50294.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_488_Em525/482760/482760502940/",
+         "channel": {
+            "channel_name": "488.0",
+            "laser_wavelength": 488,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 45.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 0
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  48276.0,
+                  50294.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_561_Em600/482760/482760502940/",
+         "channel": {
+            "channel_name": "561.0",
+            "laser_wavelength": 561,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 22.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 1
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  48276.0,
+                  50294.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_647_Em690/482760/482760502940/",
+         "channel": {
+            "channel_name": "647.0",
+            "laser_wavelength": 647,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 87.5,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 2
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  51516.0,
+                  50294.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_488_Em525/515160/515160502940/",
+         "channel": {
+            "channel_name": "488.0",
+            "laser_wavelength": 488,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 45.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 0
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  51516.0,
+                  50294.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_561_Em600/515160/515160502940/",
+         "channel": {
+            "channel_name": "561.0",
+            "laser_wavelength": 561,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 22.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 1
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  51516.0,
+                  50294.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_647_Em690/515160/515160502940/",
+         "channel": {
+            "channel_name": "647.0",
+            "laser_wavelength": 647,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 87.5,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 2
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  54756.0,
+                  50294.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_488_Em525/547560/547560502940/",
+         "channel": {
+            "channel_name": "488.0",
+            "laser_wavelength": 488,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 45.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 0
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  54756.0,
+                  50294.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_561_Em600/547560/547560502940/",
+         "channel": {
+            "channel_name": "561.0",
+            "laser_wavelength": 561,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 22.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 1
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  54756.0,
+                  50294.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_647_Em690/547560/547560502940/",
+         "channel": {
+            "channel_name": "647.0",
+            "laser_wavelength": 647,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 87.5,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 2
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  57996.0,
+                  50294.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_488_Em525/579960/579960502940/",
+         "channel": {
+            "channel_name": "488.0",
+            "laser_wavelength": 488,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 45.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 0
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  57996.0,
+                  50294.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_561_Em600/579960/579960502940/",
+         "channel": {
+            "channel_name": "561.0",
+            "laser_wavelength": 561,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 22.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 1
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  57996.0,
+                  50294.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_647_Em690/579960/579960502940/",
+         "channel": {
+            "channel_name": "647.0",
+            "laser_wavelength": 647,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 87.5,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 2
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  48276.0,
+                  52886.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_488_Em525/482760/482760528860/",
+         "channel": {
+            "channel_name": "488.0",
+            "laser_wavelength": 488,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 45.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 0
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  48276.0,
+                  52886.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_561_Em600/482760/482760528860/",
+         "channel": {
+            "channel_name": "561.0",
+            "laser_wavelength": 561,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 22.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 1
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  48276.0,
+                  52886.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_647_Em690/482760/482760528860/",
+         "channel": {
+            "channel_name": "647.0",
+            "laser_wavelength": 647,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 87.5,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 2
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  51516.0,
+                  52886.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_488_Em525/515160/515160528860/",
+         "channel": {
+            "channel_name": "488.0",
+            "laser_wavelength": 488,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 45.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 0
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  51516.0,
+                  52886.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_561_Em600/515160/515160528860/",
+         "channel": {
+            "channel_name": "561.0",
+            "laser_wavelength": 561,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 22.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 1
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  51516.0,
+                  52886.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_647_Em690/515160/515160528860/",
+         "channel": {
+            "channel_name": "647.0",
+            "laser_wavelength": 647,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 87.5,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 2
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  54756.0,
+                  52886.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_488_Em525/547560/547560528860/",
+         "channel": {
+            "channel_name": "488.0",
+            "laser_wavelength": 488,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 45.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 0
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  54756.0,
+                  52886.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_561_Em600/547560/547560528860/",
+         "channel": {
+            "channel_name": "561.0",
+            "laser_wavelength": 561,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 22.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 1
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  54756.0,
+                  52886.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_647_Em690/547560/547560528860/",
+         "channel": {
+            "channel_name": "647.0",
+            "laser_wavelength": 647,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 87.5,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 2
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  57996.0,
+                  52886.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_488_Em525/579960/579960528860/",
+         "channel": {
+            "channel_name": "488.0",
+            "laser_wavelength": 488,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 45.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 0
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  57996.0,
+                  52886.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_561_Em600/579960/579960528860/",
+         "channel": {
+            "channel_name": "561.0",
+            "laser_wavelength": 561,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 22.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 1
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  57996.0,
+                  52886.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_647_Em690/579960/579960528860/",
+         "channel": {
+            "channel_name": "647.0",
+            "laser_wavelength": 647,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 87.5,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 2
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  48276.0,
+                  55478.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_488_Em525/482760/482760554780/",
+         "channel": {
+            "channel_name": "488.0",
+            "laser_wavelength": 488,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 45.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 0
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  48276.0,
+                  55478.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_561_Em600/482760/482760554780/",
+         "channel": {
+            "channel_name": "561.0",
+            "laser_wavelength": 561,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 22.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 1
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  48276.0,
+                  55478.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_647_Em690/482760/482760554780/",
+         "channel": {
+            "channel_name": "647.0",
+            "laser_wavelength": 647,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 87.5,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 2
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  51516.0,
+                  55478.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_488_Em525/515160/515160554780/",
+         "channel": {
+            "channel_name": "488.0",
+            "laser_wavelength": 488,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 45.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 0
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  51516.0,
+                  55478.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_561_Em600/515160/515160554780/",
+         "channel": {
+            "channel_name": "561.0",
+            "laser_wavelength": 561,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 22.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 1
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  51516.0,
+                  55478.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_647_Em690/515160/515160554780/",
+         "channel": {
+            "channel_name": "647.0",
+            "laser_wavelength": 647,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 87.5,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 2
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  54756.0,
+                  55478.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_488_Em525/547560/547560554780/",
+         "channel": {
+            "channel_name": "488.0",
+            "laser_wavelength": 488,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 45.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 0
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  54756.0,
+                  55478.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_561_Em600/547560/547560554780/",
+         "channel": {
+            "channel_name": "561.0",
+            "laser_wavelength": 561,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 22.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 1
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  54756.0,
+                  55478.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_647_Em690/547560/547560554780/",
+         "channel": {
+            "channel_name": "647.0",
+            "laser_wavelength": 647,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 87.5,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 2
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  57996.0,
+                  55478.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_488_Em525/579960/579960554780/",
+         "channel": {
+            "channel_name": "488.0",
+            "laser_wavelength": 488,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 45.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 0
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  57996.0,
+                  55478.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_561_Em600/579960/579960554780/",
+         "channel": {
+            "channel_name": "561.0",
+            "laser_wavelength": 561,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 22.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 1
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  57996.0,
+                  55478.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_647_Em690/579960/579960554780/",
+         "channel": {
+            "channel_name": "647.0",
+            "laser_wavelength": 647,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 87.5,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 2
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  48276.0,
+                  58070.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_488_Em525/482760/482760580700/",
+         "channel": {
+            "channel_name": "488.0",
+            "laser_wavelength": 488,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 45.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 0
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  48276.0,
+                  58070.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_561_Em600/482760/482760580700/",
+         "channel": {
+            "channel_name": "561.0",
+            "laser_wavelength": 561,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 22.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 1
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  48276.0,
+                  58070.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_647_Em690/482760/482760580700/",
+         "channel": {
+            "channel_name": "647.0",
+            "laser_wavelength": 647,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 87.5,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 2
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  51516.0,
+                  58070.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_488_Em525/515160/515160580700/",
+         "channel": {
+            "channel_name": "488.0",
+            "laser_wavelength": 488,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 45.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 0
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  51516.0,
+                  58070.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_561_Em600/515160/515160580700/",
+         "channel": {
+            "channel_name": "561.0",
+            "laser_wavelength": 561,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 22.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 1
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  51516.0,
+                  58070.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_647_Em690/515160/515160580700/",
+         "channel": {
+            "channel_name": "647.0",
+            "laser_wavelength": 647,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 87.5,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 2
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  54756.0,
+                  58070.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_488_Em525/547560/547560580700/",
+         "channel": {
+            "channel_name": "488.0",
+            "laser_wavelength": 488,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 45.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 0
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  54756.0,
+                  58070.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_561_Em600/547560/547560580700/",
+         "channel": {
+            "channel_name": "561.0",
+            "laser_wavelength": 561,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 22.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 1
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  54756.0,
+                  58070.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_647_Em690/547560/547560580700/",
+         "channel": {
+            "channel_name": "647.0",
+            "laser_wavelength": 647,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 87.5,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 2
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  57996.0,
+                  58070.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_488_Em525/579960/579960580700/",
+         "channel": {
+            "channel_name": "488.0",
+            "laser_wavelength": 488,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 45.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 0
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  57996.0,
+                  58070.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_561_Em600/579960/579960580700/",
+         "channel": {
+            "channel_name": "561.0",
+            "laser_wavelength": 561,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 22.0,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 1
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "translation",
+               "translation": [
+                  57996.0,
+                  58070.0,
+                  130.2
+               ]
+            },
+            {
+               "type": "scale",
+               "scale": [
+                  1.8,
+                  1.8,
+                  2.0
+               ]
+            }
+         ],
+         "file_name": "Ex_647_Em690/579960/579960580700/",
+         "channel": {
+            "channel_name": "647.0",
+            "laser_wavelength": 647,
+            "laser_wavelength_unit": "nanometer",
+            "laser_power": 87.5,
+            "laser_power_unit": "milliwatt",
+            "filter_wheel_index": 2
+         },
+         "notes": "Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration",
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degree"
+      }
+   ],
+   "axes": [
+      {
+         "name": "X",
+         "dimension": 2,
+         "direction": "Left_to_right",
+         "unit": "micrometer"
+      },
+      {
+         "name": "Y",
+         "dimension": 1,
+         "direction": "Posterior_to_anterior",
+         "unit": "micrometer"
+      },
+      {
+         "name": "Z",
+         "dimension": 0,
+         "direction": "Superior_to_inferior",
+         "unit": "micrometer"
+      }
+   ],
+   "chamber_immersion": {
+      "medium": "Cargille",
+      "refractive_index": 1.522
+   },
+   "sample_immersion": null,
+   "active_objectives": null,
+   "local_storage_directory": "D:",
+   "external_storage_directory": ""
+}

--- a/examples/smartspim_acquisition.json
+++ b/examples/smartspim_acquisition.json
@@ -26,7 +26,7 @@
                ]
             }
          ],
-         "file_name": "Ex_488_Em525/482760/482760425180/",
+         "file_name": "Ex_488_Em_525/482760/482760_425180/",
          "channel": {
             "channel_name": "488.0",
             "laser_wavelength": 488,
@@ -58,7 +58,7 @@
                ]
             }
          ],
-         "file_name": "Ex_561_Em600/482760/482760425180/",
+         "file_name": "Ex_561_Em_600/482760/482760_425180/",
          "channel": {
             "channel_name": "561.0",
             "laser_wavelength": 561,
@@ -90,7 +90,7 @@
                ]
             }
          ],
-         "file_name": "Ex_647_Em690/482760/482760425180/",
+         "file_name": "Ex_647_Em_690/482760/482760_425180/",
          "channel": {
             "channel_name": "647.0",
             "laser_wavelength": 647,
@@ -122,7 +122,7 @@
                ]
             }
          ],
-         "file_name": "Ex_488_Em525/515160/515160425180/",
+         "file_name": "Ex_488_Em_525/515160/515160_425180/",
          "channel": {
             "channel_name": "488.0",
             "laser_wavelength": 488,
@@ -154,7 +154,7 @@
                ]
             }
          ],
-         "file_name": "Ex_561_Em600/515160/515160425180/",
+         "file_name": "Ex_561_Em_600/515160/515160_425180/",
          "channel": {
             "channel_name": "561.0",
             "laser_wavelength": 561,
@@ -186,7 +186,7 @@
                ]
             }
          ],
-         "file_name": "Ex_647_Em690/515160/515160425180/",
+         "file_name": "Ex_647_Em_690/515160/515160_425180/",
          "channel": {
             "channel_name": "647.0",
             "laser_wavelength": 647,
@@ -218,7 +218,7 @@
                ]
             }
          ],
-         "file_name": "Ex_488_Em525/547560/547560425180/",
+         "file_name": "Ex_488_Em_525/547560/547560_425180/",
          "channel": {
             "channel_name": "488.0",
             "laser_wavelength": 488,
@@ -250,7 +250,7 @@
                ]
             }
          ],
-         "file_name": "Ex_561_Em600/547560/547560425180/",
+         "file_name": "Ex_561_Em_600/547560/547560_425180/",
          "channel": {
             "channel_name": "561.0",
             "laser_wavelength": 561,
@@ -282,7 +282,7 @@
                ]
             }
          ],
-         "file_name": "Ex_647_Em690/547560/547560425180/",
+         "file_name": "Ex_647_Em_690/547560/547560_425180/",
          "channel": {
             "channel_name": "647.0",
             "laser_wavelength": 647,
@@ -314,7 +314,7 @@
                ]
             }
          ],
-         "file_name": "Ex_488_Em525/579960/579960425180/",
+         "file_name": "Ex_488_Em_525/579960/579960_425180/",
          "channel": {
             "channel_name": "488.0",
             "laser_wavelength": 488,
@@ -346,7 +346,7 @@
                ]
             }
          ],
-         "file_name": "Ex_561_Em600/579960/579960425180/",
+         "file_name": "Ex_561_Em_600/579960/579960_425180/",
          "channel": {
             "channel_name": "561.0",
             "laser_wavelength": 561,
@@ -378,7 +378,7 @@
                ]
             }
          ],
-         "file_name": "Ex_647_Em690/579960/579960425180/",
+         "file_name": "Ex_647_Em_690/579960/579960_425180/",
          "channel": {
             "channel_name": "647.0",
             "laser_wavelength": 647,
@@ -410,7 +410,7 @@
                ]
             }
          ],
-         "file_name": "Ex_488_Em525/482760/482760451100/",
+         "file_name": "Ex_488_Em_525/482760/482760_451100/",
          "channel": {
             "channel_name": "488.0",
             "laser_wavelength": 488,
@@ -442,7 +442,7 @@
                ]
             }
          ],
-         "file_name": "Ex_561_Em600/482760/482760451100/",
+         "file_name": "Ex_561_Em_600/482760/482760_451100/",
          "channel": {
             "channel_name": "561.0",
             "laser_wavelength": 561,
@@ -474,7 +474,7 @@
                ]
             }
          ],
-         "file_name": "Ex_647_Em690/482760/482760451100/",
+         "file_name": "Ex_647_Em_690/482760/482760_451100/",
          "channel": {
             "channel_name": "647.0",
             "laser_wavelength": 647,
@@ -506,7 +506,7 @@
                ]
             }
          ],
-         "file_name": "Ex_488_Em525/515160/515160451100/",
+         "file_name": "Ex_488_Em_525/515160/515160_451100/",
          "channel": {
             "channel_name": "488.0",
             "laser_wavelength": 488,
@@ -538,7 +538,7 @@
                ]
             }
          ],
-         "file_name": "Ex_561_Em600/515160/515160451100/",
+         "file_name": "Ex_561_Em_600/515160/515160_451100/",
          "channel": {
             "channel_name": "561.0",
             "laser_wavelength": 561,
@@ -570,7 +570,7 @@
                ]
             }
          ],
-         "file_name": "Ex_647_Em690/515160/515160451100/",
+         "file_name": "Ex_647_Em_690/515160/515160_451100/",
          "channel": {
             "channel_name": "647.0",
             "laser_wavelength": 647,
@@ -602,7 +602,7 @@
                ]
             }
          ],
-         "file_name": "Ex_488_Em525/547560/547560451100/",
+         "file_name": "Ex_488_Em_525/547560/547560_451100/",
          "channel": {
             "channel_name": "488.0",
             "laser_wavelength": 488,
@@ -634,7 +634,7 @@
                ]
             }
          ],
-         "file_name": "Ex_561_Em600/547560/547560451100/",
+         "file_name": "Ex_561_Em_600/547560/547560_451100/",
          "channel": {
             "channel_name": "561.0",
             "laser_wavelength": 561,
@@ -666,7 +666,7 @@
                ]
             }
          ],
-         "file_name": "Ex_647_Em690/547560/547560451100/",
+         "file_name": "Ex_647_Em_690/547560/547560_451100/",
          "channel": {
             "channel_name": "647.0",
             "laser_wavelength": 647,
@@ -698,7 +698,7 @@
                ]
             }
          ],
-         "file_name": "Ex_488_Em525/579960/579960451100/",
+         "file_name": "Ex_488_Em_525/579960/579960_451100/",
          "channel": {
             "channel_name": "488.0",
             "laser_wavelength": 488,
@@ -730,7 +730,7 @@
                ]
             }
          ],
-         "file_name": "Ex_561_Em600/579960/579960451100/",
+         "file_name": "Ex_561_Em_600/579960/579960_451100/",
          "channel": {
             "channel_name": "561.0",
             "laser_wavelength": 561,
@@ -762,7 +762,7 @@
                ]
             }
          ],
-         "file_name": "Ex_647_Em690/579960/579960451100/",
+         "file_name": "Ex_647_Em_690/579960/579960_451100/",
          "channel": {
             "channel_name": "647.0",
             "laser_wavelength": 647,
@@ -794,7 +794,7 @@
                ]
             }
          ],
-         "file_name": "Ex_488_Em525/482760/482760477020/",
+         "file_name": "Ex_488_Em_525/482760/482760_477020/",
          "channel": {
             "channel_name": "488.0",
             "laser_wavelength": 488,
@@ -826,7 +826,7 @@
                ]
             }
          ],
-         "file_name": "Ex_561_Em600/482760/482760477020/",
+         "file_name": "Ex_561_Em_600/482760/482760_477020/",
          "channel": {
             "channel_name": "561.0",
             "laser_wavelength": 561,
@@ -858,7 +858,7 @@
                ]
             }
          ],
-         "file_name": "Ex_647_Em690/482760/482760477020/",
+         "file_name": "Ex_647_Em_690/482760/482760_477020/",
          "channel": {
             "channel_name": "647.0",
             "laser_wavelength": 647,
@@ -890,7 +890,7 @@
                ]
             }
          ],
-         "file_name": "Ex_488_Em525/515160/515160477020/",
+         "file_name": "Ex_488_Em_525/515160/515160_477020/",
          "channel": {
             "channel_name": "488.0",
             "laser_wavelength": 488,
@@ -922,7 +922,7 @@
                ]
             }
          ],
-         "file_name": "Ex_561_Em600/515160/515160477020/",
+         "file_name": "Ex_561_Em_600/515160/515160_477020/",
          "channel": {
             "channel_name": "561.0",
             "laser_wavelength": 561,
@@ -954,7 +954,7 @@
                ]
             }
          ],
-         "file_name": "Ex_647_Em690/515160/515160477020/",
+         "file_name": "Ex_647_Em_690/515160/515160_477020/",
          "channel": {
             "channel_name": "647.0",
             "laser_wavelength": 647,
@@ -986,7 +986,7 @@
                ]
             }
          ],
-         "file_name": "Ex_488_Em525/547560/547560477020/",
+         "file_name": "Ex_488_Em_525/547560/547560_477020/",
          "channel": {
             "channel_name": "488.0",
             "laser_wavelength": 488,
@@ -1018,7 +1018,7 @@
                ]
             }
          ],
-         "file_name": "Ex_561_Em600/547560/547560477020/",
+         "file_name": "Ex_561_Em_600/547560/547560_477020/",
          "channel": {
             "channel_name": "561.0",
             "laser_wavelength": 561,
@@ -1050,7 +1050,7 @@
                ]
             }
          ],
-         "file_name": "Ex_647_Em690/547560/547560477020/",
+         "file_name": "Ex_647_Em_690/547560/547560_477020/",
          "channel": {
             "channel_name": "647.0",
             "laser_wavelength": 647,
@@ -1082,7 +1082,7 @@
                ]
             }
          ],
-         "file_name": "Ex_488_Em525/579960/579960477020/",
+         "file_name": "Ex_488_Em_525/579960/579960_477020/",
          "channel": {
             "channel_name": "488.0",
             "laser_wavelength": 488,
@@ -1114,7 +1114,7 @@
                ]
             }
          ],
-         "file_name": "Ex_561_Em600/579960/579960477020/",
+         "file_name": "Ex_561_Em_600/579960/579960_477020/",
          "channel": {
             "channel_name": "561.0",
             "laser_wavelength": 561,
@@ -1146,7 +1146,7 @@
                ]
             }
          ],
-         "file_name": "Ex_647_Em690/579960/579960477020/",
+         "file_name": "Ex_647_Em_690/579960/579960_477020/",
          "channel": {
             "channel_name": "647.0",
             "laser_wavelength": 647,
@@ -1178,7 +1178,7 @@
                ]
             }
          ],
-         "file_name": "Ex_488_Em525/482760/482760502940/",
+         "file_name": "Ex_488_Em_525/482760/482760_502940/",
          "channel": {
             "channel_name": "488.0",
             "laser_wavelength": 488,
@@ -1210,7 +1210,7 @@
                ]
             }
          ],
-         "file_name": "Ex_561_Em600/482760/482760502940/",
+         "file_name": "Ex_561_Em_600/482760/482760_502940/",
          "channel": {
             "channel_name": "561.0",
             "laser_wavelength": 561,
@@ -1242,7 +1242,7 @@
                ]
             }
          ],
-         "file_name": "Ex_647_Em690/482760/482760502940/",
+         "file_name": "Ex_647_Em_690/482760/482760_502940/",
          "channel": {
             "channel_name": "647.0",
             "laser_wavelength": 647,
@@ -1274,7 +1274,7 @@
                ]
             }
          ],
-         "file_name": "Ex_488_Em525/515160/515160502940/",
+         "file_name": "Ex_488_Em_525/515160/515160_502940/",
          "channel": {
             "channel_name": "488.0",
             "laser_wavelength": 488,
@@ -1306,7 +1306,7 @@
                ]
             }
          ],
-         "file_name": "Ex_561_Em600/515160/515160502940/",
+         "file_name": "Ex_561_Em_600/515160/515160_502940/",
          "channel": {
             "channel_name": "561.0",
             "laser_wavelength": 561,
@@ -1338,7 +1338,7 @@
                ]
             }
          ],
-         "file_name": "Ex_647_Em690/515160/515160502940/",
+         "file_name": "Ex_647_Em_690/515160/515160_502940/",
          "channel": {
             "channel_name": "647.0",
             "laser_wavelength": 647,
@@ -1370,7 +1370,7 @@
                ]
             }
          ],
-         "file_name": "Ex_488_Em525/547560/547560502940/",
+         "file_name": "Ex_488_Em_525/547560/547560_502940/",
          "channel": {
             "channel_name": "488.0",
             "laser_wavelength": 488,
@@ -1402,7 +1402,7 @@
                ]
             }
          ],
-         "file_name": "Ex_561_Em600/547560/547560502940/",
+         "file_name": "Ex_561_Em_600/547560/547560_502940/",
          "channel": {
             "channel_name": "561.0",
             "laser_wavelength": 561,
@@ -1434,7 +1434,7 @@
                ]
             }
          ],
-         "file_name": "Ex_647_Em690/547560/547560502940/",
+         "file_name": "Ex_647_Em_690/547560/547560_502940/",
          "channel": {
             "channel_name": "647.0",
             "laser_wavelength": 647,
@@ -1466,7 +1466,7 @@
                ]
             }
          ],
-         "file_name": "Ex_488_Em525/579960/579960502940/",
+         "file_name": "Ex_488_Em_525/579960/579960_502940/",
          "channel": {
             "channel_name": "488.0",
             "laser_wavelength": 488,
@@ -1498,7 +1498,7 @@
                ]
             }
          ],
-         "file_name": "Ex_561_Em600/579960/579960502940/",
+         "file_name": "Ex_561_Em_600/579960/579960_502940/",
          "channel": {
             "channel_name": "561.0",
             "laser_wavelength": 561,
@@ -1530,7 +1530,7 @@
                ]
             }
          ],
-         "file_name": "Ex_647_Em690/579960/579960502940/",
+         "file_name": "Ex_647_Em_690/579960/579960_502940/",
          "channel": {
             "channel_name": "647.0",
             "laser_wavelength": 647,
@@ -1562,7 +1562,7 @@
                ]
             }
          ],
-         "file_name": "Ex_488_Em525/482760/482760528860/",
+         "file_name": "Ex_488_Em_525/482760/482760_528860/",
          "channel": {
             "channel_name": "488.0",
             "laser_wavelength": 488,
@@ -1594,7 +1594,7 @@
                ]
             }
          ],
-         "file_name": "Ex_561_Em600/482760/482760528860/",
+         "file_name": "Ex_561_Em_600/482760/482760_528860/",
          "channel": {
             "channel_name": "561.0",
             "laser_wavelength": 561,
@@ -1626,7 +1626,7 @@
                ]
             }
          ],
-         "file_name": "Ex_647_Em690/482760/482760528860/",
+         "file_name": "Ex_647_Em_690/482760/482760_528860/",
          "channel": {
             "channel_name": "647.0",
             "laser_wavelength": 647,
@@ -1658,7 +1658,7 @@
                ]
             }
          ],
-         "file_name": "Ex_488_Em525/515160/515160528860/",
+         "file_name": "Ex_488_Em_525/515160/515160_528860/",
          "channel": {
             "channel_name": "488.0",
             "laser_wavelength": 488,
@@ -1690,7 +1690,7 @@
                ]
             }
          ],
-         "file_name": "Ex_561_Em600/515160/515160528860/",
+         "file_name": "Ex_561_Em_600/515160/515160_528860/",
          "channel": {
             "channel_name": "561.0",
             "laser_wavelength": 561,
@@ -1722,7 +1722,7 @@
                ]
             }
          ],
-         "file_name": "Ex_647_Em690/515160/515160528860/",
+         "file_name": "Ex_647_Em_690/515160/515160_528860/",
          "channel": {
             "channel_name": "647.0",
             "laser_wavelength": 647,
@@ -1754,7 +1754,7 @@
                ]
             }
          ],
-         "file_name": "Ex_488_Em525/547560/547560528860/",
+         "file_name": "Ex_488_Em_525/547560/547560_528860/",
          "channel": {
             "channel_name": "488.0",
             "laser_wavelength": 488,
@@ -1786,7 +1786,7 @@
                ]
             }
          ],
-         "file_name": "Ex_561_Em600/547560/547560528860/",
+         "file_name": "Ex_561_Em_600/547560/547560_528860/",
          "channel": {
             "channel_name": "561.0",
             "laser_wavelength": 561,
@@ -1818,7 +1818,7 @@
                ]
             }
          ],
-         "file_name": "Ex_647_Em690/547560/547560528860/",
+         "file_name": "Ex_647_Em_690/547560/547560_528860/",
          "channel": {
             "channel_name": "647.0",
             "laser_wavelength": 647,
@@ -1850,7 +1850,7 @@
                ]
             }
          ],
-         "file_name": "Ex_488_Em525/579960/579960528860/",
+         "file_name": "Ex_488_Em_525/579960/579960_528860/",
          "channel": {
             "channel_name": "488.0",
             "laser_wavelength": 488,
@@ -1882,7 +1882,7 @@
                ]
             }
          ],
-         "file_name": "Ex_561_Em600/579960/579960528860/",
+         "file_name": "Ex_561_Em_600/579960/579960_528860/",
          "channel": {
             "channel_name": "561.0",
             "laser_wavelength": 561,
@@ -1914,7 +1914,7 @@
                ]
             }
          ],
-         "file_name": "Ex_647_Em690/579960/579960528860/",
+         "file_name": "Ex_647_Em_690/579960/579960_528860/",
          "channel": {
             "channel_name": "647.0",
             "laser_wavelength": 647,
@@ -1946,7 +1946,7 @@
                ]
             }
          ],
-         "file_name": "Ex_488_Em525/482760/482760554780/",
+         "file_name": "Ex_488_Em_525/482760/482760_554780/",
          "channel": {
             "channel_name": "488.0",
             "laser_wavelength": 488,
@@ -1978,7 +1978,7 @@
                ]
             }
          ],
-         "file_name": "Ex_561_Em600/482760/482760554780/",
+         "file_name": "Ex_561_Em_600/482760/482760_554780/",
          "channel": {
             "channel_name": "561.0",
             "laser_wavelength": 561,
@@ -2010,7 +2010,7 @@
                ]
             }
          ],
-         "file_name": "Ex_647_Em690/482760/482760554780/",
+         "file_name": "Ex_647_Em_690/482760/482760_554780/",
          "channel": {
             "channel_name": "647.0",
             "laser_wavelength": 647,
@@ -2042,7 +2042,7 @@
                ]
             }
          ],
-         "file_name": "Ex_488_Em525/515160/515160554780/",
+         "file_name": "Ex_488_Em_525/515160/515160_554780/",
          "channel": {
             "channel_name": "488.0",
             "laser_wavelength": 488,
@@ -2074,7 +2074,7 @@
                ]
             }
          ],
-         "file_name": "Ex_561_Em600/515160/515160554780/",
+         "file_name": "Ex_561_Em_600/515160/515160_554780/",
          "channel": {
             "channel_name": "561.0",
             "laser_wavelength": 561,
@@ -2106,7 +2106,7 @@
                ]
             }
          ],
-         "file_name": "Ex_647_Em690/515160/515160554780/",
+         "file_name": "Ex_647_Em_690/515160/515160_554780/",
          "channel": {
             "channel_name": "647.0",
             "laser_wavelength": 647,
@@ -2138,7 +2138,7 @@
                ]
             }
          ],
-         "file_name": "Ex_488_Em525/547560/547560554780/",
+         "file_name": "Ex_488_Em_525/547560/547560_554780/",
          "channel": {
             "channel_name": "488.0",
             "laser_wavelength": 488,
@@ -2170,7 +2170,7 @@
                ]
             }
          ],
-         "file_name": "Ex_561_Em600/547560/547560554780/",
+         "file_name": "Ex_561_Em_600/547560/547560_554780/",
          "channel": {
             "channel_name": "561.0",
             "laser_wavelength": 561,
@@ -2202,7 +2202,7 @@
                ]
             }
          ],
-         "file_name": "Ex_647_Em690/547560/547560554780/",
+         "file_name": "Ex_647_Em_690/547560/547560_554780/",
          "channel": {
             "channel_name": "647.0",
             "laser_wavelength": 647,
@@ -2234,7 +2234,7 @@
                ]
             }
          ],
-         "file_name": "Ex_488_Em525/579960/579960554780/",
+         "file_name": "Ex_488_Em_525/579960/579960_554780/",
          "channel": {
             "channel_name": "488.0",
             "laser_wavelength": 488,
@@ -2266,7 +2266,7 @@
                ]
             }
          ],
-         "file_name": "Ex_561_Em600/579960/579960554780/",
+         "file_name": "Ex_561_Em_600/579960/579960_554780/",
          "channel": {
             "channel_name": "561.0",
             "laser_wavelength": 561,
@@ -2298,7 +2298,7 @@
                ]
             }
          ],
-         "file_name": "Ex_647_Em690/579960/579960554780/",
+         "file_name": "Ex_647_Em_690/579960/579960_554780/",
          "channel": {
             "channel_name": "647.0",
             "laser_wavelength": 647,
@@ -2330,7 +2330,7 @@
                ]
             }
          ],
-         "file_name": "Ex_488_Em525/482760/482760580700/",
+         "file_name": "Ex_488_Em_525/482760/482760_580700/",
          "channel": {
             "channel_name": "488.0",
             "laser_wavelength": 488,
@@ -2362,7 +2362,7 @@
                ]
             }
          ],
-         "file_name": "Ex_561_Em600/482760/482760580700/",
+         "file_name": "Ex_561_Em_600/482760/482760_580700/",
          "channel": {
             "channel_name": "561.0",
             "laser_wavelength": 561,
@@ -2394,7 +2394,7 @@
                ]
             }
          ],
-         "file_name": "Ex_647_Em690/482760/482760580700/",
+         "file_name": "Ex_647_Em_690/482760/482760_580700/",
          "channel": {
             "channel_name": "647.0",
             "laser_wavelength": 647,
@@ -2426,7 +2426,7 @@
                ]
             }
          ],
-         "file_name": "Ex_488_Em525/515160/515160580700/",
+         "file_name": "Ex_488_Em_525/515160/515160_580700/",
          "channel": {
             "channel_name": "488.0",
             "laser_wavelength": 488,
@@ -2458,7 +2458,7 @@
                ]
             }
          ],
-         "file_name": "Ex_561_Em600/515160/515160580700/",
+         "file_name": "Ex_561_Em_600/515160/515160_580700/",
          "channel": {
             "channel_name": "561.0",
             "laser_wavelength": 561,
@@ -2490,7 +2490,7 @@
                ]
             }
          ],
-         "file_name": "Ex_647_Em690/515160/515160580700/",
+         "file_name": "Ex_647_Em_690/515160/515160_580700/",
          "channel": {
             "channel_name": "647.0",
             "laser_wavelength": 647,
@@ -2522,7 +2522,7 @@
                ]
             }
          ],
-         "file_name": "Ex_488_Em525/547560/547560580700/",
+         "file_name": "Ex_488_Em_525/547560/547560_580700/",
          "channel": {
             "channel_name": "488.0",
             "laser_wavelength": 488,
@@ -2554,7 +2554,7 @@
                ]
             }
          ],
-         "file_name": "Ex_561_Em600/547560/547560580700/",
+         "file_name": "Ex_561_Em_600/547560/547560_580700/",
          "channel": {
             "channel_name": "561.0",
             "laser_wavelength": 561,
@@ -2586,7 +2586,7 @@
                ]
             }
          ],
-         "file_name": "Ex_647_Em690/547560/547560580700/",
+         "file_name": "Ex_647_Em_690/547560/547560_580700/",
          "channel": {
             "channel_name": "647.0",
             "laser_wavelength": 647,
@@ -2618,7 +2618,7 @@
                ]
             }
          ],
-         "file_name": "Ex_488_Em525/579960/579960580700/",
+         "file_name": "Ex_488_Em_525/579960/579960_580700/",
          "channel": {
             "channel_name": "488.0",
             "laser_wavelength": 488,
@@ -2650,7 +2650,7 @@
                ]
             }
          ],
-         "file_name": "Ex_561_Em600/579960/579960580700/",
+         "file_name": "Ex_561_Em_600/579960/579960_580700/",
          "channel": {
             "channel_name": "561.0",
             "laser_wavelength": 561,
@@ -2682,7 +2682,7 @@
                ]
             }
          ],
-         "file_name": "Ex_647_Em690/579960/579960580700/",
+         "file_name": "Ex_647_Em_690/579960/579960_580700/",
          "channel": {
             "channel_name": "647.0",
             "laser_wavelength": 647,

--- a/examples/smartspim_acquisition.py
+++ b/examples/smartspim_acquisition.py
@@ -1,0 +1,151 @@
+import datetime
+from aind_data_schema.imaging import acquisition, tile
+from pathlib import Path
+
+def digest_asi_line(line):
+    if b'2/' not in line:
+        return None
+    else:
+        mdy, hms, ampm = line.split()[0:3]
+        
+    mdy = [int(i) for i in mdy.split(b'/')]
+    ymd = [mdy[i] for i in [2,0,1]]
+    
+    
+    hms = [int(i) for i in hms.split(b':')]
+    if ampm == b'PM':
+        hms[0] += 12
+    ymdhms = ymd+hms
+    dtime = datetime.datetime(*ymdhms)
+    ymd = datetime.date(*ymd)
+    hms = datetime.time(*hms)
+    return dtime
+
+def digest_lc_pos_line(line):
+    try:
+        result = [int(i) for i in line.split()]
+    except:
+        return None
+    return result
+
+def get_tform(line):
+    #x, y, z = line.split()[0:3]
+    tform = tile.Translation3dTransform(
+        translation=[int(i)/10 for i in line.split()[0:3]]
+    )
+    return tform
+
+def get_scale(lc_mdata):
+    line = lc_mdata[1]
+    xy, z = line.split()[3:5]
+    scale = tile.Scale3dTransform(
+        scale=[xy,xy,z]
+    )
+    return scale
+
+filter_mapping = {
+    488:525,
+    561:600,
+    647:690
+}
+def make_acq_tiles(lc_mdata, ):
+    channels = {}
+    for idx, l in enumerate(lc_mdata[3:6]):
+        wavelength, powerl, powerr = [float(j) for j in l.split()]
+
+        channel = tile.Channel(
+                channel_name=wavelength,
+                laser_wavelength=wavelength,
+                laser_power=powerl,
+                filter_wheel_index=idx
+            )
+
+        channels[wavelength] = channel
+        
+    scale = get_scale(lc_mdata)
+    
+    tiles = []
+    for line in lc_mdata[8:]:
+        X,Y,Z,W,S,E,Sk = [int(i) for i in line.split()]
+        tform = get_tform(line)
+        channel = channels[float(W)]
+        t = tile.AcquisitionTile(
+            channel=channel,
+            notes='Example generation only -- accuracy not guaranteed.\nLaser power is in percentage of total -- needs calibration',
+            coordinate_transformations=[
+                tform,
+                scale
+            ],
+            file_name = f'Ex_{W}_Em{filter_mapping[W]}/{X}/{X}{Y}/'
+        )
+        tiles.append(t)
+    return tiles
+
+
+dataset = Path('/Volumes/aind/SmartSPIM_Data/SmartSPIM_651286_2023-02-09_18-44-28/')
+raw_data_dir = dataset.joinpath('SmartSPIM')
+
+experimenter = 'Erica Peterson'
+subject_id = '651286'
+
+ymd, hms = dataset.name.split('_')[-2:]
+ymd = [int(i) for i in ymd.split('-')]
+hms = [int(i) for i in hms.split('-')]
+session_start_time = ymd+hms
+session_start_time = datetime.datetime(*session_start_time)
+
+asi_file = dataset.joinpath('derivatives','ASI_logging.txt')
+mdata_file = dataset.joinpath('derivatives','metadata.txt')
+with open(asi_file, 'rb') as file:
+    asi_mdata = file.readlines()
+with open(mdata_file, 'rb') as file:
+    lc_mdata = file.readlines()
+
+session_end_time = digest_asi_line(asi_mdata[-2])
+
+channels = {}
+for idx, l in enumerate(lc_mdata[3:6]):
+    wavelength, powerl, powerr = [float(j) for j in l.split()]
+    
+    channel = tile.Channel(
+            channel_name=wavelength,
+            laser_wavelength=wavelength,
+            laser_power=powerl,
+            filter_wheel_index=idx
+        )
+        
+    channels[wavelength] = channel
+
+acq = acquisition.Acquisition(
+    instrument_id='SmartSPIM01',
+    experimenter_full_name=experimenter,
+    subject_id=subject_id,
+    session_start_time=session_start_time,
+    session_end_time=session_end_time,
+    local_storage_directory='D:',
+    external_storage_directory='',
+    chamber_immersion=acquisition.Immersion(
+        medium='Cargille',
+        refractive_index=1.522,
+    ),
+    axes=[
+        acquisition.Axis(
+            name="X",
+            dimension=2,
+            direction="Left_to_right",
+        ),
+        acquisition.Axis(
+            name="Y",
+            dimension=1,
+            direction="Posterior_to_anterior"
+        ),
+        acquisition.Axis(
+            name="Z",
+            dimension=0,
+            direction="Superior_to_inferior"
+        ),
+    ],
+    tiles = make_acq_tiles(lc_mdata)
+)
+
+acq.write_standard_file(prefix="smartspim")

--- a/examples/smartspim_acquisition.py
+++ b/examples/smartspim_acquisition.py
@@ -76,7 +76,7 @@ def make_acq_tiles(lc_mdata, ):
                 tform,
                 scale
             ],
-            file_name = f'Ex_{W}_Em{filter_mapping[W]}/{X}/{X}{Y}/'
+            file_name = f'Ex_{W}_Em_{filter_mapping[W]}/{X}/{X}_{Y}/'
         )
         tiles.append(t)
     return tiles


### PR DESCRIPTION
Script parses metadata files to generate acquisition JSON post hoc

A few questions about SmartSPIM acquisition schemas:
1. SmartSPIM saves data as individual files for each z (scanning axis) position, but my understanding is that a `AcquisitionTile` should refer to an image stack. So the `filename` field doesn't quite work here, since the directory path carries no information about file names, extensions, etc. So I'm not sure what to put here.
2. In this example, I used a local path to `aind.vast01.corp.alleninstitute.org`, so it won't run without editing that line. Again, I'm not sure how we want to handle that for the purpose of creating an example (I needed to make one to share with other teams within AIBS, but it doesn't need to be part of this repo.