### PR TITLE
SmartSPIM specimen procedures

### DIFF
--- a/examples/aibs_smartspim_procedures.json
+++ b/examples/aibs_smartspim_procedures.json
@@ -1,18 +1,12 @@
 {
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/procedures.py",
-   "schema_version": "0.5.4",
+   "schema_version": "0.6.0",
    "subject_id": "651286",
-   "headframes": null,
-   "craniotomies": null,
-   "mri_scans": null,
-   "injections": null,
-   "fiber_implants": null,
-   "water_restrictions": null,
-   "training_protocols": null,
+   "subject_procedures": null,
    "specimen_procedures": [
       {
          "specimen_id": "651286",
-         "name": "Fixation",
+         "procedure_type": "Fixation",
          "start_date": "2023-01-13",
          "end_date": "2023-01-17",
          "experimenter_full_name": "Erica Peterson",
@@ -35,7 +29,7 @@
       },
       {
          "specimen_id": "651286",
-         "name": "Fixation",
+         "procedure_type": "Fixation",
          "start_date": "2023-01-17",
          "end_date": "2023-01-18",
          "experimenter_full_name": "Erica Peterson",
@@ -52,7 +46,7 @@
       },
       {
          "specimen_id": "651286",
-         "name": "Soak",
+         "procedure_type": "Soak",
          "start_date": "2023-01-18",
          "end_date": "2023-01-19",
          "experimenter_full_name": "Erica Peterson",
@@ -69,7 +63,7 @@
       },
       {
          "specimen_id": "651286",
-         "name": "Active delipidation",
+         "procedure_type": "Active delipidation",
          "start_date": "2023-01-19",
          "end_date": "2023-01-20",
          "experimenter_full_name": "Erica Peterson",
@@ -92,7 +86,7 @@
       },
       {
          "specimen_id": "651286",
-         "name": "Soak",
+         "procedure_type": "Soak",
          "start_date": "2023-01-30",
          "end_date": "2023-01-31",
          "experimenter_full_name": "Erica Peterson",
@@ -115,7 +109,7 @@
       },
       {
          "specimen_id": "651286",
-         "name": "Soak",
+         "procedure_type": "Soak",
          "start_date": "2023-01-31",
          "end_date": "2023-02-02",
          "experimenter_full_name": "Erica Peterson",
@@ -132,7 +126,7 @@
       },
       {
          "specimen_id": "651286",
-         "name": "Embedding",
+         "procedure_type": "Embedding",
          "start_date": "2023-01-31",
          "end_date": "2023-02-02",
          "experimenter_full_name": "Erica Peterson",
@@ -154,6 +148,5 @@
          "notes": null
       }
    ],
-   "other_procedures": null,
    "notes": null
 }

--- a/examples/aibs_smartspim_procedures.json
+++ b/examples/aibs_smartspim_procedures.json
@@ -1,0 +1,159 @@
+{
+   "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/procedures.py",
+   "schema_version": "0.5.4",
+   "subject_id": "651286",
+   "headframes": null,
+   "craniotomies": null,
+   "mri_scans": null,
+   "injections": null,
+   "fiber_implants": null,
+   "water_restrictions": null,
+   "training_protocols": null,
+   "specimen_procedures": [
+      {
+         "specimen_id": "651286",
+         "name": "Fixation",
+         "start_date": "2023-01-13",
+         "end_date": "2023-01-17",
+         "experimenter_full_name": "Erica Peterson",
+         "protocol_id": "unknown",
+         "reagents": [
+            {
+               "name": "SHIELD Buffer",
+               "RRID": null,
+               "lot_number": "1234",
+               "expiration_date": null
+            },
+            {
+               "name": "SHIELD Epoxy",
+               "RRID": null,
+               "lot_number": "1234",
+               "expiration_date": null
+            }
+         ],
+         "notes": null
+      },
+      {
+         "specimen_id": "651286",
+         "name": "Fixation",
+         "start_date": "2023-01-17",
+         "end_date": "2023-01-18",
+         "experimenter_full_name": "Erica Peterson",
+         "protocol_id": "unknown",
+         "reagents": [
+            {
+               "name": "SHIELD On",
+               "RRID": null,
+               "lot_number": "1234",
+               "expiration_date": null
+            }
+         ],
+         "notes": "40 deg. C"
+      },
+      {
+         "specimen_id": "651286",
+         "name": "Soak",
+         "start_date": "2023-01-18",
+         "end_date": "2023-01-19",
+         "experimenter_full_name": "Erica Peterson",
+         "protocol_id": "unknown",
+         "reagents": [
+            {
+               "name": "Delipidation Buffer",
+               "RRID": null,
+               "lot_number": "1234",
+               "expiration_date": null
+            }
+         ],
+         "notes": null
+      },
+      {
+         "specimen_id": "651286",
+         "name": "Active delipidation",
+         "start_date": "2023-01-19",
+         "end_date": "2023-01-20",
+         "experimenter_full_name": "Erica Peterson",
+         "protocol_id": "unknown",
+         "reagents": [
+            {
+               "name": "Delipidation Buffer",
+               "RRID": null,
+               "lot_number": "1234",
+               "expiration_date": null
+            },
+            {
+               "name": "Conductivity Buffer",
+               "RRID": null,
+               "lot_number": "1234",
+               "expiration_date": null
+            }
+         ],
+         "notes": null
+      },
+      {
+         "specimen_id": "651286",
+         "name": "Soak",
+         "start_date": "2023-01-30",
+         "end_date": "2023-01-31",
+         "experimenter_full_name": "Erica Peterson",
+         "protocol_id": "unknown",
+         "reagents": [
+            {
+               "name": "Easy Index",
+               "RRID": null,
+               "lot_number": "1234",
+               "expiration_date": null
+            },
+            {
+               "name": "Deionized water",
+               "RRID": null,
+               "lot_number": "DDI/Filtered in house",
+               "expiration_date": null
+            }
+         ],
+         "notes": null
+      },
+      {
+         "specimen_id": "651286",
+         "name": "Soak",
+         "start_date": "2023-01-31",
+         "end_date": "2023-02-02",
+         "experimenter_full_name": "Erica Peterson",
+         "protocol_id": "unknown",
+         "reagents": [
+            {
+               "name": "Easy Index",
+               "RRID": null,
+               "lot_number": "1234",
+               "expiration_date": null
+            }
+         ],
+         "notes": null
+      },
+      {
+         "specimen_id": "651286",
+         "name": "Embedding",
+         "start_date": "2023-01-31",
+         "end_date": "2023-02-02",
+         "experimenter_full_name": "Erica Peterson",
+         "protocol_id": "unknown",
+         "reagents": [
+            {
+               "name": "Easy Index",
+               "RRID": null,
+               "lot_number": "1234",
+               "expiration_date": null
+            },
+            {
+               "name": "Agarose",
+               "RRID": null,
+               "lot_number": "1234",
+               "expiration_date": null
+            }
+         ],
+         "notes": null
+      }
+   ],
+   "other_procedures": null,
+   "notes": null
+}

--- a/examples/aibs_smartspim_procedures.py
+++ b/examples/aibs_smartspim_procedures.py
@@ -53,7 +53,7 @@ perfusion = procedures.Perfusion(
 # perfused brain goes into SHIELD OFF solution
 shield_off_procedure = procedures.SpecimenProcedure(
     specimen_id=specimen_id,
-    name=procedures.TissuePrepName("Fixation"),
+    procedure_type="Fixation",
     start_date=datetime.date(2023, 1, 13),
     end_date=datetime.date(2023, 1, 17),
     experimenter_full_name=experimenter,
@@ -64,7 +64,7 @@ shield_off_procedure = procedures.SpecimenProcedure(
 # specimen gets transfered to SHIELD ON and baked
 shield_on_procedure = procedures.SpecimenProcedure(
     specimen_id=specimen_id,
-    name=procedures.TissuePrepName("Fixation"),
+    procedure_type="Fixation",
     start_date=datetime.date(2023, 1, 17),
     end_date=datetime.date(2023, 1, 18),
     experimenter_full_name=experimenter,
@@ -78,7 +78,7 @@ shield_on_procedure = procedures.SpecimenProcedure(
 # specimen gets transferred to delipidation buffer
 delipidation_prep_procedure = procedures.SpecimenProcedure(
     specimen_id=specimen_id,
-    name=procedures.TissuePrepName("Soak"),
+    procedure_type="Soak",
     start_date=datetime.date(2023, 1, 18),
     end_date=datetime.date(2023, 1, 19),
     experimenter_full_name=experimenter,
@@ -91,7 +91,7 @@ delipidation_prep_procedure = procedures.SpecimenProcedure(
 # specimen goes into active delipidation box
 active_delipidation_procedure = procedures.SpecimenProcedure(
     specimen_id=specimen_id,
-    name=procedures.TissuePrepName("Active delipidation"),
+    procedure_type="Active delipidation",
     start_date=datetime.date(2023, 1, 19),
     end_date=datetime.date(2023, 1, 20),
     experimenter_full_name=experimenter,
@@ -102,7 +102,7 @@ active_delipidation_procedure = procedures.SpecimenProcedure(
 # First index matching is to 50% EasyIndex
 index1 = procedures.SpecimenProcedure(
     specimen_id=specimen_id,
-    name=procedures.TissuePrepName("Soak"),
+    procedure_type="Soak",
     start_date=datetime.date(2023, 1, 30),
     end_date=datetime.date(2023, 1, 31),
     experimenter_full_name=experimenter,
@@ -116,7 +116,7 @@ index1 = procedures.SpecimenProcedure(
 # Now to 100% EasyIndex
 index2 = procedures.SpecimenProcedure(
     specimen_id=specimen_id,
-    name=procedures.TissuePrepName("Soak"),
+    procedure_type="Soak",
     start_date=datetime.date(2023, 1, 31),
     end_date=datetime.date(2023, 2, 2),
     experimenter_full_name=experimenter,
@@ -129,7 +129,7 @@ index2 = procedures.SpecimenProcedure(
 # Specimen embedded into 2% agarose, prepared with EasyIndex
 embedding = procedures.SpecimenProcedure(
     specimen_id=specimen_id,
-    name=procedures.TissuePrepName("Embedding"),
+    procedure_type="Embedding",
     start_date=datetime.date(2023, 1, 31),
     end_date=datetime.date(2023, 2, 2),
     experimenter_full_name=experimenter,

--- a/examples/aibs_smartspim_procedures.py
+++ b/examples/aibs_smartspim_procedures.py
@@ -167,4 +167,4 @@ all_procedures = procedures.Procedures(
     ],
 )
 
-all_procedures.write_standard_file(prefix='smartspim')
+all_procedures.write_standard_file(prefix='aibs_smartspim')

--- a/examples/aibs_smartspim_procedures.py
+++ b/examples/aibs_smartspim_procedures.py
@@ -1,50 +1,42 @@
 import datetime
+
 from aind_data_schema import procedures
 
-experimenter = 'Erica Peterson'
+experimenter = "Erica Peterson"
 # subject and specimen id can be the same?
-specimen_id = '651286'
+specimen_id = "651286"
 
 ## Reagents
 shield_buffer = procedures.Reagent(
-    name='SHIELD Buffer',
-    lot_number='1234',
+    name="SHIELD Buffer",
+    lot_number="1234",
 )
 
 shield_epoxy = procedures.Reagent(
-    name='SHIELD Epoxy',
-    lot_number='1234',
+    name="SHIELD Epoxy",
+    lot_number="1234",
 )
 
 shield_on = procedures.Reagent(
-    name='SHIELD On',
-    lot_number='1234',
+    name="SHIELD On",
+    lot_number="1234",
 )
 
 delipidation_buffer = procedures.Reagent(
-    name='Delipidation Buffer',
-    lot_number='1234',
+    name="Delipidation Buffer",
+    lot_number="1234",
 )
 
 conductivity_buffer = procedures.Reagent(
-    name='Conductivity Buffer',
-    lot_number='1234',
+    name="Conductivity Buffer",
+    lot_number="1234",
 )
 
-easy_index = procedures.Reagent(
-    name='Easy Index',
-    lot_number='1234'
-)
+easy_index = procedures.Reagent(name="Easy Index", lot_number="1234")
 
-water = procedures.Reagent(
-    name='Deionized water',
-    lot_number='DDI/Filtered in house'
-)
+water = procedures.Reagent(name="Deionized water", lot_number="DDI/Filtered in house")
 
-agarose = procedures.Reagent(
-    name="Agarose",
-    lot_number='1234'
-)
+agarose = procedures.Reagent(name="Agarose", lot_number="1234")
 
 ## Procedures
 
@@ -52,48 +44,45 @@ perfusion = procedures.Perfusion(
     output_specimen_ids=[
         specimen_id,
     ],
-    experimenter_full_name='LAS',
+    experimenter_full_name="LAS",
     start_date=datetime.date(2022, 11, 17),
     end_date=datetime.date(2022, 11, 17),
-    protocol_id='unknown',
+    protocol_id="unknown",
 )
 
 # perfused brain goes into SHIELD OFF solution
 shield_off_procedure = procedures.SpecimenProcedure(
     specimen_id=specimen_id,
-    name = procedures.TissuePrepName("Fixation"),
+    name=procedures.TissuePrepName("Fixation"),
     start_date=datetime.date(2023, 1, 13),
     end_date=datetime.date(2023, 1, 17),
     experimenter_full_name=experimenter,
-    protocol_id='unknown',
-    reagents=[
-        shield_buffer,
-        shield_epoxy
-    ],
+    protocol_id="unknown",
+    reagents=[shield_buffer, shield_epoxy],
 )
 
 # specimen gets transfered to SHIELD ON and baked
 shield_on_procedure = procedures.SpecimenProcedure(
     specimen_id=specimen_id,
-    name = procedures.TissuePrepName("Fixation"),
+    name=procedures.TissuePrepName("Fixation"),
     start_date=datetime.date(2023, 1, 17),
     end_date=datetime.date(2023, 1, 18),
     experimenter_full_name=experimenter,
-    protocol_id='unknown',
+    protocol_id="unknown",
     reagents=[
         shield_on,
     ],
-    notes="40 deg. C"
+    notes="40 deg. C",
 )
 
 # specimen gets transferred to delipidation buffer
 delipidation_prep_procedure = procedures.SpecimenProcedure(
     specimen_id=specimen_id,
-    name= procedures.TissuePrepName("Soak"),
+    name=procedures.TissuePrepName("Soak"),
     start_date=datetime.date(2023, 1, 18),
     end_date=datetime.date(2023, 1, 19),
     experimenter_full_name=experimenter,
-    protocol_id='unknown',
+    protocol_id="unknown",
     reagents=[
         delipidation_buffer,
     ],
@@ -102,25 +91,22 @@ delipidation_prep_procedure = procedures.SpecimenProcedure(
 # specimen goes into active delipidation box
 active_delipidation_procedure = procedures.SpecimenProcedure(
     specimen_id=specimen_id,
-    name= procedures.TissuePrepName("Active delipidation"),
+    name=procedures.TissuePrepName("Active delipidation"),
     start_date=datetime.date(2023, 1, 19),
     end_date=datetime.date(2023, 1, 20),
     experimenter_full_name=experimenter,
-    protocol_id='unknown',
-    reagents=[
-        delipidation_buffer,
-        conductivity_buffer
-    ],
+    protocol_id="unknown",
+    reagents=[delipidation_buffer, conductivity_buffer],
 )
 
 # First index matching is to 50% EasyIndex
 index1 = procedures.SpecimenProcedure(
     specimen_id=specimen_id,
-    name= procedures.TissuePrepName("Soak"),
+    name=procedures.TissuePrepName("Soak"),
     start_date=datetime.date(2023, 1, 30),
     end_date=datetime.date(2023, 1, 31),
     experimenter_full_name=experimenter,
-    protocol_id='unknown',
+    protocol_id="unknown",
     reagents=[
         easy_index,
         water,
@@ -130,11 +116,11 @@ index1 = procedures.SpecimenProcedure(
 # Now to 100% EasyIndex
 index2 = procedures.SpecimenProcedure(
     specimen_id=specimen_id,
-    name= procedures.TissuePrepName("Soak"),
+    name=procedures.TissuePrepName("Soak"),
     start_date=datetime.date(2023, 1, 31),
     end_date=datetime.date(2023, 2, 2),
     experimenter_full_name=experimenter,
-    protocol_id='unknown',
+    protocol_id="unknown",
     reagents=[
         easy_index,
     ],
@@ -143,11 +129,11 @@ index2 = procedures.SpecimenProcedure(
 # Specimen embedded into 2% agarose, prepared with EasyIndex
 embedding = procedures.SpecimenProcedure(
     specimen_id=specimen_id,
-    name= procedures.TissuePrepName("Embedding"),
+    name=procedures.TissuePrepName("Embedding"),
     start_date=datetime.date(2023, 1, 31),
     end_date=datetime.date(2023, 2, 2),
     experimenter_full_name=experimenter,
-    protocol_id='unknown',
+    protocol_id="unknown",
     reagents=[
         easy_index,
         agarose,
@@ -163,8 +149,8 @@ all_procedures = procedures.Procedures(
         active_delipidation_procedure,
         index1,
         index2,
-        embedding
+        embedding,
     ],
 )
 
-all_procedures.write_standard_file(prefix='aibs_smartspim')
+all_procedures.write_standard_file(prefix="aibs_smartspim")

--- a/examples/smartspim_procedures.py
+++ b/examples/smartspim_procedures.py
@@ -1,0 +1,170 @@
+import datetime
+from aind_data_schema import procedures
+
+experimenter = 'Erica Peterson'
+# subject and specimen id can be the same?
+specimen_id = '651286'
+
+## Reagents
+shield_buffer = procedures.Reagent(
+    name='SHIELD Buffer',
+    lot_number='1234',
+)
+
+shield_epoxy = procedures.Reagent(
+    name='SHIELD Epoxy',
+    lot_number='1234',
+)
+
+shield_on = procedures.Reagent(
+    name='SHIELD On',
+    lot_number='1234',
+)
+
+delipidation_buffer = procedures.Reagent(
+    name='Delipidation Buffer',
+    lot_number='1234',
+)
+
+conductivity_buffer = procedures.Reagent(
+    name='Conductivity Buffer',
+    lot_number='1234',
+)
+
+easy_index = procedures.Reagent(
+    name='Easy Index',
+    lot_number='1234'
+)
+
+water = procedures.Reagent(
+    name='Deionized water',
+    lot_number='DDI/Filtered in house'
+)
+
+agarose = procedures.Reagent(
+    name="Agarose",
+    lot_number='1234'
+)
+
+## Procedures
+
+perfusion = procedures.Perfusion(
+    output_specimen_ids=[
+        specimen_id,
+    ],
+    experimenter_full_name='LAS',
+    start_date=datetime.date(2022, 11, 17),
+    end_date=datetime.date(2022, 11, 17),
+    protocol_id='unknown',
+)
+
+# perfused brain goes into SHIELD OFF solution
+shield_off_procedure = procedures.SpecimenProcedure(
+    specimen_id=specimen_id,
+    name = procedures.TissuePrepName("Fixation"),
+    start_date=datetime.date(2023, 1, 13),
+    end_date=datetime.date(2023, 1, 17),
+    experimenter_full_name=experimenter,
+    protocol_id='unknown',
+    reagents=[
+        shield_buffer,
+        shield_epoxy
+    ],
+)
+
+# specimen gets transfered to SHIELD ON and baked
+shield_on_procedure = procedures.SpecimenProcedure(
+    specimen_id=specimen_id,
+    name = procedures.TissuePrepName("Fixation"),
+    start_date=datetime.date(2023, 1, 17),
+    end_date=datetime.date(2023, 1, 18),
+    experimenter_full_name=experimenter,
+    protocol_id='unknown',
+    reagents=[
+        shield_on,
+    ],
+    notes="40 deg. C"
+)
+
+# specimen gets transferred to delipidation buffer
+delipidation_prep_procedure = procedures.SpecimenProcedure(
+    specimen_id=specimen_id,
+    name= procedures.TissuePrepName("Soak"),
+    start_date=datetime.date(2023, 1, 18),
+    end_date=datetime.date(2023, 1, 19),
+    experimenter_full_name=experimenter,
+    protocol_id='unknown',
+    reagents=[
+        delipidation_buffer,
+    ],
+)
+
+# specimen goes into active delipidation box
+active_delipidation_procedure = procedures.SpecimenProcedure(
+    specimen_id=specimen_id,
+    name= procedures.TissuePrepName("Active delipidation"),
+    start_date=datetime.date(2023, 1, 19),
+    end_date=datetime.date(2023, 1, 20),
+    experimenter_full_name=experimenter,
+    protocol_id='unknown',
+    reagents=[
+        delipidation_buffer,
+        conductivity_buffer
+    ],
+)
+
+# First index matching is to 50% EasyIndex
+index1 = procedures.SpecimenProcedure(
+    specimen_id=specimen_id,
+    name= procedures.TissuePrepName("Soak"),
+    start_date=datetime.date(2023, 1, 30),
+    end_date=datetime.date(2023, 1, 31),
+    experimenter_full_name=experimenter,
+    protocol_id='unknown',
+    reagents=[
+        easy_index,
+        water,
+    ],
+)
+
+# Now to 100% EasyIndex
+index2 = procedures.SpecimenProcedure(
+    specimen_id=specimen_id,
+    name= procedures.TissuePrepName("Soak"),
+    start_date=datetime.date(2023, 1, 31),
+    end_date=datetime.date(2023, 2, 2),
+    experimenter_full_name=experimenter,
+    protocol_id='unknown',
+    reagents=[
+        easy_index,
+    ],
+)
+
+# Specimen embedded into 2% agarose, prepared with EasyIndex
+embedding = procedures.SpecimenProcedure(
+    specimen_id=specimen_id,
+    name= procedures.TissuePrepName("Embedding"),
+    start_date=datetime.date(2023, 1, 31),
+    end_date=datetime.date(2023, 2, 2),
+    experimenter_full_name=experimenter,
+    protocol_id='unknown',
+    reagents=[
+        easy_index,
+        agarose,
+    ],
+)
+
+all_procedures = procedures.Procedures(
+    subject_id=specimen_id,
+    specimen_procedures=[
+        shield_off_procedure,
+        shield_on_procedure,
+        delipidation_prep_procedure,
+        active_delipidation_procedure,
+        index1,
+        index2,
+        embedding
+    ],
+)
+
+all_procedures.write_standard_file(prefix='smartspim')

--- a/src/aind_data_schema/procedures.py
+++ b/src/aind_data_schema/procedures.py
@@ -409,4 +409,5 @@ class Procedures(AindCoreModel):
     training_protocols: Optional[List[TrainingProtocol]] = Field(None, title="Training protocols", unique_items=True)
     tissue_preparations: Optional[List[TissuePrep]] = Field(None, title="Tissue preparations", unique_items=True)
     other_procedures: Optional[List[SubjectProcedure]] = Field(None, title="Other procedures", unique_items=True)
+    specimen_procedures = Optional[List[SpecimenProcedure]] = Field(None, title="Specimen Procedures", unique_items=True)
     notes: Optional[str] = Field(None, title="Notes")

--- a/src/aind_data_schema/procedures.py
+++ b/src/aind_data_schema/procedures.py
@@ -403,7 +403,7 @@ class Procedures(AindCoreModel):
                 SubjectProcedure
             ]
         ]
-    ] = Field(None, title="Injections", unique_items=True)
+    ] = Field(None, title="Subject Procedures", unique_items=True)
     fiber_implants: Optional[List[FiberImplant]] = Field(None, title="Fiber implants", unique_items=True)
     water_restrictions: Optional[List[WaterRestriction]] = Field(None, title="Water restriction")
     training_protocols: Optional[List[TrainingProtocol]] = Field(None, title="Training protocols", unique_items=True)

--- a/src/aind_data_schema/procedures.py
+++ b/src/aind_data_schema/procedures.py
@@ -387,7 +387,7 @@ class Procedures(AindCoreModel):
         description="Unique identifier for the subject. If this is not a Allen LAS ID, indicate this in the Notes.",
         title="Subject ID",
     )
-    subject_procedures = Optional[
+    subject_procedures: Optional[
         List[
             Union[
                 Headframe,
@@ -406,7 +406,7 @@ class Procedures(AindCoreModel):
             ]
         ]
     ] = Field(None, title="Subject Procedures", unique_items=True)
-    specimen_procedures = Optional[List[SpecimenProcedure]] = Field(
+    specimen_procedures: Optional[List[SpecimenProcedure]] = Field(
         None, title="Specimen Procedures", unique_items=True
     )
     notes: Optional[str] = Field(None, title="Notes")

--- a/src/aind_data_schema/procedures.py
+++ b/src/aind_data_schema/procedures.py
@@ -36,14 +36,17 @@ class TissuePrepName(Enum):
     DCM_DELIPIDATION = "DCM delipidation"
     IMMUNOSTAINING = "Immunostaining"
     GELATION = "Gelation"
+    ACTIVE_DELIPIDATION = "Active delipidation"
+    SOAK = "Soak"
+    EMBEDDING = "Embedding"
 
 
 class Reagent(AindModel):
     """Description of reagents used in procedure"""
     name: str = Field(..., title="Name")
-    RRID: Optional[str] = Field(None, "Research Resource ID")
+    RRID: Optional[str] = Field(None, title="Research Resource ID")
     lot_number: str = Field(..., title="Lot number")
-    expiration_date: Optional[date] = Field(None, "Lot expiration date")
+    expiration_date: Optional[date] = Field(None, title="Lot expiration date")
 
 
 class SpecimenProcedure(AindModel):
@@ -58,7 +61,7 @@ class SpecimenProcedure(AindModel):
         title="Experimenter full name",
     )
     protocol_id: str = Field(..., title="Protocol ID", description="DOI for protocols.io")
-    reagents: Optional[List[Reagent]] = Field(None, "Reagents")
+    reagents: Optional[List[Reagent]] = Field(None, title="Reagents")
     notes: Optional[str] = Field(None, title="Notes")
 
 
@@ -389,6 +392,6 @@ class Procedures(AindCoreModel):
     fiber_implants: Optional[List[FiberImplant]] = Field(None, title="Fiber implants", unique_items=True)
     water_restrictions: Optional[List[WaterRestriction]] = Field(None, title="Water restriction")
     training_protocols: Optional[List[TrainingProtocol]] = Field(None, title="Training protocols", unique_items=True)
-    tissue_preparations: Optional[List[TissuePrep]] = Field(None, title="Tissue preparations", unique_items=True)
+    specimen_procedures: Optional[List[SpecimenProcedure]] = Field(None, title="Specimen procedures", unique_items=True)
     other_procedures: Optional[List[SubjectProcedure]] = Field(None, title="Other procedures", unique_items=True)
     notes: Optional[str] = Field(None, title="Notes")

--- a/src/aind_data_schema/procedures.py
+++ b/src/aind_data_schema/procedures.py
@@ -31,7 +31,6 @@ class CurrentUnit(Enum):
 class SpecimenProcedureName(Enum):
     """Specimen procedure type name"""
 
-    
     ACTIVE_DELIPIDATION = "Active delipidation"
     DCM_DELIPIDATION = "DCM delipidation"
     DOUBLE_DELIPIDATION = "Double delipidation"
@@ -41,10 +40,11 @@ class SpecimenProcedureName(Enum):
     IMMUNOSTAINING = "Immunostaining"
     SOAK = "Soak"
     OTHER = "Other - see notes"
-    
+
 
 class Reagent(AindModel):
     """Description of reagents used in procedure"""
+
     name: str = Field(..., title="Name")
     RRID: Optional[str] = Field(None, title="Research Resource ID")
     lot_number: str = Field(..., title="Lot number")
@@ -53,6 +53,7 @@ class Reagent(AindModel):
 
 class SpecimenProcedure(AindModel):
     """Description of surgical or other procedure performed on a specimen"""
+
     specimen_id: str = Field(..., title="Specimen ID")
     procedure_type: SpecimenProcedureName = Field(..., title="Procedure type")
     start_date: date = Field(..., title="Start date")
@@ -122,6 +123,7 @@ class SubjectProcedure(AindModel):
 
 class CraniotomyType(Enum):
     """Name of craniotomy Type"""
+
     VISCTX = "Visual Cortex"
     WHC = "Whole hemisphere craniotomy"
     THREE_MM = "3 mm"
@@ -133,7 +135,7 @@ class Craniotomy(SubjectProcedure):
     """Description of craniotomy procedure"""
 
     procedure_type: str = Field("Craniotomy", title="Procedure type", const=True)
-    craniotomy_type: CraniotomyType = Field(..., title="Craniotomy type") 
+    craniotomy_type: CraniotomyType = Field(..., title="Craniotomy type")
     craniotomy_hemisphere: Optional[Side] = Field(None, title="Craniotomy hemisphere")
     craniotomy_coordinates_ml: Optional[float] = Field(None, title="Craniotomy coordinate ML (mm)", units="mm")
     craniotomy_coordinates_ap: Optional[float] = Field(None, title="Craniotomy coordinates AP (mm)", units="mm")
@@ -369,11 +371,11 @@ class Perfusion(SubjectProcedure):
 
     procedure_type: str = Field("Perfusion", title="Procedure type", const=True)
     output_specimen_ids: List[str] = Field(
-        ..., 
+        ...,
         title="Specimen ID",
         description="IDs of specimens resulting from this procedure.",
         unique_items=True,
-        )
+    )
 
 
 class Procedures(AindCoreModel):
@@ -400,9 +402,11 @@ class Procedures(AindCoreModel):
                 WaterRestriction,
                 TrainingProtocol,
                 Perfusion,
-                SubjectProcedure
+                SubjectProcedure,
             ]
         ]
     ] = Field(None, title="Subject Procedures", unique_items=True)
-    specimen_procedures = Optional[List[SpecimenProcedure]] = Field(None, title="Specimen Procedures", unique_items=True)
+    specimen_procedures = Optional[List[SpecimenProcedure]] = Field(
+        None, title="Specimen Procedures", unique_items=True
+    )
     notes: Optional[str] = Field(None, title="Notes")

--- a/src/aind_data_schema/procedures.py
+++ b/src/aind_data_schema/procedures.py
@@ -404,10 +404,5 @@ class Procedures(AindCoreModel):
             ]
         ]
     ] = Field(None, title="Subject Procedures", unique_items=True)
-    fiber_implants: Optional[List[FiberImplant]] = Field(None, title="Fiber implants", unique_items=True)
-    water_restrictions: Optional[List[WaterRestriction]] = Field(None, title="Water restriction")
-    training_protocols: Optional[List[TrainingProtocol]] = Field(None, title="Training protocols", unique_items=True)
-    tissue_preparations: Optional[List[TissuePrep]] = Field(None, title="Tissue preparations", unique_items=True)
-    other_procedures: Optional[List[SubjectProcedure]] = Field(None, title="Other procedures", unique_items=True)
     specimen_procedures = Optional[List[SpecimenProcedure]] = Field(None, title="Specimen Procedures", unique_items=True)
     notes: Optional[str] = Field(None, title="Notes")


### PR DESCRIPTION
I wanted to try generating one of these but needed to add a few things:
- `src.procedures.py` -- new `TissuePrepName` entries.
-- "Active delipidation" for using the SmartBatch+ clearing box
-- "Soak" as a general specimen in a reagent for an amount of time step. I'm not sure what you want to call this, but there are several instances where we leave a specimen in a reagent for 1 or more days, so I think it makes sense to have it.
-- "Embedding" in this case for agarose embedding for imaging, but could be used for others. Not sure if you want to specifically track this procedure or not, but it will have an SOP
- Fixed several instances of the `Field` class needing a `title` keyword

I'm not sure what the current thinking is for specimen vs. subject functionality here. In my example, the subject_id and the specimen_id are identical, but you may disallow this for clarity.
