### PR TITLE
name/abbrev, experiment type 

### DIFF
--- a/examples/aibs_smartspim_instrument.json
+++ b/examples/aibs_smartspim_instrument.json
@@ -2,6 +2,7 @@
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/imaging/instrument.py",
    "schema_version": "0.5.0",
    "instrument_id": "SmartSPIM1-1",
+   "instrument_type": "SmartSPIM",
    "location": "440 Westlake",
    "manufacturer": "LifeCanvas",
    "temperature_control": false,

--- a/examples/aibs_smartspim_instrument.json
+++ b/examples/aibs_smartspim_instrument.json
@@ -2,7 +2,7 @@
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/imaging/instrument.py",
    "schema_version": "0.4.2",
    "instrument_id": "SmartSPIM1-1",
-   "type": "smartSPIM",
+   "type": "SmartSPIM",
    "location": "440 Westlake",
    "manufacturer": "LifeCanvas",
    "temperature_control": false,

--- a/examples/aibs_smartspim_instrument.json
+++ b/examples/aibs_smartspim_instrument.json
@@ -1,6 +1,6 @@
 {
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/imaging/instrument.py",
-   "schema_version": "0.4.2",
+   "schema_version": "0.5.0",
    "instrument_id": "SmartSPIM1-1",
    "location": "440 Westlake",
    "manufacturer": "LifeCanvas",

--- a/examples/aibs_smartspim_instrument.json
+++ b/examples/aibs_smartspim_instrument.json
@@ -2,7 +2,6 @@
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/imaging/instrument.py",
    "schema_version": "0.4.2",
    "instrument_id": "SmartSPIM1-1",
-   "type": "SmartSPIM",
    "location": "440 Westlake",
    "manufacturer": "LifeCanvas",
    "temperature_control": false,

--- a/examples/aibs_smartspim_instrument.py
+++ b/examples/aibs_smartspim_instrument.py
@@ -4,7 +4,7 @@ from aind_data_schema.imaging.instrument import (AdditionalImagingDevice, Com, D
 
 inst = Instrument(
     instrument_id="SmartSPIM1-1",
-    type="smartSPIM",
+    type="SmartSPIM",
     manufacturer="LifeCanvas",
     location="440 Westlake",
     objectives=[

--- a/examples/aibs_smartspim_instrument.py
+++ b/examples/aibs_smartspim_instrument.py
@@ -4,7 +4,6 @@ from aind_data_schema.imaging.instrument import (AdditionalImagingDevice, Com, D
 
 inst = Instrument(
     instrument_id="SmartSPIM1-1",
-    type="SmartSPIM",
     manufacturer="LifeCanvas",
     location="440 Westlake",
     objectives=[

--- a/examples/aibs_smartspim_instrument.py
+++ b/examples/aibs_smartspim_instrument.py
@@ -4,6 +4,7 @@ from aind_data_schema.imaging.instrument import (AdditionalImagingDevice, Com, D
 
 inst = Instrument(
     instrument_id="SmartSPIM1-1",
+    instrument_type="SmartSPIM",
     manufacturer="LifeCanvas",
     location="440 Westlake",
     objectives=[

--- a/examples/aind_smartspim_instrument.json
+++ b/examples/aind_smartspim_instrument.json
@@ -2,7 +2,6 @@
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/imaging/instrument.py",
    "schema_version": "0.4.2",
    "instrument_id": "SmartSPIM2-1",
-   "type": "SmartSPIM",
    "location": "440 Westlake",
    "manufacturer": "LifeCanvas",
    "temperature_control": false,

--- a/examples/aind_smartspim_instrument.json
+++ b/examples/aind_smartspim_instrument.json
@@ -2,6 +2,7 @@
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/imaging/instrument.py",
    "schema_version": "0.5.0",
    "instrument_id": "SmartSPIM2-1",
+   "instrument_type": "SmartSPIM",
    "location": "440 Westlake",
    "manufacturer": "LifeCanvas",
    "temperature_control": false,

--- a/examples/aind_smartspim_instrument.json
+++ b/examples/aind_smartspim_instrument.json
@@ -2,7 +2,7 @@
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/imaging/instrument.py",
    "schema_version": "0.4.2",
    "instrument_id": "SmartSPIM2-1",
-   "type": "smartSPIM",
+   "type": "SmartSPIM",
    "location": "440 Westlake",
    "manufacturer": "LifeCanvas",
    "temperature_control": false,

--- a/examples/aind_smartspim_instrument.json
+++ b/examples/aind_smartspim_instrument.json
@@ -1,6 +1,6 @@
 {
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/imaging/instrument.py",
-   "schema_version": "0.4.2",
+   "schema_version": "0.5.0",
    "instrument_id": "SmartSPIM2-1",
    "location": "440 Westlake",
    "manufacturer": "LifeCanvas",

--- a/examples/aind_smartspim_instrument.py
+++ b/examples/aind_smartspim_instrument.py
@@ -3,7 +3,6 @@ from aind_data_schema.imaging import instrument
 
 inst = instrument.Instrument(
     instrument_id="SmartSPIM2-1",
-    type="SmartSPIM",
     manufacturer="LifeCanvas",
     location="440 Westlake",
     objectives=[

--- a/examples/aind_smartspim_instrument.py
+++ b/examples/aind_smartspim_instrument.py
@@ -3,7 +3,7 @@ from aind_data_schema.imaging import instrument
 
 inst = instrument.Instrument(
     instrument_id="SmartSPIM2-1",
-    type="smartSPIM",
+    type="SmartSPIM",
     manufacturer="LifeCanvas",
     location="440 Westlake",
     objectives=[

--- a/examples/aind_smartspim_instrument.py
+++ b/examples/aind_smartspim_instrument.py
@@ -3,6 +3,7 @@ from aind_data_schema.imaging import instrument
 
 inst = instrument.Instrument(
     instrument_id="SmartSPIM2-1",
+    instrument_type="SmartSPIM",
     manufacturer="LifeCanvas",
     location="440 Westlake",
     objectives=[

--- a/examples/data_description.json
+++ b/examples/data_description.json
@@ -22,10 +22,12 @@
    "project_name": null,
    "project_id": null,
    "restrictions": null,
-   "modality": {
-      "name": "Selective plane illumination microscopy",
-      "abbreviation": "SPIM"
-   },
+   "modality": [
+      {
+         "name": "Selective plane illumination microscopy",
+         "abbreviation": "SPIM"
+      }
+   ],
    "experiment_type": "diSPIM",
    "subject_id": "12345",
    "related_data": [],

--- a/examples/data_description.json
+++ b/examples/data_description.json
@@ -23,7 +23,7 @@
    "project_id": null,
    "restrictions": null,
    "modality": {
-      "name": "selective plane illumination microscopy",
+      "name": "Selective plane illumination microscopy",
       "abbreviation": "SPIM"
    },
    "instrument_type": "diSPIM",

--- a/examples/data_description.json
+++ b/examples/data_description.json
@@ -26,7 +26,7 @@
       "name": "Selective plane illumination microscopy",
       "abbreviation": "SPIM"
    },
-   "instrument_type": "diSPIM",
+   "experiment_type": "diSPIM",
    "subject_id": "12345",
    "related_data": [],
    "data_summary": null

--- a/examples/data_description.json
+++ b/examples/data_description.json
@@ -1,11 +1,14 @@
 {
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/data_description.py",
-   "schema_version": "0.3.1",
+   "schema_version": "0.4.0",
    "license": "CC-BY-4.0",
    "creation_time": "16:30:01",
    "creation_date": "2022-02-21",
-   "name": "ecephys_12345_2022-02-21_16-30-01",
-   "institution": "AIND",
+   "name": "diSPIM_12345_2022-02-21_16-30-01",
+   "institution": {
+      "name": "Allen Institute for Neural Dynamics",
+      "abbreviation": "AIND"
+   },
    "ror_id": null,
    "funding_source": [
       {
@@ -19,7 +22,11 @@
    "project_name": null,
    "project_id": null,
    "restrictions": null,
-   "modality": "ecephys",
+   "modality": {
+      "name": "selective plane illumination microscopy",
+      "abbreviation": "SPIM"
+   },
+   "instrument_type": "diSPIM",
    "subject_id": "12345",
    "data_summary": null
 }

--- a/examples/data_description.py
+++ b/examples/data_description.py
@@ -5,7 +5,7 @@ from aind_data_schema.data_description import Funding, Institution, Modality, Ra
 
 d = RawDataDescription(
     modality=Modality.SPIM,
-    instrument_type="diSPIM",
+    experiment_type="diSPIM",
     subject_id="12345",
     creation_date=date(2022, 2, 21),
     creation_time=time(16, 30, 1),

--- a/examples/data_description.py
+++ b/examples/data_description.py
@@ -4,7 +4,7 @@ from datetime import date, time
 from aind_data_schema.data_description import Funding, Institution, Modality, RawDataDescription
 
 d = RawDataDescription(
-    modality=Modality.SPIM,
+    modality=[Modality.SPIM],
     experiment_type="diSPIM",
     subject_id="12345",
     creation_date=date(2022, 2, 21),

--- a/examples/data_description.py
+++ b/examples/data_description.py
@@ -1,15 +1,16 @@
 """ example data description """
 from datetime import date, time
 
-from aind_data_schema import RawDataDescription
-from aind_data_schema.data_description import Funding
+from aind_data_schema.data_description import Funding, Institution, Modality, RawDataDescription
+from aind_data_schema.device import InstrumentType
 
 d = RawDataDescription(
-    modality="ecephys",
+    modality=Modality.SPIM,
+    instrument_type="diSPIM",
     subject_id="12345",
     creation_date=date(2022, 2, 21),
     creation_time=time(16, 30, 1),
-    institution="AIND",
+    institution=Institution.AIND,
     funding_source=[Funding(funder="AIND")],
 )
 

--- a/examples/data_description.py
+++ b/examples/data_description.py
@@ -2,7 +2,6 @@
 from datetime import date, time
 
 from aind_data_schema.data_description import Funding, Institution, Modality, RawDataDescription
-from aind_data_schema.device import InstrumentType
 
 d = RawDataDescription(
     modality=Modality.SPIM,

--- a/examples/exaspim_instrument.json
+++ b/examples/exaspim_instrument.json
@@ -1,6 +1,6 @@
 {
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/imaging/instrument.py",
-   "schema_version": "0.4.2",
+   "schema_version": "0.5.0",
    "instrument_id": "exaSPIM1-1",
    "location": "440 Westlake",
    "manufacturer": "Custom",

--- a/examples/exaspim_instrument.json
+++ b/examples/exaspim_instrument.json
@@ -2,6 +2,7 @@
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/imaging/instrument.py",
    "schema_version": "0.5.0",
    "instrument_id": "exaSPIM1-1",
+   "instrument_type": "exaSPIM",
    "location": "440 Westlake",
    "manufacturer": "Custom",
    "temperature_control": false,

--- a/examples/exaspim_instrument.json
+++ b/examples/exaspim_instrument.json
@@ -2,7 +2,6 @@
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/imaging/instrument.py",
    "schema_version": "0.4.2",
    "instrument_id": "exaSPIM1-1",
-   "type": "exaSPIM",
    "location": "440 Westlake",
    "manufacturer": "Custom",
    "temperature_control": false,

--- a/examples/exaspim_instrument.py
+++ b/examples/exaspim_instrument.py
@@ -4,6 +4,7 @@ from aind_data_schema.imaging import instrument
 
 inst = instrument.Instrument(
     instrument_id="exaSPIM1-1",
+    instrument_type="exaSPIM",
     manufacturer="Custom",
     location="440 Westlake",
     objectives=[

--- a/examples/exaspim_instrument.py
+++ b/examples/exaspim_instrument.py
@@ -4,7 +4,6 @@ from aind_data_schema.imaging import instrument
 
 inst = instrument.Instrument(
     instrument_id="exaSPIM1-1",
-    type="exaSPIM",
     manufacturer="Custom",
     location="440 Westlake",
     objectives=[

--- a/src/aind_data_schema/base.py
+++ b/src/aind_data_schema/base.py
@@ -36,7 +36,7 @@ class AindModel(BaseModel, extra=Extra.forbid):
 
 class BaseName(AindModel):
     """A simple model associating a name with an abbreviation"""
-    
+
     name: str
     abbreviation: str
 

--- a/src/aind_data_schema/base.py
+++ b/src/aind_data_schema/base.py
@@ -35,6 +35,7 @@ class AindModel(BaseModel, extra=Extra.forbid):
 
     pass
 
+
 class BaseName(AindModel):
     name: str
     abbreviation: str

--- a/src/aind_data_schema/base.py
+++ b/src/aind_data_schema/base.py
@@ -35,6 +35,10 @@ class AindModel(BaseModel, extra=Extra.forbid):
 
     pass
 
+class BaseName(AindModel):
+    name: str
+    abbreviation: str
+
 
 class AindCoreModel(AindModel):
     """Generic base class to hold common fields/validators/etc for all basic AIND schema"""

--- a/src/aind_data_schema/base.py
+++ b/src/aind_data_schema/base.py
@@ -37,6 +37,8 @@ class AindModel(BaseModel, extra=Extra.forbid):
 
 
 class BaseName(AindModel):
+    """A simple model associating a name with an abbreviation"""
+    
     name: str
     abbreviation: str
 

--- a/src/aind_data_schema/data_description.py
+++ b/src/aind_data_schema/data_description.py
@@ -224,13 +224,6 @@ class DataDescription(AindCoreModel):
             creation_time=creation_time,
         )
 
-    @classmethod
-    def from_name(cls, name, **kwargs):
-        """construct a DataDescription from a name string"""
-        d = cls.parse_name(name)
-
-        return cls(**d, **kwargs)
-
 
 class DerivedDataDescription(DataDescription):
     """A logical collection of data files derived via processing"""

--- a/src/aind_data_schema/data_description.py
+++ b/src/aind_data_schema/data_description.py
@@ -7,7 +7,7 @@ from datetime import date, datetime, time
 from enum import Enum
 from typing import List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from .base import AindCoreModel, AindModel, BaseName
 from .device import InstrumentType

--- a/src/aind_data_schema/data_description.py
+++ b/src/aind_data_schema/data_description.py
@@ -7,7 +7,7 @@ from datetime import date, datetime, time
 from enum import Enum
 from typing import List, Optional
 
-from pydantic import Field, BaseModel
+from pydantic import BaseModel, Field
 
 from .base import AindCoreModel, AindModel, BaseName
 from .device import InstrumentType
@@ -105,7 +105,7 @@ class Funding(AindModel):
 class DataDescription(AindCoreModel):
     """Description of a logical collection of data files"""
 
-    schema_version: str = Field("0.3.1", title="Schema Version", const=True)
+    schema_version: str = Field("0.4.0", title="Schema Version", const=True)
     license: str = Field("CC-BY-4.0", title="License", const=True)
 
     creation_time: time = Field(
@@ -127,7 +127,7 @@ class DataDescription(AindCoreModel):
         ...,
         description="An established society, corporation, foundation or other organization that collected this data",
         title="Institution",
-        enumNames=[ i.value.name for i in Institution ]
+        enumNames=[i.value.name for i in Institution],
     )
     ror_id: Optional[str] = Field(
         None,
@@ -167,16 +167,14 @@ class DataDescription(AindCoreModel):
     )
     modality: Modality = Field(
         ...,
-        description="A short name for the specific manner, characteristic, pattern of application, or the employment of"
-        " any technology or formal procedure to generate data for a study",
+        description="A short name for the specific manner, characteristic, pattern of application, or the employment of any technology or formal procedure to generate data for a study",
         title="Modality",
-    ),
+    )
     instrument_type: InstrumentType = Field(
         ...,
-        regex=DataRegex.NO_UNDERSCORES.value,
         description="A short name for the type of instrument used to collect this data",
         title="Instrument Type",
-    ),
+    )
     subject_id: str = Field(
         ...,
         regex=DataRegex.NO_UNDERSCORES.value,
@@ -257,7 +255,6 @@ class DerivedDataDescription(DataDescription):
         )
 
 
-
 class RawDataDescription(DataDescription):
     """A logical collection of data files as acquired from a rig or instrument"""
 
@@ -268,11 +265,17 @@ class RawDataDescription(DataDescription):
         const=True,
     )
 
-    def __init__(self, **kwargs):
+    def __init__(self, instrument_type, subject_id, **kwargs):
         """Construct a raw data description"""
-        instrument_type = kwargs["instrument_type"]
-        subject_id = kwargs["subject_id"]
-        super().__init__(label=f"{instrument_type}_{subject_id}", **kwargs)
+
+        instrument_type = InstrumentType(instrument_type)
+
+        super().__init__(
+            label=f"{instrument_type.value}_{subject_id}",
+            instrument_type=instrument_type,
+            subject_id=subject_id,
+            **kwargs,
+        )
 
     @classmethod
     def parse_name(cls, name):
@@ -291,4 +294,3 @@ class RawDataDescription(DataDescription):
             creation_date=creation_date,
             creation_time=creation_time,
         )
-

--- a/src/aind_data_schema/data_description.py
+++ b/src/aind_data_schema/data_description.py
@@ -75,15 +75,15 @@ class Modality(Enum):
 class ExperimentType(Enum):
     """Experiment type name"""
 
-    MESOSPIM = "mesoSPIM"
-    EXASPIM = "exaSPIM"
+    CONFOCAL = "confocal"
     DISPIM = "diSPIM"
-    SMARTSPIM = "SmartSPIM"
+    EXASPIM = "exaSPIM"
     ECEPHYS = "ecephys"
-    OPHYS = "ophys"
-    CONFOCAL = "Confocal"
     MESOSCOPE = "mesoscope"
+    MESOSPIM = "mesoSPIM"
+    OPHYS = "ophys"
     OTHER = "Other"
+    SMARTSPIM = "SmartSPIM"
 
 
 def datetime_to_name_string(d, t):
@@ -185,7 +185,7 @@ class DataDescription(AindCoreModel):
         description="Detail any restrictions on publishing or sharing these data",
         title="Restrictions",
     )
-    modality: Modality = Field(
+    modality: List[Modality] = Field(
         ...,
         description="A short name for the specific manner, characteristic, pattern of application, or the employment"
         "of any technology or formal procedure to generate data for a study",

--- a/src/aind_data_schema/data_description.py
+++ b/src/aind_data_schema/data_description.py
@@ -167,7 +167,8 @@ class DataDescription(AindCoreModel):
     )
     modality: Modality = Field(
         ...,
-        description="A short name for the specific manner, characteristic, pattern of application, or the employment of any technology or formal procedure to generate data for a study",
+        description="A short name for the specific manner, characteristic, pattern of application, or the employment"
+        "of any technology or formal procedure to generate data for a study",
         title="Modality",
     )
     instrument_type: InstrumentType = Field(

--- a/src/aind_data_schema/data_description.py
+++ b/src/aind_data_schema/data_description.py
@@ -70,7 +70,8 @@ class Modality(Enum):
     HSFP = BaseName(name="Hyperspectral fiber photometry", abbreviation="HSFP")
     MRI = BaseName(name="Magnetic resonance imaging", abbreviation="MRI")
     OPHYS = BaseName(name="Optical physiology", abbreviation="ophys")
-    
+
+
 class ExperimentType(Enum):
     """Experiment type name"""
 

--- a/src/aind_data_schema/data_description.py
+++ b/src/aind_data_schema/data_description.py
@@ -47,7 +47,7 @@ class Institution(Enum):
 
     AIBS = BaseName(name="Allen Institute for Brain Science", abbreviation="AIBS")
     AIND = BaseName(name="Allen Institute for Neural Dynamics", abbreviation="AIND")
-    CU = BaseName(name="Columbia University", abbreviation="CU")
+    COLUMBIA = BaseName(name="Columbia University", abbreviation="Columbia")
     HUST = BaseName(name="Huazhong University of Science and Technology", abbreviation="HUST")
     NYU = BaseName(name="New York University", abbreviation="NYU")
 
@@ -64,13 +64,13 @@ class Group(Enum):
 class Modality(Enum):
     """Data collection modality name"""
 
-    ECEPHYS = BaseName(name="extracellular electrophysiology", abbreviation="ecephys")
-    SPIM = BaseName(name="selective plane illumination microscopy", abbreviation="SPIM")
-    FIP = BaseName(name="frame-projected independent-fiber photometry", abbreviation="FIP")
-    FMOST = BaseName(name="fluorescence micro-optical sectioning tomography", abbreviation="fMOST")
-    HSFP = BaseName(name="hyperspectral fiber photometry", abbreviation="HSFP")
-    MRI = BaseName(name="magnetic resonance imaging", abbreviation="MRI")
-    OPHYS = BaseName(name="optical physiology", abbreviation="ophys")
+    ECEPHYS = BaseName(name="Extracellular electrophysiology", abbreviation="ecephys")
+    SPIM = BaseName(name="Selective plane illumination microscopy", abbreviation="SPIM")
+    FIP = BaseName(name="Frame-projected independent-fiber photometry", abbreviation="FIP")
+    FMOST = BaseName(name="Fluorescence micro-optical sectioning tomography", abbreviation="fMOST")
+    HSFP = BaseName(name="Hyperspectral fiber photometry", abbreviation="HSFP")
+    MRI = BaseName(name="Magnetic resonance imaging", abbreviation="MRI")
+    OPHYS = BaseName(name="Optical physiology", abbreviation="ophys")
 
 
 def datetime_to_name_string(d, t):

--- a/src/aind_data_schema/data_description.py
+++ b/src/aind_data_schema/data_description.py
@@ -193,7 +193,7 @@ class DataDescription(AindCoreModel):
     )
     experiment_type: ExperimentType = Field(
         ...,
-        description="A short name for the experiment motivating the collection of this data",
+        description="A short name for the experimental technique used to collect this data",
         title="Experiment Type",
     )
     subject_id: str = Field(

--- a/src/aind_data_schema/device.py
+++ b/src/aind_data_schema/device.py
@@ -14,6 +14,20 @@ from pydantic import Field
 from .base import AindModel
 
 
+class InstrumentType(Enum):
+    """Instrument type name"""
+
+    MESOSPIM = "mesoSPIM"
+    EXASPIM = "exaSPIM"
+    DISPIM = "diSPIM"
+    SMARTSPIM = "smartSPIM"
+    ECEPHYS = "ecephys",
+    OPHYS = "ophys",
+    CONFOCAL = "Confocal"
+    TWO_PHOTON = "Two photon"
+    OTHER = "Other"
+
+
 class SizeUnit(Enum):
     """units for sizes"""
 

--- a/src/aind_data_schema/device.py
+++ b/src/aind_data_schema/device.py
@@ -14,20 +14,6 @@ from pydantic import Field
 from .base import AindModel
 
 
-class InstrumentType(Enum):
-    """Instrument type name"""
-
-    MESOSPIM = "mesoSPIM"
-    EXASPIM = "exaSPIM"
-    DISPIM = "diSPIM"
-    SMARTSPIM = "SmartSPIM"
-    ECEPHYS = "ecephys"
-    OPHYS = "ophys"
-    CONFOCAL = "Confocal"
-    TWO_PHOTON = "Two photon"
-    OTHER = "Other"
-
-
 class SizeUnit(Enum):
     """units for sizes"""
 

--- a/src/aind_data_schema/device.py
+++ b/src/aind_data_schema/device.py
@@ -20,9 +20,9 @@ class InstrumentType(Enum):
     MESOSPIM = "mesoSPIM"
     EXASPIM = "exaSPIM"
     DISPIM = "diSPIM"
-    SMARTSPIM = "smartSPIM"
-    ECEPHYS = "ecephys",
-    OPHYS = "ophys",
+    SMARTSPIM = "SmartSPIM"
+    ECEPHYS = "ecephys"
+    OPHYS = "ophys"
     CONFOCAL = "Confocal"
     TWO_PHOTON = "Two photon"
     OTHER = "Other"

--- a/src/aind_data_schema/imaging/instrument.py
+++ b/src/aind_data_schema/imaging/instrument.py
@@ -12,18 +12,6 @@ from ..base import AindCoreModel, AindModel
 from ..device import Coupling, DAQDevice, DataInterface, Device, Filter, Manufacturer, PowerUnit, SizeUnit
 
 
-class InstrumentType(Enum):
-    """Instrument type name"""
-
-    MESOSPIM = "mesoSPIM"
-    EXASPIM = "exaSPIM"
-    DISPIM = "diSPIM"
-    SMARTSPIM = "smartSPIM"
-    CONFOCAL = "Confocal"
-    TWO_PHOTON = "Two photon"
-    OTHER = "Other"
-
-
 class Com(AindModel):
     """Description of a communication system"""
 

--- a/src/aind_data_schema/imaging/instrument.py
+++ b/src/aind_data_schema/imaging/instrument.py
@@ -9,7 +9,8 @@ from typing import List, Optional
 from pydantic import Field
 
 from ..base import AindCoreModel, AindModel
-from ..device import Coupling, DAQDevice, DataInterface, Device, Filter, Manufacturer, PowerUnit, SizeUnit
+from ..device import (Coupling, DAQDevice, DataInterface, Device, Filter, InstrumentType, Manufacturer, PowerUnit,
+                      SizeUnit)
 
 
 class Com(AindModel):

--- a/src/aind_data_schema/imaging/instrument.py
+++ b/src/aind_data_schema/imaging/instrument.py
@@ -144,7 +144,7 @@ class OpticalTable(Device):
 class Instrument(AindCoreModel):
     """Description of an instrument, which is a collection of devices"""
 
-    schema_version: str = Field("0.4.2", description="schema version", title="Version", const=True)
+    schema_version: str = Field("0.5.0", description="schema version", title="Version", const=True)
     instrument_id: Optional[str] = Field(
         None,
         description="unique identifier for this instrument configuration",

--- a/src/aind_data_schema/imaging/instrument.py
+++ b/src/aind_data_schema/imaging/instrument.py
@@ -96,6 +96,19 @@ class ImagingDeviceType(Enum):
     OTHER = "Other"
 
 
+class ImagingInstrumentType(Enum):
+    """Experiment type name"""
+
+    CONFOCAL = "confocal"
+    DISPIM = "diSPIM"
+    EXASPIM = "exaSPIM"
+    ECEPHYS = "ecephys"
+    MESOSPIM = "mesoSPIM"
+    OTHER = "Other"
+    SMARTSPIM = "SmartSPIM"
+    TWO_PHOTON = "Two photon"
+
+
 class AdditionalImagingDevice(Device):
     """Description of additional devices"""
 
@@ -150,6 +163,7 @@ class Instrument(AindCoreModel):
         description="unique identifier for this instrument configuration",
         title="Instrument ID",
     )
+    instrument_type: ImagingInstrumentType = Field(..., title="Instrument type")
     location: str = Field(..., title="Instrument location")
     manufacturer: Manufacturer = Field(..., title="Instrument manufacturer")
     temperature_control: Optional[bool] = Field(None, title="Temperature control")

--- a/src/aind_data_schema/imaging/instrument.py
+++ b/src/aind_data_schema/imaging/instrument.py
@@ -9,7 +9,7 @@ from typing import List, Optional
 from pydantic import Field
 
 from ..base import AindCoreModel, AindModel
-from ..device import (Coupling, DAQDevice, DataInterface, Device, Filter, InstrumentType, Manufacturer, PowerUnit,
+from ..device import (Coupling, DAQDevice, DataInterface, Device, Filter, Manufacturer, PowerUnit,
                       SizeUnit)
 
 
@@ -151,7 +151,6 @@ class Instrument(AindCoreModel):
         description="unique identifier for this instrument configuration",
         title="Instrument ID",
     )
-    type: InstrumentType = Field(..., title="Instrument type")
     location: str = Field(..., title="Instrument location")
     manufacturer: Manufacturer = Field(..., title="Instrument manufacturer")
     temperature_control: Optional[bool] = Field(None, title="Temperature control")

--- a/src/aind_data_schema/imaging/instrument.py
+++ b/src/aind_data_schema/imaging/instrument.py
@@ -9,8 +9,7 @@ from typing import List, Optional
 from pydantic import Field
 
 from ..base import AindCoreModel, AindModel
-from ..device import (Coupling, DAQDevice, DataInterface, Device, Filter, Manufacturer, PowerUnit,
-                      SizeUnit)
+from ..device import Coupling, DAQDevice, DataInterface, Device, Filter, Manufacturer, PowerUnit, SizeUnit
 
 
 class Com(AindModel):

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -4,7 +4,8 @@ import datetime
 import json
 import unittest
 
-from aind_data_schema.data_description import DataDescription, DerivedDataDescription, Funding, RawDataDescription, Institution
+from aind_data_schema.data_description import (DataDescription, DerivedDataDescription, Funding, Institution, Modality,
+                                               RawDataDescription)
 from aind_data_schema.device import InstrumentType
 
 
@@ -15,44 +16,6 @@ class DataDescriptionTest(unittest.TestCase):
     BASIC_NAME = "ecephys_1234_3033-12-21_04-22-11"
     DERIVED_NAME = "ecephys_1234_3033-12-21_04-22-11_spikesorted-ks25_2022-10-12_23-23-11"
 
-    def test_from_data_description(self):
-        """test the from_data_description method"""
-        dt = datetime.datetime.now()
-        d1 = RawDataDescription(
-            creation_date=dt.date(),
-            creation_time=dt.time(),
-            institution=Institution.AIND,
-            data_level="raw data",
-            funding_source=[],
-            instrument_type=InstrumentType.EXASPIM,
-            subject_id="12345",
-        )
-
-        dt = datetime.datetime.now()
-        d2 = DerivedDataDescription.from_data_description(
-            input_data=d1,
-            process_name="fishing",
-            creation_date=dt.date(),
-            creation_time=dt.time(),
-            institution=Institution.AIND,
-            funding_source=[],
-        )
-
-        assert d2.instrument_type == d1.instrument_type
-        assert d2.subject_id == d1.subject_id
-
-        d3 = DerivedDataDescription.from_data_description(
-            input_data=d2,
-            process_name="bailing",
-            creation_date=dt.date(),
-            creation_time=dt.time(),
-            institution=Institute.HUST,
-            funding_source=[],
-        )
-
-        assert d3.modality == d2.modality
-        assert d3.subject_id == d2.subject_id
-
     def test_constructors(self):
         """test building from component parts"""
         f = Funding(funder="test")
@@ -61,10 +24,11 @@ class DataDescriptionTest(unittest.TestCase):
         da = RawDataDescription(
             creation_date=dt.date(),
             creation_time=dt.time(),
-            institution=
+            institution=Institution.AIND,
             data_level="raw data",
             funding_source=[f],
-            modality="ecephys",
+            modality=Modality.ECEPHYS,
+            instrument_type="ecephys",
             subject_id="12345",
         )
 
@@ -76,6 +40,7 @@ class DataDescriptionTest(unittest.TestCase):
             institution=Institution.AIND,
             funding_source=[f],
             modality=da.modality,
+            instrument_type=da.instrument_type,
             subject_id=da.subject_id,
         )
 
@@ -84,9 +49,10 @@ class DataDescriptionTest(unittest.TestCase):
             process_name="some-model",
             creation_date=dt.date(),
             creation_time=dt.time(),
-            institution="AIND",
+            institution=Institution.AIND,
             funding_source=[f],
-            instrument_type=InstrumentType.EXASPIM,
+            modality=r1.modality,
+            instrument_type=r1.instrument_type,
             subject_id="12345",
         )
 
@@ -97,19 +63,21 @@ class DataDescriptionTest(unittest.TestCase):
             creation_time=dt.time(),
             institution=Institution.AIND,
             funding_source=[f],
-            instrument_type=InstrumentType.EXASPIM,
+            modality=r2.modality,
+            instrument_type=r2.instrument_type,
             subject_id="12345",
         )
         assert r3 is not None
 
         dd = DataDescription(
             label="test_data",
-            instrument_type=InstrumentType.EXASPIM,
+            modality=Modality.SPIM,
+            instrument_type="exaSPIM",
             subject_id="1234",
             data_level="raw data",
             creation_date=dt.date(),
             creation_time=dt.time(),
-            institution="AIND",
+            institution=Institution.AIND,
             funding_source=[f],
         )
 
@@ -126,7 +94,8 @@ class DataDescriptionTest(unittest.TestCase):
             institution=Institution.AIND,
             data_level="raw data",
             funding_source=[],
-            instrument_type=InstrumentType.EXASPIM,
+            modality=Modality.SPIM,
+            instrument_type="exaSPIM",
             subject_id="12345",
         )
 

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -106,7 +106,7 @@ class DataDescriptionTest(unittest.TestCase):
 
     def test_parse_name(self):
         """tests for parsing names"""
-        
+
         toks = DataDescription.parse_name(self.BASIC_NAME)
         assert toks["label"] == "ecephys_1234"
         assert toks["creation_date"] == datetime.date(3033, 12, 21)

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -4,7 +4,8 @@ import datetime
 import json
 import unittest
 
-from aind_data_schema.data_description import DataDescription, DerivedDataDescription, Funding, RawDataDescription
+from aind_data_schema.data_description import DataDescription, DerivedDataDescription, Funding, RawDataDescription, Institution
+from aind_data_schema.device import InstrumentType
 
 
 class DataDescriptionTest(unittest.TestCase):
@@ -14,69 +15,16 @@ class DataDescriptionTest(unittest.TestCase):
     BASIC_NAME = "ecephys_1234_3033-12-21_04-22-11"
     DERIVED_NAME = "ecephys_1234_3033-12-21_04-22-11_spikesorted-ks25_2022-10-12_23-23-11"
 
-    def test_from_name(self):
-        """test the from_name methods"""
-
-        f = Funding(funder="test")
-
-        da = DataDescription.from_name(
-            name=self.BASIC_NAME,
-            institution="AIND",
-            data_level="raw data",
-            funding_source=[f],
-            modality="exaSPIM",
-            subject_id="12345",
-        )
-        assert da.name == self.BASIC_NAME
-
-        with self.assertRaises(ValueError):
-            DataDescription.from_name(
-                name=self.BAD_NAME,
-                institution="AIND",
-                data_level="raw data",
-                funding_source=[f],
-            )
-
-        rd = RawDataDescription.from_name(name=self.BASIC_NAME, institution="AIND", funding_source=[f])
-        assert rd.name == self.BASIC_NAME
-        assert rd.data_level.value == "raw data"
-
-        with self.assertRaises(ValueError):
-            RawDataDescription.from_name(
-                name=self.BAD_NAME,
-                institution="AIND",
-                data_level="raw data",
-                funding_source=[f],
-            )
-
-        dd = DerivedDataDescription.from_name(
-            name=self.DERIVED_NAME,
-            institution="AIND",
-            funding_source=[f],
-            modality="SmartSPIM",
-            subject_id="12345",
-        )
-        assert dd.name == self.DERIVED_NAME
-        assert dd.data_level.value == "derived data"
-
-        with self.assertRaises(ValueError):
-            DerivedDataDescription.from_name(
-                name=self.BAD_NAME,
-                institution="AIND",
-                data_level="raw data",
-                funding_source=[f],
-            )
-
     def test_from_data_description(self):
         """test the from_data_description method"""
         dt = datetime.datetime.now()
         d1 = RawDataDescription(
             creation_date=dt.date(),
             creation_time=dt.time(),
-            institution="AIND",
+            institution=Institution.AIND,
             data_level="raw data",
             funding_source=[],
-            modality="ecephys",
+            instrument_type=InstrumentType.EXASPIM,
             subject_id="12345",
         )
 
@@ -86,11 +34,11 @@ class DataDescriptionTest(unittest.TestCase):
             process_name="fishing",
             creation_date=dt.date(),
             creation_time=dt.time(),
-            institution="AIND",
+            institution=Institution.AIND,
             funding_source=[],
         )
 
-        assert d2.modality == d1.modality
+        assert d2.instrument_type == d1.instrument_type
         assert d2.subject_id == d1.subject_id
 
         d3 = DerivedDataDescription.from_data_description(
@@ -98,7 +46,7 @@ class DataDescriptionTest(unittest.TestCase):
             process_name="bailing",
             creation_date=dt.date(),
             creation_time=dt.time(),
-            institution="HUST",
+            institution=Institute.HUST,
             funding_source=[],
         )
 
@@ -113,7 +61,7 @@ class DataDescriptionTest(unittest.TestCase):
         da = RawDataDescription(
             creation_date=dt.date(),
             creation_time=dt.time(),
-            institution="AIND",
+            institution=
             data_level="raw data",
             funding_source=[f],
             modality="ecephys",
@@ -125,7 +73,7 @@ class DataDescriptionTest(unittest.TestCase):
             process_name="spikesort-ks25",
             creation_date=dt.date(),
             creation_time=dt.time(),
-            institution="AIND",
+            institution=Institution.AIND,
             funding_source=[f],
             modality=da.modality,
             subject_id=da.subject_id,
@@ -138,7 +86,7 @@ class DataDescriptionTest(unittest.TestCase):
             creation_time=dt.time(),
             institution="AIND",
             funding_source=[f],
-            modality="ecephys",
+            instrument_type=InstrumentType.EXASPIM,
             subject_id="12345",
         )
 
@@ -147,16 +95,16 @@ class DataDescriptionTest(unittest.TestCase):
             process_name="a-paper",
             creation_date=dt.date(),
             creation_time=dt.time(),
-            institution="AIND",
+            institution=Institution.AIND,
             funding_source=[f],
-            modality="ecephys",
+            instrument_type=InstrumentType.EXASPIM,
             subject_id="12345",
         )
         assert r3 is not None
 
         dd = DataDescription(
             label="test_data",
-            modality="ecephys",
+            instrument_type=InstrumentType.EXASPIM,
             subject_id="1234",
             data_level="raw data",
             creation_date=dt.date(),
@@ -175,10 +123,10 @@ class DataDescriptionTest(unittest.TestCase):
         da1 = RawDataDescription(
             creation_date=dt.date(),
             creation_time=dt.time(),
-            institution="AIND",
+            institution=Institution.AIND,
             data_level="raw data",
             funding_source=[],
-            modality="ecephys",
+            instrument_type=InstrumentType.EXASPIM,
             subject_id="12345",
         )
 

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -6,7 +6,6 @@ import unittest
 
 from aind_data_schema.data_description import (DataDescription, DerivedDataDescription, Funding, Institution, Modality,
                                                RawDataDescription)
-from aind_data_schema.device import InstrumentType
 
 
 class DataDescriptionTest(unittest.TestCase):

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -104,6 +104,33 @@ class DataDescriptionTest(unittest.TestCase):
         assert da1.creation_date == da2.creation_date
         assert da1.name == da2.name
 
+    def test_parse_name(self):
+        toks = DataDescription.parse_name(self.BASIC_NAME)
+        assert toks["label"] == "ecephys_1234"
+        assert toks["creation_date"] == datetime.date(3033, 12, 21)
+        assert toks["creation_time"] == datetime.time(4, 22, 11)
+
+        with self.assertRaises(ValueError):
+            toks = DataDescription.parse_name(self.BAD_NAME)
+
+        toks = RawDataDescription.parse_name(self.BASIC_NAME)
+        assert toks["instrument_type"] == "ecephys"
+        assert toks["subject_id"] == "1234"
+        assert toks["creation_date"] == datetime.date(3033, 12, 21)
+        assert toks["creation_time"] == datetime.time(4, 22, 11)
+
+        with self.assertRaises(ValueError):
+            toks = RawDataDescription.parse_name(self.BAD_NAME)
+
+        toks = DerivedDataDescription.parse_name(self.DERIVED_NAME)
+        assert toks["input_data_name"] == "ecephys_1234_3033-12-21_04-22-11"
+        assert toks["process_name"] == "spikesorted-ks25"
+        assert toks["creation_date"] == datetime.date(2022, 10, 12)
+        assert toks["creation_time"] == datetime.time(23, 23, 11)
+
+        with self.assertRaises(ValueError):
+            toks = DerivedDataDescription.parse_name(self.BAD_NAME)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -105,6 +105,8 @@ class DataDescriptionTest(unittest.TestCase):
         assert da1.name == da2.name
 
     def test_parse_name(self):
+        """tests for parsing names"""
+        
         toks = DataDescription.parse_name(self.BASIC_NAME)
         assert toks["label"] == "ecephys_1234"
         assert toks["creation_date"] == datetime.date(3033, 12, 21)

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -26,8 +26,8 @@ class DataDescriptionTest(unittest.TestCase):
             institution=Institution.AIND,
             data_level="raw data",
             funding_source=[f],
-            modality=Modality.ECEPHYS,
-            instrument_type="ecephys",
+            modality=[Modality.ECEPHYS],
+            experiment_type="ecephys",
             subject_id="12345",
         )
 
@@ -39,7 +39,7 @@ class DataDescriptionTest(unittest.TestCase):
             institution=Institution.AIND,
             funding_source=[f],
             modality=da.modality,
-            instrument_type=da.instrument_type,
+            experiment_type=da.experiment_type,
             subject_id=da.subject_id,
         )
 
@@ -51,7 +51,7 @@ class DataDescriptionTest(unittest.TestCase):
             institution=Institution.AIND,
             funding_source=[f],
             modality=r1.modality,
-            instrument_type=r1.instrument_type,
+            experiment_type=r1.experiment_type,
             subject_id="12345",
         )
 
@@ -63,15 +63,15 @@ class DataDescriptionTest(unittest.TestCase):
             institution=Institution.AIND,
             funding_source=[f],
             modality=r2.modality,
-            instrument_type=r2.instrument_type,
+            experiment_type=r2.experiment_type,
             subject_id="12345",
         )
         assert r3 is not None
 
         dd = DataDescription(
             label="test_data",
-            modality=Modality.SPIM,
-            instrument_type="exaSPIM",
+            modality=[Modality.SPIM],
+            experiment_type="exaSPIM",
             subject_id="1234",
             data_level="raw data",
             creation_date=dt.date(),
@@ -93,8 +93,8 @@ class DataDescriptionTest(unittest.TestCase):
             institution=Institution.AIND,
             data_level="raw data",
             funding_source=[],
-            modality=Modality.SPIM,
-            instrument_type="exaSPIM",
+            modality=[Modality.SPIM],
+            experiment_type="exaSPIM",
             subject_id="12345",
         )
 
@@ -116,7 +116,7 @@ class DataDescriptionTest(unittest.TestCase):
             toks = DataDescription.parse_name(self.BAD_NAME)
 
         toks = RawDataDescription.parse_name(self.BASIC_NAME)
-        assert toks["instrument_type"] == "ecephys"
+        assert toks["experiment_type"] == "ecephys"
         assert toks["subject_id"] == "1234"
         assert toks["creation_date"] == datetime.date(3033, 12, 21)
         assert toks["creation_time"] == datetime.time(4, 22, 11)

--- a/tests/test_imaging.py
+++ b/tests/test_imaging.py
@@ -51,7 +51,6 @@ class ImagingTests(unittest.TestCase):
             i = inst.Instrument()
 
         i = inst.Instrument(
-            type="SmartSPIM",
             location="440",
             manufacturer="LifeCanvas",
             objectives=[],

--- a/tests/test_imaging.py
+++ b/tests/test_imaging.py
@@ -52,6 +52,7 @@ class ImagingTests(unittest.TestCase):
 
         i = inst.Instrument(
             location="440",
+            instrument_type="diSPIM",
             manufacturer="LifeCanvas",
             objectives=[],
             detectors=[],

--- a/tests/test_imaging.py
+++ b/tests/test_imaging.py
@@ -51,7 +51,7 @@ class ImagingTests(unittest.TestCase):
             i = inst.Instrument()
 
         i = inst.Instrument(
-            type="smartSPIM",
+            type="SmartSPIM",
             location="440",
             manufacturer="LifeCanvas",
             objectives=[],

--- a/tests/test_json_writer.py
+++ b/tests/test_json_writer.py
@@ -38,7 +38,8 @@ class SchemaWriterTests(unittest.TestCase):
         self.assertEqual(os.getcwd(), sw2.configs.output)
 
     @patch("builtins.open", new_callable=mock_open())
-    def test_write_to_json(self, mock_file: MagicMock):
+    @patch("os.path.exists", return_value=False)
+    def test_write_to_json(self, mock_ope: MagicMock, mock_file: MagicMock):
         """Tests that model is written to JSON"""
         sw = SchemaWriter(self.TEST_ARGS)
         sw.write_to_json()


### PR DESCRIPTION
This PR:

1) Creates a `BaseName` concept that is a long name + abbreviation and uses it for Modality and Institution
2) Renamed `InstrumentType` -> `ExperimentType` and moves it to `data_description.py`
3) Removes the `from_name` classmethods from `DataDescription`.  They are not very useful.
4) Removes `InstrumentType` from `Instrument`. <--- nevermind, not doing (4)
5) Makes `DataDescription.modality` a list.