### PR TITLE
pinning typing_extensions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ dynamic = ["version"]
 dependencies = [
     'pydantic',
     'jsonschema',
-    'typing_extensions; python_version < "3.8"'
+    'typing_extensions; python_version < "3.8"',
+    'typing_extensions < 4.6.0; python_version < "3.10"' # we will need to unpin this when pydantic releases a new version
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
fixed #334 

https://github.com/pydantic/pydantic/issues/545 broke again due to a change in `typing_extensions`.

adopting this solution: 
https://github.com/ewdurbin/dbml-to-fides/commit/93d0ee660d21576713ba49513e2d78d8d11e7aed

pydantic has this merged, but not released, so we can undo this at some point later.