### PR TITLE
new ValueWithUnit implementation

### DIFF
--- a/src/aind_data_schema/utils/units.py
+++ b/src/aind_data_schema/utils/units.py
@@ -5,7 +5,6 @@ from enum import Enum
 from pydantic import create_model
 
 
-
 class Size(Enum):
     """Enumeration of Length Measurements"""
 
@@ -62,14 +61,15 @@ class TimeMeasure(Enum):
 
 
 def create_unit_with_value(model_name, scalar_type, unit_type, unit_default):
-    """ this uses create_model instead of generics, which lets us set default values """
-    
-    m = create_model(model_name, value=(scalar_type,...), unit=(unit_type, unit_default))
+    """this uses create_model instead of generics, which lets us set default values"""
+
+    m = create_model(model_name, value=(scalar_type, ...), unit=(unit_type, unit_default))
     return m
 
-SizeValue = create_unit_with_value('SizeValue', float, Size, Size.MM)
-MassValue = create_unit_with_value('MassValue', float, Mass, Mass.MG)
-VolumeValue = create_unit_with_value('VolumeValue', float, Volume, Volume.NL)
-FrequencyValue = create_unit_with_value('FrequencyValue', float, Frequency, Frequency.HZ)
-AngleValue = create_unit_with_value('AngleValue', float, Angle, Angle.DEG)
-TimeValue = create_unit_with_value('TimeValue', float, TimeMeasure, TimeMeasure.S)
+
+SizeValue = create_unit_with_value("SizeValue", float, Size, Size.MM)
+MassValue = create_unit_with_value("MassValue", float, Mass, Mass.MG)
+VolumeValue = create_unit_with_value("VolumeValue", float, Volume, Volume.NL)
+FrequencyValue = create_unit_with_value("FrequencyValue", float, Frequency, Frequency.HZ)
+AngleValue = create_unit_with_value("AngleValue", float, Angle, Angle.DEG)
+TimeValue = create_unit_with_value("TimeValue", float, TimeMeasure, TimeMeasure.S)

--- a/src/aind_data_schema/utils/units.py
+++ b/src/aind_data_schema/utils/units.py
@@ -1,7 +1,6 @@
 """Script for defining UnitWithValue classes"""
 
 from enum import Enum
-from typing import Generic, TypeVar
 
 from pydantic import create_model
 

--- a/src/aind_data_schema/utils/units.py
+++ b/src/aind_data_schema/utils/units.py
@@ -13,6 +13,8 @@ class Size(Enum):
     MM = "millimeter"
     UM = "micrometer"
     NG = "nanometer"
+    IN = "inch"
+    PX = "pixel"
 
 
 class Mass(Enum):

--- a/src/aind_data_schema/utils/units.py
+++ b/src/aind_data_schema/utils/units.py
@@ -3,108 +3,74 @@
 from enum import Enum
 from typing import Generic, TypeVar
 
-from pydantic.generics import GenericModel
+from pydantic import create_model
 
 
-class Units:
-    """Class containing enumerations of relevant measurement types"""
 
-    class Size(Enum):
-        """Enumeration of Length Measurements"""
+class Size(Enum):
+    """Enumeration of Length Measurements"""
 
-        MM = "millimeter"
-        CM = "centimeter"
-        M = "meter"
-
-    class Mass(Enum):
-        """Enumeration of Mass Measurements"""
-
-        KG = "kilogram"
-        G = "gram"
-        MG = "milligram"
-
-    class Frequency(Enum):
-        """Enumeration of Frequency Measurements"""
-
-        mHZ = "millihertz"
-        HZ = "hertz"
-        KHZ = "kilohertz"
-
-    class Volume(Enum):
-        """Enumeration of Volume Measurements"""
-
-        L = "liter"
-        ML = "milliliter"
-        UL = "microliter"
-        NL = "nanoliter"
-
-    class Angle(Enum):
-        """Enumeration of Angle Measurements"""
-
-        RAD = "radians"
-        DEG = "degrees"
-
-    class TimeMeasure(Enum):
-        """Enumeration of Time Measurements"""
-
-        S = "seconds"
-        M = "minutes"
-        HR = "hours"
-
-    SizeType = TypeVar("SizeType", bound=Size)
-    MassType = TypeVar("MassType", bound=Mass)
-    FrequencyType = TypeVar("FrequencyType", bound=Frequency)
-    VolumeType = TypeVar("VolumeType", bound=Volume)
-    AngleType = TypeVar("AngleType", bound=Angle)
-    TimeType = TypeVar("TimeType", bound=TimeMeasure)
+    M = "meter"
+    CM = "centimeter"
+    MM = "millimeter"
+    UM = "micrometer"
+    NG = "nanometer"
 
 
-ScalarType = TypeVar("ScalarType", float, int)
+class Mass(Enum):
+    """Enumeration of Mass Measurements"""
+
+    KG = "kilogram"
+    G = "gram"
+    MG = "milligram"
+    UG = "microgram"
+    NG = "nanogram"
 
 
-class GenericValues:
-    """Constructs UnitWithValue class for each relevant measurement type"""
+class Frequency(Enum):
+    """Enumeration of Frequency Measurements"""
 
-    class SizeValue(GenericModel, Generic[ScalarType, Units.SizeType]):
-        """Generic for Size Measurements"""
-
-        value: ScalarType
-        unit: Units.SizeType = Units.Size.MM
-
-    class MassValue(GenericModel, Generic[ScalarType, Units.MassType]):
-        """Generic for Mass Measurements"""
-
-        value: ScalarType
-        unit: Units.MassType = Units.Mass.G
-
-    class VolumeValue(GenericModel, Generic[ScalarType, Units.VolumeType]):
-        """Generic for Volume Measurements"""
-
-        value: ScalarType
-        unit: Units.VolumeType = Units.Volume.NL
-
-    class FrequencyValue(GenericModel, Generic[ScalarType, Units.FrequencyType]):
-        """Generic for Frequency Measurements"""
-
-        value: ScalarType
-        unit: Units.FrequencyType = Units.Frequency.HZ
-
-    class AngleValue(GenericModel, Generic[ScalarType, Units.AngleType]):
-        """Generic for Angle Measurements"""
-
-        value: ScalarType
-        unit: Units.AngleType = Units.Angle.DEG
-
-    class TimeValue(GenericModel, Generic[ScalarType, Units.TimeType]):
-        """Generic for Time Measurements"""
-
-        value: ScalarType
-        unit: Units.AngleType = Units.TimeMeasure.S
+    KHZ = "kilohertz"
+    HZ = "hertz"
+    mHZ = "millihertz"
 
 
-SizeVal = GenericValues.SizeValue[ScalarType, Units.SizeType]
-MassVal = GenericValues.MassValue[ScalarType, Units.MassType]
-VolumeVal = GenericValues.VolumeValue[ScalarType, Units.VolumeType]
-FrequencyVal = GenericValues.FrequencyValue[ScalarType, Units.FrequencyType]
-AngleVal = GenericValues.AngleValue[ScalarType, Units.AngleType]
-TimeVal = GenericValues.AngleValue[ScalarType, Units.TimeType]
+class Volume(Enum):
+    """Enumeration of Volume Measurements"""
+
+    L = "liter"
+    ML = "milliliter"
+    UL = "microliter"
+    NL = "nanoliter"
+
+
+class Angle(Enum):
+    """Enumeration of Angle Measurements"""
+
+    RAD = "radians"
+    DEG = "degrees"
+
+
+class TimeMeasure(Enum):
+    """Enumeration of Time Measurements"""
+
+    HR = "hour"
+    M = "minute"
+    S = "second"
+    MS = "milisecond"
+    US = "microsecond"
+    NS = "nanosecond"
+
+
+def create_unit_with_value(model_name, scalar_type, unit_type, unit_default):
+    """ this uses create_model instead of generics, which lets us set default values """
+    
+    m = create_model(model_name, value=(scalar_type,...), unit=(unit_type, unit_default))
+    return m
+
+SizeValue = create_unit_with_value('SizeValue', float, Size, Size.MM)
+MassValue = create_unit_with_value('MassValue', float, Mass, Mass.MG)
+VolumeValue = create_unit_with_value('VolumeValue', float, Volume, Volume.NL)
+FrequencyValue = create_unit_with_value('FrequencyValue', float, Frequency, Frequency.HZ)
+AngleValue = create_unit_with_value('AngleValue', float, Angle, Angle.DEG)
+TimeValue = create_unit_with_value('TimeValue', float, TimeMeasure, TimeMeasure.S)

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -3,7 +3,8 @@
 import unittest
 from typing import TypeVar
 
-from aind_data_schema.utils.units import Size, SizeValue
+from aind_data_schema.utils.units import Size, SizeValue, create_unit_with_value
+
 
 ScalarType = TypeVar("ScalarType", float, int)
 
@@ -17,10 +18,12 @@ class UnitsTests(unittest.TestCase):
         self.assertIsNotNone(Size.MM)
 
         default = SizeValue(value=10.1)
-        # testVal = SizeValue(value=10.1, unit=Size.MM)
 
         self.assertEqual(default, SizeValue(value=10.1, unit=Size.MM))
-        # self.assertEqual(default, testVal)
+
+        ArbitraryValue = create_unit_with_value("ArbitraryValue", float, Size, Size.IN)
+
+        self.assertIsNotNone(ArbitraryValue(10, Size.PX))
 
 
 if __name__ == "__main__":

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -3,7 +3,7 @@
 import unittest
 from typing import TypeVar
 
-from aind_data_schema.utils.units import GenericValues, SizeVal, Units
+from aind_data_schema.utils.units import SizeValue, Size
 
 ScalarType = TypeVar("ScalarType", float, int)
 
@@ -14,14 +14,13 @@ class UnitsTests(unittest.TestCase):
     def test_units(self):
         """Tests creation of a SizeVal object"""
         
-        self.assertIsNotNone(Units.Size.MM)
+        self.assertIsNotNone(Size.MM)
 
-        default = SizeVal(value=10.1)
-        testType = GenericValues.SizeValue[ScalarType, Units.SizeType]
-        testVal = testType(value=10.1, unit=Units.Size.MM)
+        default = SizeValue(value=10.1)
+        # testVal = SizeValue(value=10.1, unit=Size.MM)
 
-        self.assertEqual(default, SizeVal(value=10.1, unit=Units.Size.MM))
-        self.assertEqual(default, testVal)
+        self.assertEqual(default, SizeValue(value=10.1, unit=Size.MM))
+        # self.assertEqual(default, testVal)
 
 
 if __name__ == "__main__":

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -3,7 +3,7 @@
 import unittest
 from typing import TypeVar
 
-from aind_data_schema.utils.units import SizeValue, Size
+from aind_data_schema.utils.units import Size, SizeValue
 
 ScalarType = TypeVar("ScalarType", float, int)
 
@@ -13,7 +13,7 @@ class UnitsTests(unittest.TestCase):
 
     def test_units(self):
         """Tests creation of a SizeVal object"""
-        
+
         self.assertIsNotNone(Size.MM)
 
         default = SizeValue(value=10.1)

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -23,7 +23,7 @@ class UnitsTests(unittest.TestCase):
 
         ArbitraryValue = create_unit_with_value("ArbitraryValue", float, Size, Size.IN)
 
-        self.assertIsNotNone(ArbitraryValue(10, Size.PX))
+        self.assertIsNotNone(ArbitraryValue(value=10, unit=Size.PX))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
closes #353 

Updating ValueWithUnit method to utilize a simpler implementation. Usage remains the same, user must import Measure and MeasureValue from Units, then instantiate a value in the form:

value = MeasureValue(value=, unit=Measure.unit