### PR TITLE
Bug 389 optional fields

### DIFF
--- a/examples/ephys_rig.json
+++ b/examples/ephys_rig.json
@@ -1,6 +1,6 @@
 {
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/ephys/ephys_rig.py",
-   "schema_version": "0.7.1",
+   "schema_version": "0.7.2",
    "rig_id": "323_EPHYS1",
    "ephys_assemblies": [
       {
@@ -85,7 +85,7 @@
             "chroma": "Color",
             "sensor_format": "1/2.9\"",
             "format_unit": null,
-            "recording_software": null,
+            "recording_software": [],
             "driver": null,
             "driver_version": null
          },
@@ -206,7 +206,7 @@
             "chroma": "Monochrome",
             "sensor_format": "1/2.9\"",
             "format_unit": null,
-            "recording_software": null,
+            "recording_software": [],
             "driver": null,
             "driver_version": null
          },
@@ -232,34 +232,36 @@
             "wavelength_unit": "nanometer",
             "max_aperture": "f/2"
          },
-         "filter": {
-            "name": null,
-            "serial_number": null,
-            "manufacturer": {
-               "name": "Thorlabs",
-               "abbreviation": null,
-               "registry": {
-                  "name": "Research Organization Registry",
-                  "abbreviation": "ROR"
+         "filter": [
+            {
+               "name": null,
+               "serial_number": null,
+               "manufacturer": {
+                  "name": "Thorlabs",
+                  "abbreviation": null,
+                  "registry": {
+                     "name": "Research Organization Registry",
+                     "abbreviation": "ROR"
+                  },
+                  "registry_identifier": "04gsnvb07"
                },
-               "registry_identifier": "04gsnvb07"
-            },
-            "model": null,
-            "notes": null,
-            "filter_type": "Long pass",
-            "diameter": null,
-            "width": null,
-            "height": null,
-            "size_unit": "millimeter",
-            "thickness": null,
-            "thickness_unit": "millimeter",
-            "filter_wheel_index": null,
-            "cut_off_wavelength": null,
-            "cut_on_wavelength": null,
-            "center_wavelength": null,
-            "wavelength_unit": "nanometer",
-            "description": "850 nm longpass filter"
-         },
+               "model": null,
+               "notes": null,
+               "filter_type": "Long pass",
+               "diameter": null,
+               "width": null,
+               "height": null,
+               "size_unit": "millimeter",
+               "thickness": null,
+               "thickness_unit": "millimeter",
+               "filter_wheel_index": null,
+               "cut_off_wavelength": null,
+               "cut_on_wavelength": null,
+               "center_wavelength": null,
+               "wavelength_unit": "nanometer",
+               "description": "850 nm longpass filter"
+            }
+         ],
          "position": null
       },
       {
@@ -289,7 +291,7 @@
             "chroma": "Monochrome",
             "sensor_format": "1/2.9\"",
             "format_unit": null,
-            "recording_software": null,
+            "recording_software": [],
             "driver": null,
             "driver_version": null
          },
@@ -315,34 +317,36 @@
             "wavelength_unit": "nanometer",
             "max_aperture": "f/2"
          },
-         "filter": {
-            "name": null,
-            "serial_number": null,
-            "manufacturer": {
-               "name": "Thorlabs",
-               "abbreviation": null,
-               "registry": {
-                  "name": "Research Organization Registry",
-                  "abbreviation": "ROR"
+         "filter": [
+            {
+               "name": null,
+               "serial_number": null,
+               "manufacturer": {
+                  "name": "Thorlabs",
+                  "abbreviation": null,
+                  "registry": {
+                     "name": "Research Organization Registry",
+                     "abbreviation": "ROR"
+                  },
+                  "registry_identifier": "04gsnvb07"
                },
-               "registry_identifier": "04gsnvb07"
-            },
-            "model": null,
-            "notes": null,
-            "filter_type": "Long pass",
-            "diameter": null,
-            "width": null,
-            "height": null,
-            "size_unit": "millimeter",
-            "thickness": null,
-            "thickness_unit": "millimeter",
-            "filter_wheel_index": null,
-            "cut_off_wavelength": null,
-            "cut_on_wavelength": null,
-            "center_wavelength": null,
-            "wavelength_unit": "nanometer",
-            "description": "850 nm longpass filter"
-         },
+               "model": null,
+               "notes": null,
+               "filter_type": "Long pass",
+               "diameter": null,
+               "width": null,
+               "height": null,
+               "size_unit": "millimeter",
+               "thickness": null,
+               "thickness_unit": "millimeter",
+               "filter_wheel_index": null,
+               "cut_off_wavelength": null,
+               "cut_on_wavelength": null,
+               "center_wavelength": null,
+               "wavelength_unit": "nanometer",
+               "description": "850 nm longpass filter"
+            }
+         ],
          "position": null
       }
    ],
@@ -361,7 +365,7 @@
       "output": null,
       "encoder": null,
       "decoder": null,
-      "encoder_firmware": null
+      "encoder_firmware": []
    },
    "daqs": [
       {

--- a/examples/ephys_rig.py
+++ b/examples/ephys_rig.py
@@ -113,7 +113,7 @@ face_camera = Camera(
 )
 
 camassm1 = CameraAssembly(
-    camera_assembly_name="Face Camera Assembly", camera=face_camera, camera_target="Face", filter=filt, lens=lens
+    camera_assembly_name="Face Camera Assembly", camera=face_camera, camera_target="Face", filter=[filt], lens=lens
 )
 
 body_camera = Camera(
@@ -129,7 +129,7 @@ body_camera = Camera(
 )
 
 camassm2 = CameraAssembly(
-    camera_assembly_name="Body Camera Assembly", camera=body_camera, camera_target="Body", filter=filt, lens=lens
+    camera_assembly_name="Body Camera Assembly", camera=body_camera, camera_target="Body", filter=[filt], lens=lens
 )
 
 rig = EphysRig(

--- a/src/aind_data_schema/behavior/behavior_rig.py
+++ b/src/aind_data_schema/behavior/behavior_rig.py
@@ -13,7 +13,7 @@ from aind_data_schema.device import CameraAssembly, DAQDevice, Device, Disc, Har
 class BehaviorRig(AindCoreModel):
     """Description of an behavior rig"""
 
-    schema_version: str = Field("0.1.1", description="schema version", title="Version", const=True)
+    schema_version: str = Field("0.1.2", description="schema version", title="Version", const=True)
     rig_id: str = Field(..., description="room_stim apparatus_version", title="Rig ID")
     cameras: Optional[List[CameraAssembly]] = Field(None, title="Camera assemblies", unique_items=True)
     visual_monitors: Optional[List[Monitor]] = Field(None, title="Visual monitors", unique_items=True)

--- a/src/aind_data_schema/device.py
+++ b/src/aind_data_schema/device.py
@@ -541,7 +541,7 @@ class Disc(MousePlatform):
     encoder: Optional[str] = Field(None, title="Encoder", description="Encoder hardware type")
     decoder: Optional[str] = Field(None, title="Decoder", description="Decoder chip type")
     encoder_firmware: Optional[List[Software]] = Field(
-        None, title="Encoder firmware", description="Firmware to read from decoder chip counts"
+        [], title="Encoder firmware", description="Firmware to read from decoder chip counts"
     )
 
 

--- a/src/aind_data_schema/device.py
+++ b/src/aind_data_schema/device.py
@@ -325,7 +325,7 @@ class Camera(Device):
     # optional fields
     sensor_format: Optional[str] = Field(None, title="Size of the sensor")
     format_unit: Optional[str] = Field(None, title="Format unit")
-    recording_software: Optional[Software] = Field(None, title="Recording software")
+    recording_software: Optional[List[Software]] = Field([], title="Recording software")
     driver: Optional[DeviceDriver] = Field(None, title="Driver")
     driver_version: Optional[str] = Field(None, title="Driver version")
 
@@ -416,7 +416,7 @@ class CameraAssembly(AindModel):
     lens: Lens = Field(..., title="Lens")
 
     # optional fields
-    filter: Optional[Filter] = Field(None, title="Filter")
+    filter: Optional[List[Filter]] = Field([], title="Filter")
     position: Optional[RelativePosition] = Field(None, title="Relative position of this assembly")
 
 
@@ -540,7 +540,7 @@ class Disc(MousePlatform):
     output: Optional[DaqChannelType] = Field(None, description="analog or digital electronics")
     encoder: Optional[str] = Field(None, title="Encoder", description="Encoder hardware type")
     decoder: Optional[str] = Field(None, title="Decoder", description="Decoder chip type")
-    encoder_firmware: Optional[Software] = Field(
+    encoder_firmware: Optional[List[Software]] = Field(
         None, title="Encoder firmware", description="Firmware to read from decoder chip counts"
     )
 

--- a/src/aind_data_schema/ephys/ephys_rig.py
+++ b/src/aind_data_schema/ephys/ephys_rig.py
@@ -134,7 +134,7 @@ class EphysAssembly(AindModel):
 class EphysRig(AindCoreModel):
     """Description of an ephys rig"""
 
-    schema_version: str = Field("0.7.1", description="schema version", title="Version", const=True)
+    schema_version: str = Field("0.7.2", description="schema version", title="Version", const=True)
     rig_id: str = Field(..., description="room_stim apparatus_version", title="Rig ID")
     ephys_assemblies: Optional[List[EphysAssembly]] = Field(None, title="Ephys probes", unique_items=True)
     stick_microscopes: Optional[List[StickMicroscopeAssembly]] = Field(None, title="Stick microscopes")

--- a/src/aind_data_schema/ophys/ophys_rig.py
+++ b/src/aind_data_schema/ophys/ophys_rig.py
@@ -64,7 +64,7 @@ class OphysRig(AindCoreModel):
     """Description of an optical physiology rig"""
 
     schema_version: str = Field(
-        "0.6.1",
+        "0.6.2",
         description="schema version",
         title="Schema Version",
         const=True,


### PR DESCRIPTION
closes AllenNeuralDynamics/aind-metadata-entry-js#93 

Converts some of those optional fields with required sub-fields to Lists, that way users can add it if they'd like. If a user decides to add (ex) Filter, only then will they be required to submit the fields required for it. This ensures that we still get complete metadata if optional fields are selected. This is an example of how it looks: 


<img width="545" alt="Screen Shot 2023-06-30 at 7 45 22 PM" src="https://github.com/AllenNeuralDynamics/aind-data-schema/assets/54870020/42344e3e-f21a-469c-be96-af08881b9d5f">
<img width="572" alt="Screen Shot 2023-06-30 at 7 45 30 PM" src="https://github.com/AllenNeuralDynamics/aind-data-schema/assets/54870020/e0881275-8636-4330-98d9-a11655bb4fb7">


