### PR TITLE
Bug 390 device warnings

### DIFF
--- a/examples/ephys_rig.json
+++ b/examples/ephys_rig.json
@@ -1,6 +1,6 @@
 {
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/ephys/ephys_rig.py",
-   "schema_version": "0.7.2",
+   "schema_version": "0.7.3",
    "rig_id": "323_EPHYS1",
    "ephys_assemblies": [
       {

--- a/examples/fip_ophys_rig.json
+++ b/examples/fip_ophys_rig.json
@@ -1,6 +1,6 @@
 {
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/ophys/ophys_rig.py",
-   "schema_version": "0.6.2",
+   "schema_version": "0.6.3",
    "rig_id": "428_FIP1_2",
    "temperature_control": null,
    "humidity_control": null,

--- a/examples/fip_ophys_rig.py
+++ b/examples/fip_ophys_rig.py
@@ -90,7 +90,7 @@ r = ophr.OphysRig(
             crop_height=200,
             gain=2,
             chroma="Monochrome",
-            bit_depth=16
+            bit_depth=16,
         ),
         ophr.Detector(
             name="FLIR CMOS for Red Channel",
@@ -108,7 +108,7 @@ r = ophr.OphysRig(
             crop_height=200,
             gain=2,
             chroma="Monochrome",
-            bit_depth=16
+            bit_depth=16,
         ),
     ],
     objectives=[

--- a/src/aind_data_schema/behavior/behavior_rig.py
+++ b/src/aind_data_schema/behavior/behavior_rig.py
@@ -13,7 +13,7 @@ from aind_data_schema.device import CameraAssembly, DAQDevice, Device, Disc, Har
 class BehaviorRig(AindCoreModel):
     """Description of an behavior rig"""
 
-    schema_version: str = Field("0.1.2", description="schema version", title="Version", const=True)
+    schema_version: str = Field("0.1.3", description="schema version", title="Version", const=True)
     rig_id: str = Field(..., description="room_stim apparatus_version", title="Rig ID")
     cameras: Optional[List[CameraAssembly]] = Field(None, title="Camera assemblies", unique_items=True)
     visual_monitors: Optional[List[Monitor]] = Field(None, title="Visual monitors", unique_items=True)

--- a/src/aind_data_schema/device.py
+++ b/src/aind_data_schema/device.py
@@ -289,7 +289,7 @@ class Software(AindModel):
 
     name: str = Field(..., title="Software name")
     version: str = Field(..., title="Software version")
-    parameters: Optional[dict] = Field(None, title="Software parameters")
+    parameters: Optional[dict] = Field(None, title="Software parameters", additionalProperties={"type": "string"})
 
 
 class MotorizedStage(Device):

--- a/src/aind_data_schema/ephys/ephys_rig.py
+++ b/src/aind_data_schema/ephys/ephys_rig.py
@@ -134,7 +134,7 @@ class EphysAssembly(AindModel):
 class EphysRig(AindCoreModel):
     """Description of an ephys rig"""
 
-    schema_version: str = Field("0.7.2", description="schema version", title="Version", const=True)
+    schema_version: str = Field("0.7.3", description="schema version", title="Version", const=True)
     rig_id: str = Field(..., description="room_stim apparatus_version", title="Rig ID")
     ephys_assemblies: Optional[List[EphysAssembly]] = Field(None, title="Ephys probes", unique_items=True)
     stick_microscopes: Optional[List[StickMicroscopeAssembly]] = Field(None, title="Stick microscopes")

--- a/src/aind_data_schema/ophys/ophys_rig.py
+++ b/src/aind_data_schema/ophys/ophys_rig.py
@@ -44,6 +44,7 @@ class Cooling(Enum):
     AIR = "air"
     WATER = "water"
 
+
 class BinMode(Enum):
     """Detector binning mode"""
 
@@ -70,7 +71,6 @@ class Detector(Device):
     crop_width: Optional[int] = Field(None, title="Crop width")
     crop_height: Optional[int] = Field(None, title="Crop width")
     crop_unit: Optional[SizeUnit] = Field(SizeUnit.PX, title="Crop size unit", const=True)
-
 
 
 class Patch(Device):

--- a/src/aind_data_schema/ophys/ophys_rig.py
+++ b/src/aind_data_schema/ophys/ophys_rig.py
@@ -85,7 +85,7 @@ class OphysRig(AindCoreModel):
     """Description of an optical physiology rig"""
 
     schema_version: str = Field(
-        "0.6.2",
+        "0.6.3",
         description="schema version",
         title="Schema Version",
         const=True,


### PR DESCRIPTION
closes #390 
With updated schema, the form render looks like this:

<img width="534" alt="Screen Shot 2023-07-06 at 3 34 09 PM" src="https://github.com/AllenNeuralDynamics/aind-data-schema/assets/54870020/0c67146e-d850-402f-be56-c83ed1153210">

<img width="563" alt="Screen Shot 2023-07-06 at 3 34 02 PM" src="https://github.com/AllenNeuralDynamics/aind-data-schema/assets/54870020/d4cf348a-e925-4ad5-8c96-2d099ba85002">
