### PR TITLE
Adding generic calibration class for acquisition

### DIFF
--- a/examples/aibs_smartspim_procedures.py
+++ b/examples/aibs_smartspim_procedures.py
@@ -21,7 +21,11 @@ conductivity_buffer = procedures.Reagent(name="Conductivity Buffer", lot_number=
 
 easy_index = procedures.Reagent(name="Easy Index", lot_number="1234", source="Vendor")
 
-water = procedures.Reagent(name="Deionized water", lot_number="DDI/Filtered in house", source="This is not a reagent")
+water = procedures.Reagent(
+    name="Deionized water",
+    lot_number="DDI/Filtered in house",
+    source="This is not a reagent",
+)
 
 agarose = procedures.Reagent(name="Agarose", lot_number="1234", source="Other vendor")
 

--- a/examples/ephys_rig.py
+++ b/examples/ephys_rig.py
@@ -96,7 +96,11 @@ ephys_assemblyB = EphysAssembly(
 )
 
 
-filt = Filter(filter_type="Long pass", manufacturer=Manufacturer.THORLABS, description="850 nm longpass filter")
+filt = Filter(
+    filter_type="Long pass",
+    manufacturer=Manufacturer.THORLABS,
+    description="850 nm longpass filter",
+)
 
 lens = Lens(focal_length=15, manufacturer=Manufacturer.EDMUND_OPTICS, max_aperture="f/2")
 
@@ -113,7 +117,11 @@ face_camera = Camera(
 )
 
 camassm1 = CameraAssembly(
-    camera_assembly_name="Face Camera Assembly", camera=face_camera, camera_target="Face side", filter=filt, lens=lens
+    camera_assembly_name="Face Camera Assembly",
+    camera=face_camera,
+    camera_target="Face side",
+    filter=filt,
+    lens=lens,
 )
 
 body_camera = Camera(
@@ -129,7 +137,11 @@ body_camera = Camera(
 )
 
 camassm2 = CameraAssembly(
-    camera_assembly_name="Body Camera Assembly", camera=body_camera, camera_target="Body", filter=filt, lens=lens
+    camera_assembly_name="Body Camera Assembly",
+    camera=body_camera,
+    camera_target="Body",
+    filter=filt,
+    lens=lens,
 )
 
 rig = EphysRig(

--- a/examples/exaspim_acquisition.json
+++ b/examples/exaspim_acquisition.json
@@ -10,8 +10,10 @@
    "calibrations": [
       {
          "date_of_calibration": "2022-11-22T08:43:00",
-         "description": "Cleaning chamber",
-         "notes": "We used a special liquid XXX"
+         "calibration_type": "chamber",
+         "notes": "Some notes",
+         "input": {},
+         "output": {}
       }
    ],
    "session_start_time": "2022-11-22T08:43:00",

--- a/examples/exaspim_acquisition.json
+++ b/examples/exaspim_acquisition.json
@@ -1,12 +1,19 @@
 {
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/imaging/acquisition.py",
-   "schema_version": "0.4.6",
+   "schema_version": "0.4.7",
    "experimenter_full_name": [
       "###"
    ],
    "specimen_id": "###",
    "subject_id": "###",
    "instrument_id": "###",
+   "calibrations": [
+      {
+         "date_of_calibration": "2022-11-22T08:43:00",
+         "description": "Cleaning chamber",
+         "notes": "We used a special liquid XXX"
+      }
+   ],
    "session_start_time": "2022-11-22T08:43:00",
    "session_end_time": "2022-11-22T08:43:00",
    "session_type": null,

--- a/examples/exaspim_acquisition.py
+++ b/examples/exaspim_acquisition.py
@@ -2,7 +2,10 @@
 
 import datetime
 
+from aind_data_schema.device import Calibration, CalibrationType
 from aind_data_schema.imaging import acquisition, tile
+
+# from aind_data_schema.procedures import Reagent
 
 t = datetime.datetime(2022, 11, 22, 8, 43, 00)
 
@@ -12,10 +15,13 @@ acq = acquisition.Acquisition(
     subject_id="###",
     instrument_id="###",
     calibrations=[
-        acquisition.Calibration(
+        Calibration(
             date_of_calibration=t,
-            description="Cleaning chamber",
-            notes="We used a special liquid XXX",  # Notes are optional
+            calibration_type=CalibrationType.CHAMBER,
+            # reagents=[
+            #     Reagent(name="reagent1", source="xxx", rrid="xxx", lot_number="xxx", expiration_date=t),
+            # ],
+            notes="Some notes",  # Notes are optional
         )
     ],
     session_start_time=t,

--- a/examples/exaspim_acquisition.py
+++ b/examples/exaspim_acquisition.py
@@ -11,6 +11,13 @@ acq = acquisition.Acquisition(
     specimen_id="###",
     subject_id="###",
     instrument_id="###",
+    calibrations=[
+        acquisition.Calibration(
+            date_of_calibration=t,
+            description="Cleaning chamber",
+            notes="We used a special liquid XXX",  # Notes are optional
+        )
+    ],
     session_start_time=t,
     session_end_time=t,
     local_storage_directory="D:",

--- a/examples/exaspim_instrument.py
+++ b/examples/exaspim_instrument.py
@@ -86,12 +86,42 @@ inst = instrument.Instrument(
             name="Dev2",
             serial_number="Unknown",
             channels=[
-                DAQChannel(channel_name="3", channel_type="Analog Output", device_name="LAS-08308", sample_rate=10000),
-                DAQChannel(channel_name="5", channel_type="Analog Output", device_name="539251", sample_rate=10000),
-                DAQChannel(channel_name="4", channel_type="Analog Output", device_name="LAS-08309", sample_rate=10000),
-                DAQChannel(channel_name="2", channel_type="Analog Output", device_name="stage-x", sample_rate=10000),
-                DAQChannel(channel_name="0", channel_type="Analog Output", device_name="TL-1", sample_rate=10000),
-                DAQChannel(channel_name="6", channel_type="Analog Output", device_name="LAS-08307", sample_rate=10000),
+                DAQChannel(
+                    channel_name="3",
+                    channel_type="Analog Output",
+                    device_name="LAS-08308",
+                    sample_rate=10000,
+                ),
+                DAQChannel(
+                    channel_name="5",
+                    channel_type="Analog Output",
+                    device_name="539251",
+                    sample_rate=10000,
+                ),
+                DAQChannel(
+                    channel_name="4",
+                    channel_type="Analog Output",
+                    device_name="LAS-08309",
+                    sample_rate=10000,
+                ),
+                DAQChannel(
+                    channel_name="2",
+                    channel_type="Analog Output",
+                    device_name="stage-x",
+                    sample_rate=10000,
+                ),
+                DAQChannel(
+                    channel_name="0",
+                    channel_type="Analog Output",
+                    device_name="TL-1",
+                    sample_rate=10000,
+                ),
+                DAQChannel(
+                    channel_name="6",
+                    channel_type="Analog Output",
+                    device_name="LAS-08307",
+                    sample_rate=10000,
+                ),
             ],
         )
     ],

--- a/examples/fip_ophys_rig.py
+++ b/examples/fip_ophys_rig.py
@@ -69,9 +69,24 @@ r = ophr.OphysRig(
         )
     ],
     light_sources=[
-        d.LightEmittingDiode(name="470nm LED", manufacturer=d.Manufacturer.THORLABS, model="M470F3", wavelength=470),
-        d.LightEmittingDiode(name="415nm LED", manufacturer=d.Manufacturer.THORLABS, model="M415F3", wavelength=415),
-        d.LightEmittingDiode(name="565nm LED", manufacturer=d.Manufacturer.THORLABS, model="M565F3", wavelength=415),
+        d.LightEmittingDiode(
+            name="470nm LED",
+            manufacturer=d.Manufacturer.THORLABS,
+            model="M470F3",
+            wavelength=470,
+        ),
+        d.LightEmittingDiode(
+            name="415nm LED",
+            manufacturer=d.Manufacturer.THORLABS,
+            model="M415F3",
+            wavelength=415,
+        ),
+        d.LightEmittingDiode(
+            name="565nm LED",
+            manufacturer=d.Manufacturer.THORLABS,
+            model="M565F3",
+            wavelength=415,
+        ),
     ],
     detectors=[
         ophr.Detector(

--- a/src/aind_data_schema/base.py
+++ b/src/aind_data_schema/base.py
@@ -84,7 +84,11 @@ class AindCoreModel(AindModel):
 
         value = build_described_by(cls)
         field = ModelField.infer(
-            name="describedBy", value=value, annotation=str, class_validators=None, config=cls.__config__
+            name="describedBy",
+            value=value,
+            annotation=str,
+            class_validators=None,
+            config=cls.__config__,
         )
         field.field_info.const = True
         cls.__fields__.update({"describedBy": field})

--- a/src/aind_data_schema/behavior/behavior_session.py
+++ b/src/aind_data_schema/behavior/behavior_session.py
@@ -46,14 +46,18 @@ class BehaviorSession(AindCoreModel):
     behavior_type: str = Field(..., title="Behavior type", description="Name of the behavior session")
     session_number: int = Field(..., title="Session number")
     behavior_code: str = Field(
-        ..., title="Behavior code", description="URL for the commit of the code used to run the behavior"
+        ...,
+        title="Behavior code",
+        description="URL for the commit of the code used to run the behavior",
     )
     code_version: str = Field(..., description="Version of the software used", title="Code version")
     input_parameters: Dict[str, Any] = Field(
         ..., title="Input parameters", description="Parameters used in behavior session"
     )
     output_parameters: Dict[str, Any] = Field(
-        ..., title="Performance parameters", description="Performance metrics from session"
+        ...,
+        title="Performance parameters",
+        description="Performance metrics from session",
     )
     water_consumed_during_training: Decimal = Field(..., title="Water consumed during training (uL)")
     water_consumed_total: Decimal = Field(..., title="Total water consumed (uL)")

--- a/src/aind_data_schema/data_description.py
+++ b/src/aind_data_schema/data_description.py
@@ -106,18 +106,30 @@ class Modality(Enum, metaclass=BaseNameEnumMeta):
     """Data collection modality name"""
 
     CONFOCAL = BaseName(name="Confocal microscopy", abbreviation="confocal")
-    DISPIM = BaseName(name="Dual inverted selective plane illumination microscopy", abbreviation="diSPIM")
+    DISPIM = BaseName(
+        name="Dual inverted selective plane illumination microscopy",
+        abbreviation="diSPIM",
+    )
     ECEPHYS = BaseName(name="Extracellular electrophysiology", abbreviation="ecephys")
     EPHYS = BaseName(name="Electrophysiology", abbreviation="ephys")
-    EXASPIM = BaseName(name="Expansion-assisted selective plane illumination microscopy", abbreviation="exaSPIM")
+    EXASPIM = BaseName(
+        name="Expansion-assisted selective plane illumination microscopy",
+        abbreviation="exaSPIM",
+    )
     FIP = BaseName(name="Frame-projected independent-fiber photometry", abbreviation="FIP")
     FMOST = BaseName(name="Fluorescence micro-optical sectioning tomography", abbreviation="fMOST")
     HSFP = BaseName(name="Hyperspectral fiber photometry", abbreviation="HSFP")
     ICEPHYS = BaseName(name="Intracellular electrophysiology", abbreviation="icephys")
     FIB = BaseName(name="Fiber photometry", abbreviation="fib")
     FISH = BaseName(name="Fluorescence in situ hybridization", abbreviation="fish")
-    MESOSPIM = BaseName(name="Mesoscale selective plane illumination microscopy", abbreviation="mesoSPIM")
-    MERFISH = BaseName(name="Multiplexed error-robust fluorescence in situ hybridization", abbreviation="merfish")
+    MESOSPIM = BaseName(
+        name="Mesoscale selective plane illumination microscopy",
+        abbreviation="mesoSPIM",
+    )
+    MERFISH = BaseName(
+        name="Multiplexed error-robust fluorescence in situ hybridization",
+        abbreviation="merfish",
+    )
     MPOPHYS = BaseName(name="Multiplane optical physiology", abbreviation="multiplane-ophys")
     MRI = BaseName(name="Magnetic resonance imaging", abbreviation="MRI")
     OPHYS = BaseName(name="Optical physiology", abbreviation="ophys")

--- a/src/aind_data_schema/device.py
+++ b/src/aind_data_schema/device.py
@@ -9,6 +9,8 @@ from pydantic import Field
 
 from aind_data_schema.base import AindModel, BaseName, BaseNameEnumMeta, EnumSubset, PIDName
 
+# from aind_data_schema.procedures import Reagent
+
 
 class SizeUnit(Enum):
     """units for sizes"""
@@ -336,7 +338,10 @@ class Lens(Device):
 
     # required fields
     manufacturer: EnumSubset[
-        Manufacturer.COMPUTAR, Manufacturer.EDMUND_OPTICS, Manufacturer.THORLABS, Manufacturer.OTHER
+        Manufacturer.COMPUTAR,
+        Manufacturer.EDMUND_OPTICS,
+        Manufacturer.THORLABS,
+        Manufacturer.OTHER,
     ]
 
     # optional fields
@@ -375,7 +380,9 @@ class Filter(Device):
     center_wavelength: Optional[int] = Field(None, title="Center wavelength (nm)")
     wavelength_unit: SizeUnit = Field(SizeUnit.NM, title="Wavelength unit")
     description: Optional[str] = Field(
-        None, title="Description", description="More details about filter properties and where/how it is being used"
+        None,
+        title="Description",
+        description="More details about filter properties and where/how it is being used",
     )
 
 
@@ -545,7 +552,9 @@ class Disc(MousePlatform):
     encoder: Optional[str] = Field(None, title="Encoder", description="Encoder hardware type")
     decoder: Optional[str] = Field(None, title="Decoder", description="Decoder chip type")
     encoder_firmware: Optional[Software] = Field(
-        None, title="Encoder firmware", description="Firmware to read from decoder chip counts"
+        None,
+        title="Encoder firmware",
+        description="Firmware to read from decoder chip counts",
     )
 
 
@@ -626,3 +635,30 @@ class VisualStimulusDisplayAssembly(AindModel):
 
     # optional fields
     position: Optional[RelativePosition] = Field(None, title="Relative position of the monitor")
+
+
+class CalibrationType(Enum):
+    """Calibration types"""
+
+    LASER = "laser"
+    MONITOR = "monitor"
+    SPEAKER = "speaker"
+    WATER_V = "water valve"
+    CHAMBER = "chamber"
+    OTHER = "other"
+
+
+class Calibration(AindModel):
+    """Generic calibration class for acquisition"""
+
+    date_of_calibration: datetime = Field(..., title="Date and time of calibration")
+    calibration_type: CalibrationType = Field(
+        ...,
+        title="calibration type",
+    )
+    notes: Optional[str] = Field(None, title="Notes")
+    input: Optional[Dict[str, Any]] = Field({}, description="Calibration input", title="inputs")
+    output: Optional[Dict[str, Any]] = Field({}, description="Calibration output", title="outputs")
+    # reagents: Optional[List[proc.Reagent]] = Field(
+    #     None, title="Reagents", description="List of reagents used in the calibration"
+    # )

--- a/src/aind_data_schema/ephys/ephys_session.py
+++ b/src/aind_data_schema/ephys/ephys_session.py
@@ -50,7 +50,9 @@ class DomeModule(AindModel):
     # optional fields
     rotation_angle: Optional[Decimal] = Field(0.0, title="Rotation Angle", units="degrees")
     coordinate_transform: Optional[str] = Field(
-        None, title="Transform from local manipulator axes to rig", description="Path to coordinate transform"
+        None,
+        title="Transform from local manipulator axes to rig",
+        description="Path to coordinate transform",
     )
     calibration_date: Optional[datetime] = Field(None, title="Date on which coordinate transform was last calibrated")
     notes: Optional[str] = Field(None, title="Notes")
@@ -139,7 +141,9 @@ class EphysSession(AindCoreModel):
     iacuc_protocol: Optional[str] = Field(None, title="IACUC protocol")
     rig_id: str = Field(..., title="Rig ID")
     stick_microscopes: Optional[List[DomeModule]] = Field(
-        ..., title="Stick microscopes", description="Must match stick microscope assemblies in rig file"
+        ...,
+        title="Stick microscopes",
+        description="Must match stick microscope assemblies in rig file",
     )
     data_streams: List[Stream] = Field(
         ...,

--- a/src/aind_data_schema/imaging/acquisition.py
+++ b/src/aind_data_schema/imaging/acquisition.py
@@ -10,7 +10,7 @@ from typing import List, Optional
 from pydantic import Field
 
 from aind_data_schema.base import AindCoreModel, AindModel, EnumSubset
-from aind_data_schema.device import SizeUnit
+from aind_data_schema.device import Calibration, SizeUnit
 from aind_data_schema.imaging.tile import AcquisitionTile
 from aind_data_schema.processing import ProcessName
 
@@ -96,14 +96,6 @@ class ProcessingSteps(AindModel):
             ProcessName.FILE_CONVERSION,
         ]
     ]
-
-
-class Calibration(AindModel):
-    """Generic calibration class for acquisition"""
-
-    date_of_calibration: datetime = Field(..., title="Date and time of calibration")
-    description: str = Field(..., title="Calibration description")
-    notes: Optional[str] = Field(..., title="Notes")
 
 
 class Acquisition(AindCoreModel):

--- a/src/aind_data_schema/imaging/acquisition.py
+++ b/src/aind_data_schema/imaging/acquisition.py
@@ -98,10 +98,18 @@ class ProcessingSteps(AindModel):
     ]
 
 
+class Calibration(AindModel):
+    """Generic calibration class for acquisition"""
+
+    date_of_calibration: datetime = Field(..., title="Date and time of calibration")
+    description: str = Field(..., title="Calibration description")
+    notes: Optional[str] = Field(..., title="Notes")
+
+
 class Acquisition(AindCoreModel):
     """Description of an imaging acquisition session"""
 
-    schema_version: str = Field("0.4.6", description="schema version", title="Version", const=True)
+    schema_version: str = Field("0.4.7", description="schema version", title="Version", const=True)
     experimenter_full_name: List[str] = Field(
         ...,
         description="First and last name of the experimenter(s).",
@@ -110,6 +118,11 @@ class Acquisition(AindCoreModel):
     specimen_id: str = Field(..., title="Specimen ID")
     subject_id: Optional[str] = Field(None, title="Subject ID")
     instrument_id: str = Field(..., title="Instrument ID")
+    calibrations: Optional[List[Calibration]] = Field(
+        None,
+        title="Acquisition-time instrument calibrations",
+        description="List of calibration measurements taken at time of acquisition.",
+    )
     session_start_time: datetime = Field(..., title="Session start time")
     session_end_time: datetime = Field(..., title="Session end time")
     session_type: Optional[str] = Field(None, title="Session type")

--- a/src/aind_data_schema/imaging/mri_session.py
+++ b/src/aind_data_schema/imaging/mri_session.py
@@ -78,6 +78,8 @@ class MriSession(AindCoreModel):
     mri_scanner: Scanner = Field(..., title="MRI scanner")
     axes: List[Axis] = Field(..., title="Imaging axes")
     voxel_sizes: Scale3dTransform = Field(
-        ..., title="Voxel sizes", description="Size of voxels in order as specified in axes"
+        ...,
+        title="Voxel sizes",
+        description="Size of voxels in order as specified in axes",
     )
     notes: Optional[str] = Field(None, title="Notes")

--- a/src/aind_data_schema/imaging/tile.py
+++ b/src/aind_data_schema/imaging/tile.py
@@ -63,7 +63,12 @@ class Tile(AindModel):
     """Description of an image tile"""
 
     coordinate_transformations: List[
-        Union[Scale3dTransform, Translation3dTransform, Rotation3dTransform, Affine3dTransform]
+        Union[
+            Scale3dTransform,
+            Translation3dTransform,
+            Rotation3dTransform,
+            Affine3dTransform,
+        ]
     ] = Field(..., title="Tile coordinate transformations")
     file_name: Optional[str] = Field(None, title="File name")
 

--- a/src/aind_data_schema/procedures.py
+++ b/src/aind_data_schema/procedures.py
@@ -237,7 +237,10 @@ class Craniotomy(SubjectProcedure):
         None, title="Craniotomy coordinate reference"
     )
     bregma_to_lambda_distance: Optional[Decimal] = Field(
-        None, title="Bregma to lambda (mm)", description="Distance between bregman and lambda", units="mm"
+        None,
+        title="Bregma to lambda (mm)",
+        description="Distance between bregman and lambda",
+        units="mm",
     )
     bregma_to_lambda_unit: SizeUnit = Field(SizeUnit.MM, title="Bregma to lambda unit")
     craniotomy_size: Decimal = Field(..., title="Craniotomy size (mm)", units="mm")
@@ -336,7 +339,10 @@ class BrainInjection(Injection):
         None, title="Injection coordinate reference"
     )
     bregma_to_lambda_distance: Optional[Decimal] = Field(
-        None, title="Bregma to lambda (mm)", description="Distance between bregman and lambda", units="mm"
+        None,
+        title="Bregma to lambda (mm)",
+        description="Distance between bregman and lambda",
+        units="mm",
     )
     bregma_to_lambda_unit: SizeUnit = Field(SizeUnit.MM, title="Bregma to lambda unit")
     injection_angle: Decimal = Field(..., title="Injection angle (deg)", units="deg")
@@ -351,7 +357,10 @@ class NanojectInjection(BrainInjection):
 
     procedure_type: str = Field("Nanoject injection", title="Procedure type", const=True)
     injection_volume: List[Decimal] = Field(
-        ..., title="Injection volume (nL)", units="nL", description="Injection volume, one value per location"
+        ...,
+        title="Injection volume (nL)",
+        units="nL",
+        description="Injection volume, one value per location",
     )
     injection_volume_unit: VolumeUnit = Field(VolumeUnit.NL, title="Injection volume unit")
 
@@ -370,7 +379,10 @@ class IntraCerebellarVentricleInjection(BrainInjection):
 
     procedure_type: str = Field("ICV injection", title="Procedure type", const=True)
     injection_volume: List[Decimal] = Field(
-        ..., title="Injection volume (nL)", units="nL", description="Injection volume, one value per location"
+        ...,
+        title="Injection volume (nL)",
+        units="nL",
+        description="Injection volume, one value per location",
     )
     injection_volume_unit: VolumeUnit = Field(VolumeUnit.NL, title="Injection volume unit")
 
@@ -380,7 +392,10 @@ class IntraCisternalMagnaInjection(BrainInjection):
 
     procedure_type: str = Field("ICM injection", title="Procedure type", const=True)
     injection_volume: List[Decimal] = Field(
-        ..., title="Injection volume (nL)", units="nL", description="Injection volume, one value per location"
+        ...,
+        title="Injection volume (nL)",
+        units="nL",
+        description="Injection volume, one value per location",
     )
     injection_volume_unit: VolumeUnit = Field(VolumeUnit.NL, title="Injection volume unit")
 
@@ -431,7 +446,10 @@ class OphysProbe(AindModel):
         None, title="Stereotactic coordinate reference"
     )
     bregma_to_lambda_distance: Optional[Decimal] = Field(
-        None, title="Bregma to lambda (mm)", description="Distance between bregman and lambda", units="mm"
+        None,
+        title="Bregma to lambda (mm)",
+        description="Distance between bregman and lambda",
+        units="mm",
     )
     bregma_to_lambda_unit: SizeUnit = Field(SizeUnit.MM, title="Bregma to lambda unit")
     angle: Decimal = Field(..., title="Angle (deg)", units="deg")

--- a/src/aind_data_schema/processing.py
+++ b/src/aind_data_schema/processing.py
@@ -75,9 +75,13 @@ class Registration(DataProcess):
     """Description of tile alignment coordinate transformations"""
 
     registration_type: RegistrationType = Field(
-        ..., title="Registration type", description="Either inter channel across different channels or intra channel"
+        ...,
+        title="Registration type",
+        description="Either inter channel across different channels or intra channel",
     )
     registration_channel: Optional[int] = Field(
-        None, title="Registration channel", description="Channel registered to when inter channel"
+        None,
+        title="Registration channel",
+        description="Channel registered to when inter channel",
     )
     tiles: List[Tile] = Field(..., title="Data tiles")

--- a/src/aind_data_schema/stimulus.py
+++ b/src/aind_data_schema/stimulus.py
@@ -40,7 +40,9 @@ class OptoStim(AindModel):
     )
     pulse_train_interval_unit: TimeUnit = Field(TimeUnit.S, title="Pulse train interval unit")
     baseline_duration: Decimal = Field(
-        ..., title="Baseline duration (s)", description="Duration of baseline recording prior to first pulse train"
+        ...,
+        title="Baseline duration (s)",
+        description="Duration of baseline recording prior to first pulse train",
     )
     baseline_duration_unit: TimeUnit = Field(TimeUnit.S, title="Baseline duration unit")
     other_parameters: Optional[Dict[str, Any]]
@@ -57,7 +59,9 @@ class VisualStim(AindModel):
         description="Define and list the parameter values used (e.g. all TF or orientation values)",
     )
     stimulus_template_name: Optional[List[str]] = Field(
-        None, title="Stimulus template name", description="Name of image set or movie displayed"
+        None,
+        title="Stimulus template name",
+        description="Name of image set or movie displayed",
     )
     stimulus_software: str = Field(
         ...,

--- a/src/aind_data_schema/utils/erd_generator.py
+++ b/src/aind_data_schema/utils/erd_generator.py
@@ -63,7 +63,8 @@ class ErdGenerator:
         )
         optional_args = parser.parse_args(args)
         return cls(
-            classes_to_generate=optional_args.classes_to_generate, output_directory=Path(optional_args.output_directory)
+            classes_to_generate=optional_args.classes_to_generate,
+            output_directory=Path(optional_args.output_directory),
         )
 
     def generate_erd_diagrams(self) -> None:

--- a/src/aind_data_schema/utils/json_writer.py
+++ b/src/aind_data_schema/utils/json_writer.py
@@ -36,7 +36,9 @@ class SchemaWriter:
         )
 
         parser.add_argument(
-            "--attach-version", action="store_true", help="Add extra directory with schema version number"
+            "--attach-version",
+            action="store_true",
+            help="Add extra directory with schema version number",
         )
         parser.set_defaults(attach_version=False)
 

--- a/src/aind_data_schema/utils/schema_version_check.py
+++ b/src/aind_data_schema/utils/schema_version_check.py
@@ -46,7 +46,10 @@ def compare_versions(new_ver: str, old_ver: Optional[str]) -> (bool, Optional[st
     if major_bump or minor_bump or patch_bump:
         return (True, None)
     else:
-        return (False, f"Version not bumped correctly. New Version: {new_ver}. Old Version: {old_ver}")
+        return (
+            False,
+            f"Version not bumped correctly. New Version: {new_ver}. Old Version: {old_ver}",
+        )
 
 
 def run_job(new_schema_folder: str, old_schema_folder: str) -> None:
@@ -112,4 +115,7 @@ if __name__ == "__main__":
         required=True,
     )
     folder_args = parser.parse_args(sys_args)
-    run_job(new_schema_folder=folder_args.new_schema_folder, old_schema_folder=folder_args.old_schema_folder)
+    run_job(
+        new_schema_folder=folder_args.new_schema_folder,
+        old_schema_folder=folder_args.old_schema_folder,
+    )

--- a/src/aind_data_schema/utils/schema_version_check.py
+++ b/src/aind_data_schema/utils/schema_version_check.py
@@ -86,7 +86,7 @@ def run_job(new_schema_folder: str, old_schema_folder: str) -> None:
             old_schema_version_dict = old_model["properties"].get("schema_version")
             old_schema_version = (
                 None
-                if old_schema_version_dict is None or type(old_schema_version_dict) is not dict
+                if old_schema_version_dict is None or not isinstance(old_schema_version_dict, dict)
                 else old_schema_version_dict.get("const")
             )
             v_check = compare_versions(new_schema_version, old_schema_version)

--- a/tests/test_check_schema_versions.py
+++ b/tests/test_check_schema_versions.py
@@ -33,27 +33,45 @@ class SchemaVersionTests(unittest.TestCase):
 
         # False checks
         self.assertEqual(
-            (False, "Version not bumped correctly. New Version: 0.0.1. Old Version: 0.0.2"),
+            (
+                False,
+                "Version not bumped correctly. New Version: 0.0.1. Old Version: 0.0.2",
+            ),
             compare_versions("0.0.1", "0.0.2"),
         )
         self.assertEqual(
-            (False, "Version not bumped correctly. New Version: 0.3.2. Old Version: 0.2.1"),
+            (
+                False,
+                "Version not bumped correctly. New Version: 0.3.2. Old Version: 0.2.1",
+            ),
             compare_versions("0.3.2", "0.2.1"),
         )
         self.assertEqual(
-            (False, "Version not bumped correctly. New Version: 2.0.1. Old Version: 1.2.3"),
+            (
+                False,
+                "Version not bumped correctly. New Version: 2.0.1. Old Version: 1.2.3",
+            ),
             compare_versions("2.0.1", "1.2.3"),
         )
         self.assertEqual(
-            (False, "Version not bumped correctly. New Version: 0.0.1. Old Version: 0.0.3"),
+            (
+                False,
+                "Version not bumped correctly. New Version: 0.0.1. Old Version: 0.0.3",
+            ),
             compare_versions("0.0.1", "0.0.3"),
         )
         self.assertEqual(
-            (False, "Version not bumped correctly. New Version: 0.1.1. Old Version: 0.2.1"),
+            (
+                False,
+                "Version not bumped correctly. New Version: 0.1.1. Old Version: 0.2.1",
+            ),
             compare_versions("0.1.1", "0.2.1"),
         )
         self.assertEqual(
-            (False, "Version not bumped correctly. New Version: 1.0.2. Old Version: 2.1.4"),
+            (
+                False,
+                "Version not bumped correctly. New Version: 1.0.2. Old Version: 2.1.4",
+            ),
             compare_versions("1.0.2", "2.1.4"),
         )
         self.assertEqual((False, "Malformed version: 1.0"), compare_versions("1.0", "2.1.4"))
@@ -62,7 +80,12 @@ class SchemaVersionTests(unittest.TestCase):
     def test_run_job(self):
         """Tests the run_job method."""
         # Should run without any errors
-        self.assertIsNone(run_job(new_schema_folder=str(NEW_SCHEMA_DIR), old_schema_folder=str(OLD_SCHEMA_DIR)))
+        self.assertIsNone(
+            run_job(
+                new_schema_folder=str(NEW_SCHEMA_DIR),
+                old_schema_folder=str(OLD_SCHEMA_DIR),
+            )
+        )
 
         # Should raise an assertion
         expected_error_message = (
@@ -72,7 +95,10 @@ class SchemaVersionTests(unittest.TestCase):
             "New Version: 0.2.2. Old Version: 0.2.2']"
         )
         with self.assertRaises(AssertionError) as error:
-            run_job(new_schema_folder=str(NEW_SCHEMA_DIR2), old_schema_folder=str(OLD_SCHEMA_DIR))
+            run_job(
+                new_schema_folder=str(NEW_SCHEMA_DIR2),
+                old_schema_folder=str(OLD_SCHEMA_DIR),
+            )
         self.assertEqual(str(error.exception), expected_error_message)
 
 

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -211,7 +211,9 @@ class DataDescriptionTest(unittest.TestCase):
 
         # Test Override
         derived_dd_0_6_2_wrong_field2 = DerivedDataDescription.from_data_description(
-            new_dd_0_6_2_wrong_field, process_name=process_name, experiment_type=ExperimentType.OTHER
+            new_dd_0_6_2_wrong_field,
+            process_name=process_name,
+            experiment_type=ExperimentType.OTHER,
         )
         self.assertEqual(ExperimentType.OTHER, derived_dd_0_6_2_wrong_field2.experiment_type)
 

--- a/tests/test_ephys.py
+++ b/tests/test_ephys.py
@@ -31,10 +31,26 @@ class ExampleTest(unittest.TestCase):
                 ports=[],
                 computer_name="foo",
                 channels=[
-                    DAQChannel(channel_name="123", device_name="Laser A", channel_type="Analog Output"),
-                    DAQChannel(channel_name="321", device_name="Probe A", channel_type="Analog Output"),
-                    DAQChannel(channel_name="234", device_name="Camera A", channel_type="Digital Output"),
-                    DAQChannel(channel_name="2354", device_name="Disc A", channel_type="Digital Output"),
+                    DAQChannel(
+                        channel_name="123",
+                        device_name="Laser A",
+                        channel_type="Analog Output",
+                    ),
+                    DAQChannel(
+                        channel_name="321",
+                        device_name="Probe A",
+                        channel_type="Analog Output",
+                    ),
+                    DAQChannel(
+                        channel_name="234",
+                        device_name="Camera A",
+                        channel_type="Digital Output",
+                    ),
+                    DAQChannel(
+                        channel_name="2354",
+                        device_name="Disc A",
+                        channel_type="Digital Output",
+                    ),
                 ],
             )
         ]
@@ -76,7 +92,11 @@ class ExampleTest(unittest.TestCase):
         with self.assertRaises(pydantic.ValidationError):
             rig = er.EphysRig(
                 daqs=[
-                    er.HarpDevice(computer_name="asdf", harp_device_type="Sound Board", harp_device_version="1"),
+                    er.HarpDevice(
+                        computer_name="asdf",
+                        harp_device_type="Sound Board",
+                        harp_device_version="1",
+                    ),
                     er.NeuropixelsBasestation(
                         basestation_firmware_version="1",
                         bsc_firmware_version="2",
@@ -85,7 +105,11 @@ class ExampleTest(unittest.TestCase):
                         ports=[er.ProbePort(index=0, probes=["Probe B"])],
                         computer_name="foo",
                         channels=[
-                            DAQChannel(channel_name="321", device_name="Probe A", channel_type="Analog Output"),
+                            DAQChannel(
+                                channel_name="321",
+                                device_name="Probe A",
+                                channel_type="Analog Output",
+                            ),
                         ],
                     ),
                 ],

--- a/tests/test_schema_upgrade.py
+++ b/tests/test_schema_upgrade.py
@@ -256,7 +256,10 @@ class TestFundingUpgrade(unittest.TestCase):
                     "funder": {
                         "name": "Allen Institute for Neural Dynamics",
                         "abbreviation": "AIND",
-                        "registry": {"name": "Research Organization Registry", "abbreviation": "ROR"},
+                        "registry": {
+                            "name": "Research Organization Registry",
+                            "abbreviation": "ROR",
+                        },
                         "registry_identifier": "04szwah67",
                     },
                     "grant_number": None,


### PR DESCRIPTION
Adding a generic calibration class for acquisition. I am adding this since John needs to track other metadata related to the microscope maintenance.

I included:

- Date of calibration
- Description
- Notes

I believe @miketaormina can use inherit this class in the `LightSourcePowerCalibration` here: https://github.com/AllenNeuralDynamics/aind-data-schema/pull/379