### PR TITLE
Fix bug in `EphysRig` validator

### DIFF
--- a/src/aind_data_schema/ephys/ephys_rig.py
+++ b/src/aind_data_schema/ephys/ephys_rig.py
@@ -144,7 +144,7 @@ class EphysRig(AindCoreModel):
     notes: Optional[str] = Field(None, title="Notes")
 
     @root_validator
-    def validate_device_names(cls, values): # noqa: C901
+    def validate_device_names(cls, values):  # noqa: C901
         """validate that all DAQ channels are connected to devices that
         actually exist
         """

--- a/src/aind_data_schema/ephys/ephys_rig.py
+++ b/src/aind_data_schema/ephys/ephys_rig.py
@@ -144,7 +144,7 @@ class EphysRig(AindCoreModel):
     notes: Optional[str] = Field(None, title="Notes")
 
     @root_validator
-    def validate_device_names(cls, values):
+    def validate_device_names(cls, values): # noqa: C901
         """validate that all DAQ channels are connected to devices that
         actually exist
         """

--- a/src/aind_data_schema/ephys/ephys_rig.py
+++ b/src/aind_data_schema/ephys/ephys_rig.py
@@ -163,6 +163,9 @@ class EphysRig(AindCoreModel):
         if cameras is not None:
             device_names += [c.camera.name for c in cameras]
 
+        if daqs is not None:
+            device_names += [daq.name for daq in daqs]
+
         if ephys_assemblies is not None:
             device_names += [probe.name for ephys_assembly in ephys_assemblies for probe in ephys_assembly.probes]
 


### PR DESCRIPTION
The validator for the `EphysRig` class checks whether all devices connected to `DAQDevice` objects exist in the schema. But it did not previously allow connections *between* `DAQDevice` objects. This change fixes that.

Fixes #458 