### PR TITLE
feat-435 validator for coordinate depth list length and injection volumes

### DIFF
--- a/examples/processing.py
+++ b/examples/processing.py
@@ -60,7 +60,7 @@ p = Processing(
             code_version="0.1",
             code_url="https://github.com/abcd",
             parameters={"size": 7},
-            ),
+        ),
         AnalysisProcess(
             analyst_full_name="Some Analyzer",
             description="some description",

--- a/src/aind_data_schema/device.py
+++ b/src/aind_data_schema/device.py
@@ -8,8 +8,8 @@ from typing import Any, Dict, List, Optional
 from pydantic import Field
 
 from aind_data_schema.base import AindModel, EnumSubset
-from aind_data_schema.manufacturers import Manufacturer
 from aind_data_schema.coordinates import RelativePosition
+from aind_data_schema.manufacturers import Manufacturer
 from aind_data_schema.procedures import Reagent
 from aind_data_schema.utils.units import FrequencyUnit, PowerUnit, SizeUnit
 

--- a/src/aind_data_schema/manufacturers.py
+++ b/src/aind_data_schema/manufacturers.py
@@ -1,6 +1,7 @@
 """Enum of Manufacturers for use in the AIND data schema."""
 
 from enum import Enum
+
 from aind_data_schema.base import BaseNameEnumMeta, PIDName, Registry
 
 
@@ -69,7 +70,7 @@ class Manufacturer(Enum, metaclass=BaseNameEnumMeta):
         name="Meadowlark Optics",
         registry=Registry.ROR,
         registry_identifier="00n8qbq54",
-        )
+    )
     MIGHTY_ZAP = PIDName(name="IR Robot Co")
     MKS_NEWPORT = PIDName(
         name="MKS Newport",

--- a/src/aind_data_schema/procedures.py
+++ b/src/aind_data_schema/procedures.py
@@ -399,14 +399,14 @@ class NanojectInjection(BrainInjection):
 
     @root_validator
     def check_dv_and_vol_list_lengths(cls, v):
-        injection_vol_len = len(v.get('injection_volume'))
-        coords_len = len(v.get('injection_coordinate_depth'))
+        """Validator for list length of injection volumes and depths"""
+
+        injection_vol_len = len(v.get("injection_volume"))
+        coords_len = len(v.get("injection_coordinate_depth"))
 
         if injection_vol_len != coords_len:
             raise ValueError("Unmatched list sizes for injection volumes and coordinate depths")
         return v
-
-
 
 
 class IontophoresisInjection(BrainInjection):

--- a/src/aind_data_schema/procedures.py
+++ b/src/aind_data_schema/procedures.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 from enum import Enum
 from typing import List, Optional, Union
 
-from pydantic import Field
+from pydantic import Field, root_validator
 
 from aind_data_schema.base import AindCoreModel, AindModel, PIDName
 from aind_data_schema.subject import Species
@@ -396,6 +396,17 @@ class NanojectInjection(BrainInjection):
         description="Injection volume, one value per location",
     )
     injection_volume_unit: VolumeUnit = Field(VolumeUnit.NL, title="Injection volume unit")
+
+    @root_validator
+    def check_dv_and_vol_list_lengths(cls, v):
+        injection_vol_len = len(v.get('injection_volume'))
+        coords_len = len(v.get('injection_coordinate_depth'))
+
+        if injection_vol_len != coords_len:
+            raise ValueError("Unmatched list sizes for injection volumes and coordinate depths")
+        return v
+
+
 
 
 class IontophoresisInjection(BrainInjection):

--- a/src/aind_data_schema/rig.py
+++ b/src/aind_data_schema/rig.py
@@ -47,8 +47,10 @@ class Rig(AindCoreModel):
     modalities: List[Modality] = Field(..., title="Modalities", unique_items=True)
     mouse_platform: Union[Disc, Treadmill, Tube, Wheel] = Field(..., title="Mouse platform")
     stimulus_devices: Optional[List[Union[Monitor, Olfactometer, RewardDelivery, Speaker]]] = Field(
-        None, title="Stimulus devices", unique_items=True,
-        )
+        None,
+        title="Stimulus devices",
+        unique_items=True,
+    )
     cameras: Optional[List[CameraAssembly]] = Field(None, title="Camera assemblies", unique_items=True)
     daqs: Optional[List[Union[HarpDevice, NeuropixelsBasestation, OpenEphysAcquisitionBoard, DAQDevice]]] = Field(
         None, title="Data acquisition devices"
@@ -59,7 +61,7 @@ class Rig(AindCoreModel):
     patch_cords: Optional[List[Patch]] = Field(None, title="Patch cords", unique_items=True)
     light_sources: Optional[List[Union[Laser, LightEmittingDiode]]] = Field(
         None, title="Light sources", unique_items=True
-        )
+    )
     detectors: Optional[List[Detector]] = Field(None, title="Detectors", unique_items=True)
     objectives: Optional[List[Objective]] = Field(None, title="Objectives", unique_items=True)
     filters: Optional[List[Filter]] = Field(None, title="Filters", unique_items=True)
@@ -67,7 +69,8 @@ class Rig(AindCoreModel):
     additional_devices: Optional[List[Device]] = Field(None, title="Additional devices", unique_items=True)
     calibrations: List[Calibration] = Field(..., title="Full calibration of devices", unique_items=True)
     ccf_coordinate_transform: Optional[str] = Field(
-        None, title="CCF coordinate transform",
+        None,
+        title="CCF coordinate transform",
         description="Path to file that details the CCF-to-lab coordinate transform",
     )
     notes: Optional[str] = Field(None, title="Notes")

--- a/src/aind_data_schema/session.py
+++ b/src/aind_data_schema/session.py
@@ -10,11 +10,11 @@ from typing import List, Optional, Union
 from pydantic import Field
 
 from aind_data_schema.base import AindCoreModel, AindModel
+from aind_data_schema.coordinates import CcfCoords, Coordinates3d
 from aind_data_schema.data_description import Modality
 from aind_data_schema.device import Calibration, Maintenance, RelativePosition, SpoutSide
-from aind_data_schema.coordinates import CcfCoords, Coordinates3d
-from aind_data_schema.stimulus import StimulusEpoch
 from aind_data_schema.imaging.tile import Channel
+from aind_data_schema.stimulus import StimulusEpoch
 from aind_data_schema.utils.units import AngleUnit, FrequencyUnit, MassUnit, PowerUnit, SizeUnit, TimeUnit
 
 
@@ -193,10 +193,8 @@ class RewardSpout(AindModel):
     side: SpoutSide = Field(..., title="Spout side", description="Must match rig")
     starting_position: RelativePosition = Field(..., title="Starting position")
     variable_position: bool = Field(
-        ...,
-        title="Variable position",
-        description="True if spout position changes during session as tracked in data"
-        )
+        ..., title="Variable position", description="True if spout position changes during session as tracked in data"
+    )
 
 
 class RewardDelivery(AindModel):
@@ -217,7 +215,7 @@ class Stream(AindModel):
     camera_names: Optional[List[str]] = Field(None, title="Cameras", unique_items=True)
     light_sources: Optional[List[Union[Laser, LightEmittingDiode]]] = Field(
         None, title="Light source", unique_items=True
-        )
+    )
     ephys_modules: Optional[List[EphysModule]] = Field(None, title="Ephys modules", unique_items=True)
     detectors: Optional[List[Detector]] = Field(None, title="Detectors", unique_items=True)
     fiber_photometry_assemblies: Optional[List[FiberPhotometryAssembly]] = Field(None, title="Fiber photometry devices")

--- a/tests/test_procedures.py
+++ b/tests/test_procedures.py
@@ -122,7 +122,7 @@ class ProceduresTests(unittest.TestCase):
 
     def test_coordinate_volume_validator(self):
         """Test validator for list lengths on NanojectInjection"""
-        
+
         with self.assertRaises(ValidationError):
             NanojectInjection(injection_coordinate_depth=[0.1], injection_volume=[1, 2])
 

--- a/tests/test_procedures.py
+++ b/tests/test_procedures.py
@@ -120,6 +120,13 @@ class ProceduresTests(unittest.TestCase):
 
         self.assertEqual(3, len(p.subject_procedures))
 
+    def test_coordinate_volume_validator(self):
+        with self.assertRaises(ValidationError):
+            NanojectInjection(
+                injection_coordinate_depth=[.1],
+                injection_volume=[1, 2]
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_procedures.py
+++ b/tests/test_procedures.py
@@ -121,11 +121,10 @@ class ProceduresTests(unittest.TestCase):
         self.assertEqual(3, len(p.subject_procedures))
 
     def test_coordinate_volume_validator(self):
+        """Test validator for list lengths on NanojectInjection"""
+        
         with self.assertRaises(ValidationError):
-            NanojectInjection(
-                injection_coordinate_depth=[.1],
-                injection_volume=[1, 2]
-            )
+            NanojectInjection(injection_coordinate_depth=[0.1], injection_volume=[1, 2])
 
 
 if __name__ == "__main__":

--- a/tests/test_rig.py
+++ b/tests/test_rig.py
@@ -18,7 +18,7 @@ from aind_data_schema.device import (
     LaserAssembly,
     Lens,
     Manipulator,
-    NeuropixelsBasestation
+    NeuropixelsBasestation,
 )
 from aind_data_schema.manufacturers import Manufacturer
 from aind_data_schema.rig import Rig

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -5,8 +5,8 @@ import unittest
 
 import pydantic
 
-from aind_data_schema.data_description import Modality
 from aind_data_schema.coordinates import CcfCoords, Coordinates3d
+from aind_data_schema.data_description import Modality
 from aind_data_schema.session import EphysModule, EphysProbe, Session, Stream
 
 


### PR DESCRIPTION
closes #435 

Now checks to ensure that lists are of equal length when constructing a Nanoject Injection

If this validator should apply to any other classes as well, please let me know