### PR TITLE
fix: adds Rig and Session to list of core models

### DIFF
--- a/src/aind_data_schema/__init__.py
+++ b/src/aind_data_schema/__init__.py
@@ -16,6 +16,8 @@ from .ophys.ophys_rig import OphysRig
 from .ophys.ophys_session import OphysSession
 from .procedures import Procedures
 from .processing import DataProcess, Processing
+from .rig import Rig
+from .session import Session
 from .subject import LightCycle, Subject
 
 __all__ = [
@@ -40,4 +42,6 @@ __all__ = [
     "OphysSession",
     "OphysRig",
     "MriSession",
+    "Rig",
+    "Session",
 ]


### PR DESCRIPTION
Closes #521 

- Currently, the core models need to be added to a list in the init file to be picked up downstream
- There's probably a better way to do this in the future, but might require re-organizing the module structure of the project