### PR TITLE
Fix 533: correct `DataDescriptionUpgrade` to work with recent schema versions

### DIFF
--- a/src/aind_data_schema/schema_upgrade/data_description_upgrade.py
+++ b/src/aind_data_schema/schema_upgrade/data_description_upgrade.py
@@ -144,8 +144,8 @@ class DataDescriptionUpgrade:
             platform = self._get_or_default(self.old_data_description_model, "platform", kwargs)
 
         creation_date = self._get_or_default(self.old_data_description_model, "creation_date", kwargs)
+        creation_time = self._get_or_default(self.old_data_description_model, "creation_time", kwargs)
         if creation_date is not None:
-            creation_time = self._get_or_default(self.old_data_description_model, "creation_time", kwargs)
             creation_date = datetime.strptime(creation_date, "%Y-%m-%d").date()
             creation_time = datetime.strptime(creation_time, "%H:%M:%S").time()
             creation_time = datetime.combine(creation_date, creation_time)

--- a/tests/resources/ephys_data_description/data_description_0.10.0.json
+++ b/tests/resources/ephys_data_description/data_description_0.10.0.json
@@ -1,0 +1,49 @@
+{
+   "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/data_description.py",
+   "schema_version": "0.10.0",
+   "license": "CC-BY-4.0",
+   "creation_time": "2023-10-18T16:00:06",
+   "name": "ecephys_691897_2023-10-18_16-00-06",
+   "institution": {
+      "name": "Allen Institute for Neural Dynamics",
+      "abbreviation": "AIND",
+      "registry": {
+         "name": "Research Organization Registry",
+         "abbreviation": "ROR"
+      },
+      "registry_identifier": "04szwah67"
+   },
+   "funding_source": [
+      {
+         "funder": {
+            "name": "Allen Institute for Neural Dynamics",
+            "abbreviation": "AIND",
+            "registry": {
+               "name": "Research Organization Registry",
+               "abbreviation": "ROR"
+            },
+            "registry_identifier": "04szwah67"
+         },
+         "grant_number": null,
+         "fundee": null
+      }
+   ],
+   "data_level": "raw",
+   "group": null,
+   "investigators": [],
+   "platform": {
+      "name": "Electrophysiology platform",
+      "abbreviation": "ecephys"
+   },
+   "project_name": null,
+   "restrictions": null,
+   "modality": [
+      {
+         "name": "Extracellular electrophysiology",
+         "abbreviation": "ecephys"
+      }
+   ],
+   "subject_id": "691897",
+   "related_data": [],
+   "data_summary": null
+}

--- a/tests/test_schema_upgrade.py
+++ b/tests/test_schema_upgrade.py
@@ -216,6 +216,28 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
             new_data_description.data_summary,
         )
 
+    def test_upgrades_0_10_0(self):
+        """Tests data_description_0.6.0.json is mapped correctly."""
+        data_description_0_10_0 = self.data_descriptions["data_description_0.10.0.json"]
+        upgrader = DataDescriptionUpgrade(old_data_description_model=data_description_0_10_0)
+
+        # Should work by setting experiment type explicitly
+        new_data_description = upgrader.upgrade_data_description()
+        self.assertEqual(datetime.datetime(2023, 10, 18, 16, 00, 6), new_data_description.creation_time)
+        self.assertEqual("ecephys_691897_2023-10-18_16-00-06", new_data_description.name)
+        self.assertEqual(Institution.AIND, new_data_description.institution)
+        self.assertEqual([Funding(funder=Institution.AIND)], new_data_description.funding_source)
+        self.assertEqual(DataLevel.RAW, new_data_description.data_level)
+        self.assertIsNone(new_data_description.group)
+        self.assertEqual([], new_data_description.investigators)
+        self.assertIsNone(new_data_description.project_name)
+        self.assertIsNone(new_data_description.restrictions)
+        self.assertEqual([Modality.ECEPHYS], new_data_description.modality)
+        self.assertEqual("691897", new_data_description.subject_id)
+        self.assertEqual([], new_data_description.related_data)
+        self.assertEqual(Platform.ECEPHYS, new_data_description.platform)
+        self.assertIsNone(new_data_description.data_summary)
+
     # def test_edge_cases(self):
     #     """Tests a few edge cases"""
     #     data_description_0_6_2 = deepcopy(self.data_descriptions["data_description_0.6.2.json"])


### PR DESCRIPTION
Fixes #533