### PR TITLE
feat: adds default file ext

### DIFF
--- a/src/aind_data_schema/base.py
+++ b/src/aind_data_schema/base.py
@@ -85,6 +85,8 @@ class PIDName(BaseName):
 class AindCoreModel(AindModel):
     """Generic base class to hold common fields/validators/etc for all basic AIND schema"""
 
+    _DEFAULT_FILE_EXTENSION = ".json"
+
     describedBy: str
     schema_version: str = Field(..., regex=r"^\d+.\d+.\d+$")
 
@@ -127,7 +129,7 @@ class AindCoreModel(AindModel):
         Returns standard filename in snakecase
         """
         name = cls._get_direct_subclass(cls).__name__
-        return re.sub(r"(?<!^)(?=[A-Z])", "_", name).lower() + ".json"
+        return re.sub(r"(?<!^)(?=[A-Z])", "_", name).lower() + cls._DEFAULT_FILE_EXTENSION
 
     def write_standard_file(self, output_directory: Optional[Path] = None, prefix=None, suffix=None):
         """
@@ -147,7 +149,7 @@ class AindCoreModel(AindModel):
             filename = str(prefix) + "_" + self.default_filename()
 
         if suffix:
-            filename = filename.replace(".json", suffix)
+            filename = filename.replace(self._DEFAULT_FILE_EXTENSION, suffix)
 
         if output_directory is not None:
             output_directory = Path(output_directory)
@@ -155,6 +157,11 @@ class AindCoreModel(AindModel):
 
         with open(filename, "w") as f:
             f.write(self.json(indent=3, by_alias=True))
+
+    @classmethod
+    def default_file_extension(cls) -> str:
+        """Public method to retrieve protected _DEFAULT_FILE_EXTENSION"""
+        return cls._DEFAULT_FILE_EXTENSION
 
 
 class _TypeEnumSubset(object):

--- a/src/aind_data_schema/metadata.py
+++ b/src/aind_data_schema/metadata.py
@@ -112,7 +112,7 @@ class Metadata(AindCoreModel):
         "instrument",
         pre=True,
     )
-    def validate_core_fields(cls, value, values, field):
+    def validate_core_fields(cls, value, field):
         """Don't automatically raise errors if the core models are invalid"""
         if isinstance(value, dict):
             core_model = field.type_.construct(**value)

--- a/src/aind_data_schema/metadata.py
+++ b/src/aind_data_schema/metadata.py
@@ -37,6 +37,11 @@ class Metadata(AindCoreModel):
     """The records in the Data Asset Collection needs to contain certain fields
     to easily query and index the data."""
 
+    # Special file name extension to distinguish this json file from others
+    # The models base on this schema will be saved to metadata.nd.json as
+    # default
+    _DEFAULT_FILE_EXTENSION = ".nd.json"
+
     schema_version: str = Field("0.0.6", description="schema version", title="Version", const=True)
 
     id: UUID = Field(

--- a/src/aind_data_schema/utils/json_writer.py
+++ b/src/aind_data_schema/utils/json_writer.py
@@ -63,7 +63,8 @@ class SchemaWriter:
         output_path = self.configs.output
         for schema in schemas_to_write:
             filename = schema.default_filename()
-            schema_filename = filename.replace(".json", "_schema.json")
+            file_extension = schema.default_file_extension()
+            schema_filename = filename.replace(file_extension, "_schema.json")
             if self.configs.attach_version:
                 schema_version = schema.construct().schema_version
                 model_directory_name = schema_filename.replace("_schema.json", "")

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -60,6 +60,8 @@ class BaseTests(unittest.TestCase):
 
         mock_open.assert_called_once_with(default_filename, "w")
         mock_open.return_value.__enter__().write.assert_called_once_with(json_contents)
+        # The default file extension is expected to be ".json"
+        self.assertEqual("procedures.json", default_filename)
 
     @patch("builtins.open", new_callable=unittest.mock.mock_open())
     def test_write_standard_file_with_prefix(self, mock_open):

--- a/tests/test_json_writer.py
+++ b/tests/test_json_writer.py
@@ -20,7 +20,8 @@ class SchemaWriterTests(unittest.TestCase):
 
         for schema in schema_gen:
             filename = schema.default_filename()
-            schema_filename = filename.replace(".json", "_schema.json")
+            file_extension = schema.default_file_extension()
+            schema_filename = filename.replace(file_extension, "_schema.json")
             schema_contents = schema.schema_json(indent=3)
             self.assertIsNotNone(schema_filename)
             self.assertIsNotNone(schema_contents)
@@ -53,7 +54,8 @@ class SchemaWriterTests(unittest.TestCase):
         write_calls = []
         for schema in schema_gen:
             filename = schema.default_filename()
-            schema_filename = filename.replace(".json", "_schema.json")
+            file_extension = schema.default_file_extension()
+            schema_filename = filename.replace(file_extension, "_schema.json")
             path = Path("some_test_dir") / schema_filename
             schema_contents = schema.schema_json(indent=3)
             open_calls.append(call(path, "w"))
@@ -82,7 +84,8 @@ class SchemaWriterTests(unittest.TestCase):
         mkdir_calls = []
         for schema in schema_gen:
             filename = schema.default_filename()
-            schema_filename = filename.replace(".json", "_schema.json")
+            file_extension = schema.default_file_extension()
+            schema_filename = filename.replace(file_extension, "_schema.json")
             model_directory_name = schema_filename.replace("_schema.json", "")
             path = Path("some_test_dir") / model_directory_name / schema.construct().schema_version / schema_filename
             schema_contents = schema.schema_json(indent=3)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -96,6 +96,10 @@ class TestMetadata(unittest.TestCase):
         )
         self.assertEqual(MetadataStatus.INVALID, d3.metadata_status)
 
+    def test_default_file_extension(self):
+        """Tests that the default file extension used is as expected."""
+        self.assertEqual(".nd.json", Metadata.default_file_extension())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,7 +14,8 @@ class UtilsTests(unittest.TestCase):
 
         for schema in schema_gen:
             filename = schema.default_filename()
-            schema_filename = filename.replace(".json", "_schema.json")
+            file_extension = schema.default_file_extension()
+            schema_filename = filename.replace(file_extension, "_schema.json")
             schema_contents = schema.schema_json(indent=3)
             self.assertIsNotNone(schema_filename)
             self.assertIsNotNone(schema_contents)


### PR DESCRIPTION
Closes #595 

- Tech debt to make the default file extension (.json) a constant instead of hard-coded strings
- Makes the default file extension for Metadata model ".nd.json"