### PR TITLE
Feat 628 improve datadesc upgrader

### DIFF
--- a/src/aind_data_schema/data_description.py
+++ b/src/aind_data_schema/data_description.py
@@ -314,13 +314,23 @@ class DataDescription(AindCoreModel):
     @validator("data_level", pre=True, always=True)
     def upgrade_data_level(cls, value: Union[str, DataLevel]):
         """Updates legacy values to current values"""
-        # If user inputs a string and is 'raw level', convert it to RAW
-        if isinstance(value, str) and value in ["raw level", "raw data"]:
-            return DataLevel.RAW
-        # If user inputs a string, try to convert it to a DataLevel. Will raise
-        # an error if unable to parse the input string
-        elif isinstance(value, str):
-            return DataLevel(value)
+
+        lookup_table = {
+            "derived data": DataLevel.DERIVED.value,
+            "derived level": DataLevel.DERIVED.value,
+            "derived": DataLevel.DERIVED.value,
+            "processed data": DataLevel.DERIVED.value,
+            "processed": DataLevel.DERIVED.value,
+            "raw data": DataLevel.RAW.value,
+            "raw level": DataLevel.RAW.value,
+            "raw": DataLevel.RAW.value,
+        }
+
+        if isinstance(value, str):
+            if value.lower() in lookup_table.keys():
+                return lookup_table[value.lower()]
+            else:
+                raise ValueError(f"'{value}' is not a valid DataLevel")
         # If user inputs a DataLevel object, return the object without parsing
         elif isinstance(value, DataLevel):
             return value

--- a/src/aind_data_schema/schema_upgrade/data_description_upgrade.py
+++ b/src/aind_data_schema/schema_upgrade/data_description_upgrade.py
@@ -12,24 +12,22 @@ def map_modality(modality):
     """converts modality string to an enumerated value"""
 
     lookup_table = {
-        "exaspim": Modality.SPIM.value.name,
-        "smartspim": Modality.SPIM.value.name,
-        "ecephys": Modality.ECEPHYS.value.name,
-        "mri-14t": Modality.MRI.value.name,
-        "mri-7t": Modality.MRI.value.name,
-        "test-fip-opto": Modality.FIB.value.name,
-        "hsfp": Modality.FIB.value.name,
-        "fip": Modality.FIB.value.name,
-        "merfish": Modality.FISH.value.name,
-        "dispim": Modality.SPIM.value.name,
-        "mesospim": Modality.MESOSPIM.value.name,
-        'exaspim': Modality.SPIM.value.name,
-        'single-plane-ophys': Modality.OPHYS.value.name,
-        'multiplane-ophys': Modality.OPHYS.value.name,
+        "exaspim": Modality.SPIM.value,
+        "smartspim": Modality.SPIM.value,
+        "ecephys": Modality.ECEPHYS.value,
+        "mri-14t": Modality.MRI.value,
+        "mri-7t": Modality.MRI.value,
+        "test-fip-opto": Modality.FIB.value,
+        "hsfp": Modality.FIB.value,
+        "fip": Modality.FIB.value,
+        "merfish": Modality.MERFISH.value,
+        "dispim": Modality.SPIM.value,
+        "mesospim": Modality.SPIM.value,
+        'single-plane-ophys': Modality.POPHYS.value,
+        'multiplane-ophys': Modality.POPHYS.value,
     }
 
     return lookup_table[modality.lower()]
-
 
 
 class ModalityUpgrade:
@@ -53,7 +51,7 @@ class ModalityUpgrade:
         if type(old_modality) is str or type(old_modality) is dict:
             try:
                 return Modality(old_modality)
-            except:
+            except AttributeError:
                 return Modality(map_modality(old_modality))
         elif type(old_modality) is Modality:
             return old_modality
@@ -125,8 +123,6 @@ class DataDescriptionUpgrade(BaseModelUpgrade):
         if funding_source is not None:
             if type(funding_source) is list:
                 funding_source = [FundingUpgrade.upgrade_funding(funding) for funding in funding_source]
-            else:
-                funding_source = FundingUpgrade.upgrade_funding(funding_source)
         else:
             funding_source = []
             
@@ -140,6 +136,7 @@ class DataDescriptionUpgrade(BaseModelUpgrade):
         else:
             modality = getattr(DataDescription.__fields__.get("modality"), "default")
         old_data_level = self._get_or_default(self.old_model, "data_level", kwargs)
+        
 
         experiment_type = self._get_or_default(self.old_model, "experiment_type", kwargs)
         platform = None

--- a/src/aind_data_schema/schema_upgrade/data_description_upgrade.py
+++ b/src/aind_data_schema/schema_upgrade/data_description_upgrade.py
@@ -94,7 +94,13 @@ class DataDescriptionUpgrade(BaseModelUpgrade):
             self._get_or_default(self.old_model, "institution", kwargs)
         )
         funding_source = self._get_or_default(self.old_model, "funding_source", kwargs)
-        funding_source = [FundingUpgrade.upgrade_funding(funding) for funding in funding_source]
+        if funding_source is not None:
+            if type(funding_source) is list:
+                funding_source = [FundingUpgrade.upgrade_funding(funding) for funding in funding_source]
+            else:
+                funding_source = FundingUpgrade.upgrade_funding(funding_source)
+        else:
+            funding_source = []
         old_modality: Any = self.old_model.modality
         if kwargs.get("modality") is not None:
             modality = kwargs["modality"]

--- a/src/aind_data_schema/schema_upgrade/data_description_upgrade.py
+++ b/src/aind_data_schema/schema_upgrade/data_description_upgrade.py
@@ -8,6 +8,30 @@ from aind_data_schema.data_description import DataDescription, Funding, Institut
 from aind_data_schema.schema_upgrade.base_upgrade import BaseModelUpgrade
 
 
+def map_modality(modality):
+    """converts modality string to an enumerated value"""
+
+    lookup_table = {
+        "exaspim": Modality.SPIM.value.name,
+        "smartspim": Modality.SPIM.value.name,
+        "ecephys": Modality.ECEPHYS.value.name,
+        "mri-14t": Modality.MRI.value.name,
+        "mri-7t": Modality.MRI.value.name,
+        "test-fip-opto": Modality.FIB.value.name,
+        "hsfp": Modality.FIB.value.name,
+        "fip": Modality.FIB.value.name,
+        "merfish": Modality.FISH.value.name,
+        "dispim": Modality.SPIM.value.name,
+        "mesospim": Modality.MESOSPIM.value.name,
+        'exaspim': Modality.SPIM.value.name,
+        'single-plane-ophys': Modality.OPHYS.value.name,
+        'multiplane-ophys': Modality.OPHYS.value.name,
+    }
+
+    return lookup_table[modality.lower()]
+
+
+
 class ModalityUpgrade:
     """Handle upgrades for Modality models."""
 
@@ -27,7 +51,10 @@ class ModalityUpgrade:
 
         """
         if type(old_modality) is str or type(old_modality) is dict:
-            return Modality(old_modality)
+            try:
+                return Modality(old_modality)
+            except:
+                return Modality(map_modality(old_modality))
         elif type(old_modality) is Modality:
             return old_modality
         else:

--- a/src/aind_data_schema/schema_upgrade/data_description_upgrade.py
+++ b/src/aind_data_schema/schema_upgrade/data_description_upgrade.py
@@ -85,7 +85,7 @@ class FundingUpgrade:
             return Funding.parse_obj(old_funding)
         else:
             return None
-    
+
     @staticmethod
     def upgrade_funding_source(funding_source):
         """Get funding source from old model"""
@@ -124,8 +124,9 @@ class DataDescriptionUpgrade(BaseModelUpgrade):
         """
         super().__init__(old_data_description_model, model_class=DataDescription)
 
-    
     def get_modality(self, **kwargs):
+        """Get modality from old model"""
+
         old_modality: Any = self.old_model.modality
         if kwargs.get("modality") is not None:
             modality = kwargs["modality"]
@@ -137,8 +138,10 @@ class DataDescriptionUpgrade(BaseModelUpgrade):
             modality = getattr(DataDescription.__fields__.get("modality"), "default")
 
         return modality
-    
+
     def get_creation_time(self, **kwargs):
+        """Get creation time from old model"""
+
         creation_date = self._get_or_default(self.old_model, "creation_date", kwargs)
         creation_time = self._get_or_default(self.old_model, "creation_time", kwargs)
         if creation_date is not None:
@@ -147,7 +150,6 @@ class DataDescriptionUpgrade(BaseModelUpgrade):
             creation_time = datetime.combine(creation_date, creation_time)
 
         return creation_time
-
 
     def upgrade(self, **kwargs) -> AindModel:
         """Upgrades the old model into the current version"""

--- a/src/aind_data_schema/schema_upgrade/data_description_upgrade.py
+++ b/src/aind_data_schema/schema_upgrade/data_description_upgrade.py
@@ -121,6 +121,7 @@ class DataDescriptionUpgrade(BaseModelUpgrade):
             self._get_or_default(self.old_model, "institution", kwargs)
         )
         funding_source = self._get_or_default(self.old_model, "funding_source", kwargs)
+        
         if funding_source is not None:
             if type(funding_source) is list:
                 funding_source = [FundingUpgrade.upgrade_funding(funding) for funding in funding_source]
@@ -128,6 +129,7 @@ class DataDescriptionUpgrade(BaseModelUpgrade):
                 funding_source = FundingUpgrade.upgrade_funding(funding_source)
         else:
             funding_source = []
+            
         old_modality: Any = self.old_model.modality
         if kwargs.get("modality") is not None:
             modality = kwargs["modality"]

--- a/tests/test_imaging.py
+++ b/tests/test_imaging.py
@@ -7,13 +7,13 @@ from pydantic import ValidationError
 
 from aind_data_schema.device import Calibration, DAQChannel, DAQDevice
 from aind_data_schema.imaging import acquisition as acq
+from aind_data_schema.imaging import instrument
 from aind_data_schema.imaging import instrument as inst
 from aind_data_schema.imaging import mri_session as ms
 from aind_data_schema.imaging import tile
 from aind_data_schema.manufacturers import Manufacturer
 from aind_data_schema.processing import Registration
 from aind_data_schema.utils.units import PowerValue
-from aind_data_schema.imaging import instrument
 
 
 class ImagingTests(unittest.TestCase):

--- a/tests/test_schema_upgrade.py
+++ b/tests/test_schema_upgrade.py
@@ -332,23 +332,24 @@ class TestModalityUpgrade(unittest.TestCase):
     def test_modality_lookup(self):
         """Tests old modality lookup case"""
         dd_dict = {
-            'describedBy': 'https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/data_description.py', 
-            'schema_version': '0.3.0',
-            'license': 'CC-BY-4.0',
-            'creation_time': '16:01:12',
-            'creation_date': '2022-11-01',
-            'name': 'SmartSPIM_623711_2022-10-27_16-48-54_stitched_2022-11-01_16-01-12',
-            'institution': 'AIND',
-            'funding_source': None,
-            'data_level': 'derived data',
-            'group': None,
-            'project_name': None,
-            'project_id': None,
-            'restrictions': None,
-            'modality': 'SmartSPIM',
-            'platform': Platform('SMARTSPIM'),
-            'subject_id': '623711',
-            'input_data_name': 'SmartSPIM_623711_2022-10-27_16-48-54'
+            "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema"
+            "/main/src/aind_data_schema/data_description.py",
+            "schema_version": "0.3.0",
+            "license": "CC-BY-4.0",
+            "creation_time": "16:01:12",
+            "creation_date": "2022-11-01",
+            "name": "SmartSPIM_623711_2022-10-27_16-48-54_stitched_2022-11-01_16-01-12",
+            "institution": "AIND",
+            "funding_source": None,
+            "data_level": "derived data",
+            "group": None,
+            "project_name": None,
+            "project_id": None,
+            "restrictions": None,
+            "modality": "SmartSPIM",
+            "platform": Platform.SMARTSPIM,
+            "subject_id": "623711",
+            "input_data_name": "SmartSPIM_623711_2022-10-27_16-48-54",
         }
         dd = DataDescription.construct(**dd_dict)
         upgrader = DataDescriptionUpgrade(old_data_description_model=dd)

--- a/tests/test_schema_upgrade.py
+++ b/tests/test_schema_upgrade.py
@@ -320,6 +320,13 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
     #     new_dd_0_6_2 = upgrader.upgrade(modality=[Modality.ECEPHYS])
     #     self.assertEqual([Modality.ECEPHYS], new_dd_0_6_2.modality)
 
+    def test_missing_funding(self):
+        desc = {'project_name': None, 'modality': [{'name': 'Extracellular electrophysiology', 'abbreviation': 'ecephys'}]}
+
+        data_desc = DataDescription.construct(**desc)
+        upgrader = DataDescriptionUpgrade(old_data_description_model=data_desc)
+        upgrader.upgrade()
+
 
 class TestModalityUpgrade(unittest.TestCase):
     """Tests ModalityUpgrade methods"""

--- a/tests/test_schema_upgrade.py
+++ b/tests/test_schema_upgrade.py
@@ -320,13 +320,6 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
     #     new_dd_0_6_2 = upgrader.upgrade(modality=[Modality.ECEPHYS])
     #     self.assertEqual([Modality.ECEPHYS], new_dd_0_6_2.modality)
 
-    def test_missing_funding(self):
-        desc = {'project_name': None, 'modality': [{'name': 'Extracellular electrophysiology', 'abbreviation': 'ecephys'}]}
-
-        data_desc = DataDescription.construct(**desc)
-        upgrader = DataDescriptionUpgrade(old_data_description_model=data_desc)
-        upgrader.upgrade()
-
 
 class TestModalityUpgrade(unittest.TestCase):
     """Tests ModalityUpgrade methods"""
@@ -335,6 +328,31 @@ class TestModalityUpgrade(unittest.TestCase):
         """Tests edge case"""
         self.assertIsNone(ModalityUpgrade.upgrade_modality(None))
         self.assertEqual(Modality.ECEPHYS, ModalityUpgrade.upgrade_modality(Modality.ECEPHYS))
+
+    def test_modality_lookup(self):
+        """Tests old modality lookup case"""
+        dd_dict = {
+            'describedBy': 'https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/data_description.py', 
+            'schema_version': '0.3.0',
+            'license': 'CC-BY-4.0',
+            'creation_time': '16:01:12',
+            'creation_date': '2022-11-01',
+            'name': 'SmartSPIM_623711_2022-10-27_16-48-54_stitched_2022-11-01_16-01-12',
+            'institution': 'AIND',
+            'funding_source': None,
+            'data_level': 'derived data',
+            'group': None,
+            'project_name': None,
+            'project_id': None,
+            'restrictions': None,
+            'modality': 'SmartSPIM',
+            'platform': Platform('SMARTSPIM'),
+            'subject_id': '623711',
+            'input_data_name': 'SmartSPIM_623711_2022-10-27_16-48-54'
+        }
+        dd = DataDescription.construct(**dd_dict)
+        upgrader = DataDescriptionUpgrade(old_data_description_model=dd)
+        upgrader.upgrade()
 
 
 class TestFundingUpgrade(unittest.TestCase):


### PR DESCRIPTION
closes #628 

Updates to `DataDescriptionUpgrader`, `DataDescription`, and `ModalityUpgrader`.

`map_modality` function added to `data_description_upgrade.py` to convert outdated modalities to modern ones.

similar lookup added to `DataDescription` for `DataLevel` validation.

Error handling for funding if funding does not exist.