### PR TITLE
Add method to export model as a json-schema

### DIFF
--- a/src/aind_data_schema/base.py
+++ b/src/aind_data_schema/base.py
@@ -1,6 +1,8 @@
 """ generic base class with supporting validators and fields for basic AIND schema """
 
 import re
+import json
+from os import PathLike
 from pathlib import Path
 from typing import Optional
 
@@ -11,6 +13,19 @@ class AindModel(BaseModel):
     """BaseModel that disallows extra fields"""
 
     model_config = ConfigDict(extra="forbid", use_enum_values=True)
+
+    @classmethod
+    def write_standard_model(cls, filename: Optional[PathLike] = None) -> None:
+        """
+        Compiles and writes a model to a json-schema
+        Parameters
+        ----------
+        filename:
+            optional PathLike object for the filename
+        """
+        filename = cls.__name__ + '.json' if filename is None else filename
+        with open(filename, "w") as f:
+            f.write(json.dumps(cls.model_json_schema(), indent=3))
 
 
 class AindCoreModel(AindModel):
@@ -34,7 +49,7 @@ class AindCoreModel(AindModel):
         name = cls.__name__
         return re.sub(r"(?<!^)(?=[A-Z])", "_", name).lower() + cls._FILE_EXTENSION.default
 
-    def write_standard_file(self, output_directory: Optional[Path] = None, prefix=None, suffix=None):
+    def write_standard_file(self, output_directory: Optional[PathLike] = None, prefix=None, suffix=None):
         """
         Writes schema to standard json file
         Parameters


### PR DESCRIPTION
This PR adds a method to the core `AindModel` class that exports the model as json-schema. 

Closes #652 