### PR TITLE
adding optional filename in base

### DIFF
--- a/src/aind_data_schema/base.py
+++ b/src/aind_data_schema/base.py
@@ -34,19 +34,35 @@ class AindCoreModel(AindModel):
         name = cls.__name__
         return re.sub(r"(?<!^)(?=[A-Z])", "_", name).lower() + cls._FILE_EXTENSION.default
 
-    def write_standard_file(self, output_directory: Optional[Path] = None, prefix=None, suffix=None):
+    def write_standard_file(
+        self,
+        output_directory: Optional[Path] = None,
+        filename: Optional[str] = None,
+        prefix: Optional[str] = None,
+        suffix: Optional[str] = None,
+    ):
         """
         Writes schema to standard json file
         Parameters
         ----------
-        output_directory:
-            optional Path object for output directory
-        prefix:
+        output_directory: Optional[Path]
+            optional Path object for output directory.
+            Default: None
+
+        filename: Optional[str]
+            Optional filename for intended json
+
+        prefix: Optional[str]
             optional str for intended filepath with extra naming convention
-        suffix:
+            Default: None
+
+        suffix: Optional[str]
             optional str for intended filepath with extra naming convention
+            Default: None
+
         """
-        filename = self.default_filename()
+        if filename is None:
+            filename = self.default_filename()
         if prefix:
             filename = str(prefix) + "_" + filename
         if suffix:


### PR DESCRIPTION
I am adding an optional filename parameter in the default_filename method that fixes #676. The repository uses the CamelCase convention for the names of the classes and the method [default_filename](https://github.com/AllenNeuralDynamics/aind-data-schema/blob/main/src/aind_data_schema/base.py#L30) uses this to build the json filename. I personally don't find this wrong but for the derived data description it's an exception of this rule. 

PD: I could have modified the regular expression but having an optional parameter gives us more freedom. Any thoughts? 