### PR TITLE
importing functional validators

### DIFF
--- a/src/aind_data_schema/core/data_description.py
+++ b/src/aind_data_schema/core/data_description.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, List, Literal, Optional, Union
 
-from pydantic import Field, 
+from pydantic import Field
 from pydantic.functional_validators import field_validator, model_validator
 
 from aind_data_schema.base import AindCoreModel, AindModel

--- a/src/aind_data_schema/core/data_description.py
+++ b/src/aind_data_schema/core/data_description.py
@@ -5,7 +5,8 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, List, Literal, Optional, Union
 
-from pydantic import Field, field_validator, model_validator
+from pydantic import Field, 
+from pydantic.functional_validators import field_validator, model_validator
 
 from aind_data_schema.base import AindCoreModel, AindModel
 from aind_data_schema.models.institutions import Institution


### PR DESCRIPTION
`field_validator` and `model_validators` were not importing properly, and needed to be pulled from a separate library. 

import statement has been updated.