### PR TITLE
remove stick microscopes as requirement

### DIFF
--- a/src/aind_data_schema/core/rig.py
+++ b/src/aind_data_schema/core/rig.py
@@ -129,7 +129,6 @@ class Rig(AindCoreModel):
         if Modality.ECEPHYS in value:
             for k, v in {
                 "ephys_assemblies": len(info.data["ephys_assemblies"]) > 0,
-                "stick_microscopes": len(info.data["stick_microscopes"]) > 0,
             }.items():
                 if v is False:
                     errors.append(f"{k} field must be utilized for Ecephys modality")


### PR DESCRIPTION
Addresses #672 by removing the requirement from `_validate_ephys_modality`.