### PR TITLE
Refactor Calibration model to allow `Any`

### DIFF
--- a/examples/aibs_smartspim_instrument.json
+++ b/examples/aibs_smartspim_instrument.json
@@ -1,6 +1,6 @@
 {
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/instrument.py",
-   "schema_version": "0.10.2",
+   "schema_version": "0.10.3",
    "instrument_id": "SmartSPIM2-2",
    "modification_date": "2023-10-04",
    "instrument_type": "SmartSPIM",

--- a/examples/bergamo_ophys_session.json
+++ b/examples/bergamo_ophys_session.json
@@ -1,6 +1,6 @@
 {
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/session.py",
-   "schema_version": "0.1.2",
+   "schema_version": "0.1.3",
    "experimenter_full_name": [
       "John Doe"
    ],

--- a/examples/ephys_rig.json
+++ b/examples/ephys_rig.json
@@ -1,6 +1,6 @@
 {
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/rig.py",
-   "schema_version": "0.2.3",
+   "schema_version": "0.2.4",
    "rig_id": "323_EPHYS1",
    "modification_date": "2023-10-03",
    "mouse_platform": {

--- a/examples/ephys_session.json
+++ b/examples/ephys_session.json
@@ -1,6 +1,6 @@
 {
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/session.py",
-   "schema_version": "0.1.2",
+   "schema_version": "0.1.3",
    "experimenter_full_name": [
       "Jane Doe"
    ],

--- a/examples/exaspim_acquisition.json
+++ b/examples/exaspim_acquisition.json
@@ -1,6 +1,6 @@
 {
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/acquisition.py",
-   "schema_version": "0.6.3",
+   "schema_version": "0.6.4",
    "experimenter_full_name": [
       "###"
    ],

--- a/examples/exaspim_instrument.json
+++ b/examples/exaspim_instrument.json
@@ -1,6 +1,6 @@
 {
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/instrument.py",
-   "schema_version": "0.10.2",
+   "schema_version": "0.10.3",
    "instrument_id": "exaSPIM1-1",
    "modification_date": "2023-10-04",
    "instrument_type": "exaSPIM",

--- a/examples/ophys_session.json
+++ b/examples/ophys_session.json
@@ -1,6 +1,6 @@
 {
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/session.py",
-   "schema_version": "0.1.2",
+   "schema_version": "0.1.3",
    "experimenter_full_name": [
       "John Doe"
    ],

--- a/examples/procedures.py
+++ b/examples/procedures.py
@@ -4,11 +4,11 @@ import datetime
 from aind_data_schema.core.procedures import (
     Anaesthetic,
     Craniotomy,
-    ViralMaterial,
     NanojectInjection,
     Perfusion,
     Procedures,
     TarsVirusIdentifiers,
+    ViralMaterial,
 )
 
 t = datetime.datetime(2022, 7, 12, 7, 00, 00)

--- a/src/aind_data_schema/__init__.py
+++ b/src/aind_data_schema/__init__.py
@@ -1,4 +1,4 @@
 """ imports for AindModel subclasses
 """
 
-__version__ = "0.22.7"
+__version__ = "0.22.8"

--- a/src/aind_data_schema/base.py
+++ b/src/aind_data_schema/base.py
@@ -31,20 +31,37 @@ class AindCoreModel(AindModel):
         """
         Returns standard filename in snakecase
         """
+        parent_classes = [base_class for base_class in cls.__bases__ if base_class.__name__ != AindCoreModel.__name__]
+
         name = cls.__name__
+
+        if len(parent_classes):
+            name = parent_classes[0].__name__
+
         return re.sub(r"(?<!^)(?=[A-Z])", "_", name).lower() + cls._FILE_EXTENSION.default
 
-    def write_standard_file(self, output_directory: Optional[Path] = None, prefix=None, suffix=None):
+    def write_standard_file(
+        self,
+        output_directory: Optional[Path] = None,
+        prefix: Optional[str] = None,
+        suffix: Optional[str] = None,
+    ):
         """
         Writes schema to standard json file
         Parameters
         ----------
-        output_directory:
-            optional Path object for output directory
-        prefix:
+        output_directory: Optional[Path]
+            optional Path object for output directory.
+            Default: None
+
+        prefix: Optional[str]
             optional str for intended filepath with extra naming convention
-        suffix:
+            Default: None
+
+        suffix: Optional[str]
             optional str for intended filepath with extra naming convention
+            Default: None
+
         """
         filename = self.default_filename()
         if prefix:

--- a/src/aind_data_schema/core/acquisition.py
+++ b/src/aind_data_schema/core/acquisition.py
@@ -82,7 +82,7 @@ class Acquisition(AindCoreModel):
 
     _DESCRIBED_BY_URL = AindCoreModel._DESCRIBED_BY_BASE_URL.default + "aind_data_schema/core/acquisition.py"
     describedBy: str = Field(_DESCRIBED_BY_URL, json_schema_extra={"const": _DESCRIBED_BY_URL})
-    schema_version: Literal["0.6.3"] = Field("0.6.3")
+    schema_version: Literal["0.6.4"] = Field("0.6.4")
     experimenter_full_name: List[str] = Field(
         ...,
         description="First and last name of the experimenter(s).",

--- a/src/aind_data_schema/core/instrument.py
+++ b/src/aind_data_schema/core/instrument.py
@@ -35,7 +35,7 @@ class Instrument(AindCoreModel):
 
     _DESCRIBED_BY_URL = AindCoreModel._DESCRIBED_BY_BASE_URL.default + "aind_data_schema/core/instrument.py"
     describedBy: str = Field(_DESCRIBED_BY_URL, json_schema_extra={"const": _DESCRIBED_BY_URL})
-    schema_version: Literal["0.10.2"] = Field("0.10.2")
+    schema_version: Literal["0.10.3"] = Field("0.10.3")
 
     instrument_id: Optional[str] = Field(
         None,

--- a/src/aind_data_schema/core/metadata.py
+++ b/src/aind_data_schema/core/metadata.py
@@ -46,7 +46,7 @@ class Metadata(AindCoreModel):
     _DESCRIBED_BY_URL = AindCoreModel._DESCRIBED_BY_BASE_URL.default + "aind_data_schema/core/metadata.py"
     describedBy: str = Field(_DESCRIBED_BY_URL, json_schema_extra={"const": _DESCRIBED_BY_URL})
 
-    schema_version: Literal["0.1.10"] = Field("0.1.10")
+    schema_version: Literal["0.1.11"] = Field("0.1.11")
     id: UUID = Field(
         default_factory=uuid4,
         alias="_id",

--- a/src/aind_data_schema/core/procedures.py
+++ b/src/aind_data_schema/core/procedures.py
@@ -346,14 +346,14 @@ class ViralMaterial(AindModel):
         description="Full genome for virus construct",
     )
     tars_identifiers: Optional[TarsVirusIdentifiers] = Field(
-        None, title="TARS IDs",
-        description="TARS database identifiers"
-        )
+        None, title="TARS IDs", description="TARS database identifiers"
+    )
     addgene_id: Optional[PIDName] = Field(None, title="Addgene id", description="Registry must be Addgene")
     titer: Optional[int] = Field(
-        None, title="Effective titer (gc/mL)",
-        description="Final titer of viral material, accounting for mixture/diliution"
-        )
+        None,
+        title="Effective titer (gc/mL)",
+        description="Final titer of viral material, accounting for mixture/diliution",
+    )
     titer_unit: str = Field("gc/mL", title="Titer unit")
 
 
@@ -368,9 +368,10 @@ class NonViralMaterial(Reagent):
 class Injection(SubjectProcedure):
     """Description of an injection procedure"""
 
-    injection_materials: Annotated[List[Union[ViralMaterial, NonViralMaterial]], Field(
-        title="Injection material", min_length=1, discriminator="material_type")
-        ] = []
+    injection_materials: Annotated[
+        List[Union[ViralMaterial, NonViralMaterial]],
+        Field(title="Injection material", min_length=1, discriminator="material_type"),
+    ] = []
     recovery_time: Optional[Decimal] = Field(None, title="Recovery time")
     recovery_time_unit: TimeUnit = Field(TimeUnit.M, title="Recovery time unit")
     injection_duration: Optional[Decimal] = Field(None, title="Injection duration")

--- a/src/aind_data_schema/core/rig.py
+++ b/src/aind_data_schema/core/rig.py
@@ -49,7 +49,7 @@ class Rig(AindCoreModel):
 
     _DESCRIBED_BY_URL = AindCoreModel._DESCRIBED_BY_BASE_URL.default + "aind_data_schema/core/rig.py"
     describedBy: str = Field(_DESCRIBED_BY_URL, json_schema_extra={"const": _DESCRIBED_BY_URL})
-    schema_version: Literal["0.2.3"] = Field("0.2.3")
+    schema_version: Literal["0.2.4"] = Field("0.2.4")
 
     rig_id: str = Field(..., description="room_stim apparatus_version", title="Rig ID")
     modification_date: date = Field(..., title="Date of modification")

--- a/src/aind_data_schema/core/session.py
+++ b/src/aind_data_schema/core/session.py
@@ -339,7 +339,7 @@ class Session(AindCoreModel):
 
     _DESCRIBED_BY_URL = AindCoreModel._DESCRIBED_BY_BASE_URL.default + "aind_data_schema/core/session.py"
     describedBy: str = Field(_DESCRIBED_BY_URL, json_schema_extra={"const": _DESCRIBED_BY_URL})
-    schema_version: Literal["0.1.2"] = Field("0.1.2")
+    schema_version: Literal["0.1.3"] = Field("0.1.3")
 
     experimenter_full_name: List[str] = Field(
         ...,

--- a/src/aind_data_schema/models/devices.py
+++ b/src/aind_data_schema/models/devices.py
@@ -291,7 +291,9 @@ class Calibration(AindModel):
     notes: Optional[str] = Field(None, title="Notes")
 
 
-class WaterCalibrationInput(AindModel):
+class WaterValveCalibrationInput(AindModel):
+    """Input for water valve calibration class"""
+
     valve_open_interval: PositiveFloat = Field(
         ..., description="Time between two consecutive valve openings (s)", title="Valve open interval", units="s"
     )
@@ -304,7 +306,9 @@ class WaterCalibrationInput(AindModel):
     repeat_count: int = Field(..., ge=0, description="Number of times the valve opened.", title="Repeat count")
 
 
-class WaterCalibrationOutput(AindModel):
+class WaterValveCalibrationOutput(AindModel):
+    """Output for water valve calibration class"""
+
     interval_average: Optional[Dict[PositiveFloat, PositiveFloat]] = Field(
         None,
         description="Dictionary keyed by measured valve interval and corresponding average single event volume.",
@@ -333,12 +337,14 @@ class WaterCalibrationOutput(AindModel):
     )
 
 
-class WaterCalibration(Calibration):
+class WaterValveCalibration(Calibration):
+    """Water valve calibration class"""
+
     description: Literal[
         "Calibration of the water valve delivery system"
     ] = "Calibration of the water valve delivery system"
-    input: List[WaterCalibrationInput] = Field([], title="Input of the calibration")
-    output: Optional[WaterCalibrationOutput] = Field(None, title="Output of the calibration.")
+    input: List[WaterValveCalibrationInput] = Field([], title="Input of the calibration")
+    output: Optional[WaterValveCalibrationOutput] = Field(None, title="Output of the calibration.")
 
 
 class Maintenance(AindModel):

--- a/src/aind_data_schema/models/devices.py
+++ b/src/aind_data_schema/models/devices.py
@@ -12,14 +12,7 @@ from aind_data_schema.base import AindModel
 from aind_data_schema.models.coordinates import RelativePosition, Size3d
 from aind_data_schema.models.manufacturers import InteruniversityMicroelectronicsCenter, Manufacturer
 from aind_data_schema.models.reagent import Reagent
-from aind_data_schema.models.units import (
-    FrequencyUnit,
-    PowerUnit,
-    SizeUnit,
-    SpeedUnit,
-    TemperatureUnit,
-    UnitlessUnit,
-    )
+from aind_data_schema.models.units import FrequencyUnit, PowerUnit, SizeUnit, SpeedUnit, TemperatureUnit, UnitlessUnit
 
 
 class ImagingDeviceType(str, Enum):

--- a/src/aind_data_schema/models/devices.py
+++ b/src/aind_data_schema/models/devices.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from pydantic import Field, PositiveFloat
+from pydantic import Field
 from typing_extensions import Annotated
 
 from aind_data_schema.base import AindModel
@@ -289,62 +289,6 @@ class Calibration(AindModel):
     input: Optional[Any] = Field(None, description="Calibration input", title="inputs")
     output: Optional[Any] = Field(None, description="Calibration output", title="outputs")
     notes: Optional[str] = Field(None, title="Notes")
-
-
-class WaterValveCalibrationInput(AindModel):
-    """Input for water valve calibration class"""
-
-    valve_open_interval: PositiveFloat = Field(
-        ..., description="Time between two consecutive valve openings (s)", title="Valve open interval", units="s"
-    )
-    valve_open_time: PositiveFloat = Field(
-        ..., description="Valve open interval (s)", title="Valve open time", units="s"
-    )
-    water_weight: List[PositiveFloat] = Field(
-        ..., description="Weight of water delivered (g)", title="Water weight", units="g", min_length=1
-    )
-    repeat_count: int = Field(..., ge=0, description="Number of times the valve opened.", title="Repeat count")
-
-
-class WaterValveCalibrationOutput(AindModel):
-    """Output for water valve calibration class"""
-
-    interval_average: Optional[Dict[PositiveFloat, PositiveFloat]] = Field(
-        None,
-        description="Dictionary keyed by measured valve interval and corresponding average single event volume.",
-        title="Interval average",
-        units="s",
-    )
-    slope: float = Field(
-        ...,
-        description="Slope of the linear regression : Volume(g) = Slope(g/s) * time(s) + offset(g)",
-        title="Regression slope",
-        units="g/s",
-    )
-    offset: float = Field(
-        ...,
-        description="Offset of the linear regression : Volume(g) = Slope(g/s) * time(s) + offset(g)",
-        title="Regression offset",
-        units="g",
-    )
-    r2: PositiveFloat = Field(..., description="R2 metric from the linear model.", title="R2", gt=0, le=1)
-    valid_domain: Optional[List[PositiveFloat]] = Field(
-        None,
-        description="The optional time-intervals the calibration curve was calculated on.",
-        min_length=2,
-        title="Valid domain",
-        units="s",
-    )
-
-
-class WaterValveCalibration(Calibration):
-    """Water valve calibration class"""
-
-    description: Literal[
-        "Calibration of the water valve delivery system"
-    ] = "Calibration of the water valve delivery system"
-    input: List[WaterValveCalibrationInput] = Field([], title="Input of the calibration")
-    output: Optional[WaterValveCalibrationOutput] = Field(None, title="Output of the calibration.")
 
 
 class Maintenance(AindModel):

--- a/src/aind_data_schema/models/devices.py
+++ b/src/aind_data_schema/models/devices.py
@@ -12,7 +12,14 @@ from aind_data_schema.base import AindModel
 from aind_data_schema.models.coordinates import RelativePosition, Size3d
 from aind_data_schema.models.manufacturers import InteruniversityMicroelectronicsCenter, Manufacturer
 from aind_data_schema.models.reagent import Reagent
-from aind_data_schema.models.units import FrequencyUnit, PowerUnit, SizeUnit, SpeedUnit, TemperatureUnit, UnitlessUnit
+from aind_data_schema.models.units import (
+    FrequencyUnit,
+    PowerUnit,
+    SizeUnit,
+    SpeedUnit,
+    TemperatureUnit,
+    UnitlessUnit,
+)
 
 
 class ImagingDeviceType(str, Enum):
@@ -285,23 +292,52 @@ class Calibration(AindModel):
 
 
 class WaterCalibrationInput(AindModel):
-    valve_open_interval: PositiveFloat = Field(..., description="Time between two consecutive valve openings (s)", title="Valve open interval", units="s")
-    valve_open_time: PositiveFloat = Field(..., description="Valve open interval (s)", title="Valve open time", units="s")
-    water_weight: List[PositiveFloat] = Field(..., description="Weight of water delivered (g)", title="Water weight", units="g", min_length=1)
+    valve_open_interval: PositiveFloat = Field(
+        ..., description="Time between two consecutive valve openings (s)", title="Valve open interval", units="s"
+    )
+    valve_open_time: PositiveFloat = Field(
+        ..., description="Valve open interval (s)", title="Valve open time", units="s"
+    )
+    water_weight: List[PositiveFloat] = Field(
+        ..., description="Weight of water delivered (g)", title="Water weight", units="g", min_length=1
+    )
     repeat_count: int = Field(..., ge=0, description="Number of times the valve opened.", title="Repeat count")
 
 
 class WaterCalibrationOutput(AindModel):
-    interval_average: Optional[Dict[PositiveFloat, PositiveFloat]] = Field(None, description="Dictionary keyed by measured valve interval and corresponding average single event volume.", title="Interval average", units="s")
-    slope: float = Field(..., description="Slope of the linear regression : Volume(g) = Slope(g/s) * time(s) + offset(g)", title="Regression slope", units="g/s")
-    offset: float = Field(..., description="Offset of the linear regression : Volume(g) = Slope(g/s) * time(s) + offset(g)", title="Regression offset", units="g")
+    interval_average: Optional[Dict[PositiveFloat, PositiveFloat]] = Field(
+        None,
+        description="Dictionary keyed by measured valve interval and corresponding average single event volume.",
+        title="Interval average",
+        units="s",
+    )
+    slope: float = Field(
+        ...,
+        description="Slope of the linear regression : Volume(g) = Slope(g/s) * time(s) + offset(g)",
+        title="Regression slope",
+        units="g/s",
+    )
+    offset: float = Field(
+        ...,
+        description="Offset of the linear regression : Volume(g) = Slope(g/s) * time(s) + offset(g)",
+        title="Regression offset",
+        units="g",
+    )
     r2: PositiveFloat = Field(..., description="R2 metric from the linear model.", title="R2", gt=0, le=1)
-    valid_domain: Optional[List[PositiveFloat]] = Field(None, description="The optional time-intervals the calibration curve was calculated on.", min_length=2, title="Valid domain", units="s")
+    valid_domain: Optional[List[PositiveFloat]] = Field(
+        None,
+        description="The optional time-intervals the calibration curve was calculated on.",
+        min_length=2,
+        title="Valid domain",
+        units="s",
+    )
 
 
 class WaterCalibration(Calibration):
-    description: Literal["Calibration of the water valve delivery system"] = "Calibration of the water valve delivery system"
-    input: List[WaterCalibrationInput] = Field([], title="Input of the calibration") #see note 1.
+    description: Literal[
+        "Calibration of the water valve delivery system"
+    ] = "Calibration of the water valve delivery system"
+    input: List[WaterCalibrationInput] = Field([], title="Input of the calibration")
     output: Optional[WaterCalibrationOutput] = Field(None, title="Output of the calibration.")
 
 

--- a/src/aind_data_schema/models/devices.py
+++ b/src/aind_data_schema/models/devices.py
@@ -279,8 +279,8 @@ class Calibration(AindModel):
     calibration_date: datetime = Field(..., title="Date and time of calibration")
     device_name: str = Field(..., title="Device name", description="Must match a device name in rig/instrument")
     description: str = Field(..., title="Description", description="Brief description of what is being calibrated")
-    input: Dict[str, Any] = Field(dict(), description="Calibration input", title="inputs")
-    output: Dict[str, Any] = Field(dict(), description="Calibration output", title="outputs")
+    input: Optional[Any] = Field(None, description="Calibration input", title="inputs")
+    output: Optional[Any] = Field(None, description="Calibration output", title="outputs")
     notes: Optional[str] = Field(None, title="Notes")
 
 

--- a/src/aind_data_schema/models/devices.py
+++ b/src/aind_data_schema/models/devices.py
@@ -23,7 +23,7 @@ from aind_data_schema.models.units import (
 
 
 class ImagingDeviceType(str, Enum):
-    """Imaginge device type name"""
+    """Imaging device type name"""
 
     BEAM_EXPANDER = "Beam expander"
     SAMPLE_CHAMBER = "Sample Chamber"

--- a/src/aind_data_schema/models/devices.py
+++ b/src/aind_data_schema/models/devices.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from pydantic import Field
+from pydantic import Field, PositiveFloat
 from typing_extensions import Annotated
 
 from aind_data_schema.base import AindModel
@@ -282,6 +282,27 @@ class Calibration(AindModel):
     input: Optional[Any] = Field(None, description="Calibration input", title="inputs")
     output: Optional[Any] = Field(None, description="Calibration output", title="outputs")
     notes: Optional[str] = Field(None, title="Notes")
+
+
+class WaterCalibrationInput(AindModel):
+    valve_open_interval: PositiveFloat = Field(..., description="Time between two consecutive valve openings (s)", title="Valve open interval", units="s")
+    valve_open_time: PositiveFloat = Field(..., description="Valve open interval (s)", title="Valve open time", units="s")
+    water_weight: List[PositiveFloat] = Field(..., description="Weight of water delivered (g)", title="Water weight", units="g", min_length=1)
+    repeat_count: int = Field(..., ge=0, description="Number of times the valve opened.", title="Repeat count")
+
+
+class WaterCalibrationOutput(AindModel):
+    interval_average: Optional[Dict[PositiveFloat, PositiveFloat]] = Field(None, description="Dictionary keyed by measured valve interval and corresponding average single event volume.", title="Interval average", units="s")
+    slope: float = Field(..., description="Slope of the linear regression : Volume(g) = Slope(g/s) * time(s) + offset(g)", title="Regression slope", units="g/s")
+    offset: float = Field(..., description="Offset of the linear regression : Volume(g) = Slope(g/s) * time(s) + offset(g)", title="Regression offset", units="g")
+    r2: PositiveFloat = Field(..., description="R2 metric from the linear model.", title="R2", gt=0, le=1)
+    valid_domain: Optional[List[PositiveFloat]] = Field(None, description="The optional time-intervals the calibration curve was calculated on.", min_length=2, title="Valid domain", units="s")
+
+
+class WaterCalibration(Calibration):
+    description: Literal["Calibration of the water valve delivery system"] = "Calibration of the water valve delivery system"
+    input: List[WaterCalibrationInput] = Field([], title="Input of the calibration") #see note 1.
+    output: Optional[WaterCalibrationOutput] = Field(None, title="Output of the calibration.")
 
 
 class Maintenance(AindModel):

--- a/src/aind_data_schema/models/manufacturers.py
+++ b/src/aind_data_schema/models/manufacturers.py
@@ -622,7 +622,7 @@ class Manufacturer:
             InteruniversityMicroelectronicsCenter,
             OpenEphysProductionSite,
             ChampalimaudFoundation,
-            Other
+            Other,
         ],
         Field(discriminator="name"),
     ]

--- a/tests/test_procedures.py
+++ b/tests/test_procedures.py
@@ -6,13 +6,13 @@ from pydantic import ValidationError
 
 from aind_data_schema.core.procedures import (
     FiberImplant,
-    ViralMaterial,
     NanojectInjection,
     OphysProbe,
     Procedures,
     RetroOrbitalInjection,
     SpecimenProcedure,
     TarsVirusIdentifiers,
+    ViralMaterial,
 )
 from aind_data_schema.models.devices import FiberProbe
 from aind_data_schema.models.manufacturers import Manufacturer

--- a/tests/test_rig.py
+++ b/tests/test_rig.py
@@ -200,7 +200,7 @@ class RigTests(unittest.TestCase):
                             channel_index=1,
                             channel_type=ChannelType.ODOR,
                             flow_capacity=100,
-                        )
+                        ),
                     ],
                 )
             ],


### PR DESCRIPTION
This PR:

- Refactors the Calibration class to allow "Any" types;
- Adds a water calibration model to the core schema.


Additionally, the follow example and script can be used to run unit tests, but I would like to know where you want me to drop it since the current tests do not seem to comtemplate tests for indivual 'AindModel' classes


```Python

from pydantic import PositiveFloat, PositiveInt, Field
from typing import List, Optional, Dict, Literal
from datetime import datetime
from aind_data_schema.base import AindModel
from aind_data_schema.models.devices import Calibration, WaterCalibration, WaterCalibrationInput, WaterCalibrationOutput
import json


_delta_times = [0.1, 0.2, 0.3, 0.4, 0.5]
_slope = 10.1
_offset = -0.3
_linear_model = (lambda time: _slope * time + _offset)
_water_weights = [_linear_model(x) for x in _delta_times]
_inputs = [
    WaterCalibrationInput(valve_open_interval=0.5, valve_open_time=t[0], water_weight=[t[1]], repeat_count=1)
    for t in zip(_delta_times, _water_weights)]

_outputs = WaterCalibrationOutput(
    interval_average={interval: volume for interval, volume in zip(_delta_times, _water_weights)},
    slope=_slope,
    offset=_offset,
    r2=1.0,
    valid_domain=[value for value in _delta_times])

calibration = WaterCalibration(
    input=_inputs,
    output=_outputs,
    device_name="WaterValve",
    calibration_date=datetime.now(),
    )

roundtrip = WaterCalibration.model_validate_json(calibration.model_dump_json())
roundtrip_parent = Calibration.model_validate_json(calibration.model_dump_json())


test = json.dumps(WaterCalibration.model_json_schema(), indent=3)
with open('test.json', "w") as f:
    f.write(test)

'''
