### PR TITLE
Refactor `Dict[str, Any]` types with explicit Generic types 

### DIFF
--- a/examples/aibs_smartspim_instrument.json
+++ b/examples/aibs_smartspim_instrument.json
@@ -1,6 +1,6 @@
 {
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/instrument.py",
-   "schema_version": "0.10.8",
+   "schema_version": "0.10.9",
    "instrument_id": "SmartSPIM2-2",
    "modification_date": "2023-10-04",
    "instrument_type": "SmartSPIM",

--- a/examples/aibs_smartspim_procedures.json
+++ b/examples/aibs_smartspim_procedures.json
@@ -1,6 +1,6 @@
 {
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/procedures.py",
-   "schema_version": "0.12.2",
+   "schema_version": "0.12.3",
    "subject_id": "651286",
    "subject_procedures": [
       {

--- a/examples/bergamo_ophys_session.json
+++ b/examples/bergamo_ophys_session.json
@@ -1,6 +1,6 @@
 {
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/session.py",
-   "schema_version": "0.1.7",
+   "schema_version": "0.1.8",
    "protocol_id": [],
    "experimenter_full_name": [
       "John Doe"

--- a/examples/ephys_rig.json
+++ b/examples/ephys_rig.json
@@ -1,6 +1,6 @@
 {
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/rig.py",
-   "schema_version": "0.2.13",
+   "schema_version": "0.2.14",
    "rig_id": "323_EPHYS1",
    "modification_date": "2023-10-03",
    "mouse_platform": {

--- a/examples/ephys_session.json
+++ b/examples/ephys_session.json
@@ -1,6 +1,6 @@
 {
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/session.py",
-   "schema_version": "0.1.7",
+   "schema_version": "0.1.8",
    "protocol_id": [],
    "experimenter_full_name": [
       "Jane Doe"

--- a/examples/exaspim_acquisition.json
+++ b/examples/exaspim_acquisition.json
@@ -1,6 +1,6 @@
 {
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/acquisition.py",
-   "schema_version": "0.6.7",
+   "schema_version": "0.6.8",
    "protocol_id": [],
    "experimenter_full_name": [
       "###"

--- a/examples/exaspim_instrument.json
+++ b/examples/exaspim_instrument.json
@@ -1,6 +1,6 @@
 {
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/instrument.py",
-   "schema_version": "0.10.8",
+   "schema_version": "0.10.9",
    "instrument_id": "exaSPIM1-1",
    "modification_date": "2023-10-04",
    "instrument_type": "exaSPIM",

--- a/examples/fip_ophys_rig.json
+++ b/examples/fip_ophys_rig.json
@@ -1,6 +1,6 @@
 {
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/rig.py",
-   "schema_version": "0.2.13",
+   "schema_version": "0.2.14",
    "rig_id": "428_FIP1_2",
    "modification_date": "2023-10-03",
    "mouse_platform": {

--- a/examples/ophys_procedures.json
+++ b/examples/ophys_procedures.json
@@ -1,6 +1,6 @@
 {
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/procedures.py",
-   "schema_version": "0.12.2",
+   "schema_version": "0.12.3",
    "subject_id": "625100",
    "subject_procedures": [
       {

--- a/examples/ophys_session.json
+++ b/examples/ophys_session.json
@@ -1,6 +1,6 @@
 {
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/session.py",
-   "schema_version": "0.1.7",
+   "schema_version": "0.1.8",
    "protocol_id": [],
    "experimenter_full_name": [
       "John Doe"

--- a/examples/procedures.json
+++ b/examples/procedures.json
@@ -1,6 +1,6 @@
 {
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/procedures.py",
-   "schema_version": "0.12.2",
+   "schema_version": "0.12.3",
    "subject_id": "625100",
    "subject_procedures": [
       {

--- a/examples/processing.json
+++ b/examples/processing.json
@@ -1,6 +1,6 @@
 {
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/processing.py",
-   "schema_version": "0.4.3",
+   "schema_version": "0.4.4",
    "processing_pipeline": {
       "data_processes": [
          {

--- a/src/aind_data_schema/base.py
+++ b/src/aind_data_schema/base.py
@@ -2,7 +2,7 @@
 
 import re
 from pathlib import Path
-from typing import Optional, TypeVar, Generic
+from typing import Generic, Optional, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 

--- a/src/aind_data_schema/base.py
+++ b/src/aind_data_schema/base.py
@@ -2,12 +2,24 @@
 
 import re
 from pathlib import Path
-from typing import Optional
+from typing import Optional, TypeVar, Generic
 
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 
 
-class AindModel(BaseModel):
+class AindGeneric(BaseModel, extra="allow"):
+    """Base class for generic types that can be used in AIND schema"""
+
+    # extra="allow" is needed because BaseModel by default drops extra parameters.
+    # Alternatively, consider using 'SerializeAsAny' once this issue is resolved
+    # https://github.com/pydantic/pydantic/issues/6423
+    pass
+
+
+AindGenericType = TypeVar("AindGenericType", bound=AindGeneric)
+
+
+class AindModel(BaseModel, Generic[AindGenericType]):
     """BaseModel that disallows extra fields"""
 
     model_config = ConfigDict(extra="forbid", use_enum_values=True)

--- a/src/aind_data_schema/core/acquisition.py
+++ b/src/aind_data_schema/core/acquisition.py
@@ -45,7 +45,7 @@ class Acquisition(AindCoreModel):
 
     _DESCRIBED_BY_URL = AindCoreModel._DESCRIBED_BY_BASE_URL.default + "aind_data_schema/core/acquisition.py"
     describedBy: str = Field(_DESCRIBED_BY_URL, json_schema_extra={"const": _DESCRIBED_BY_URL})
-    schema_version: Literal["0.6.7"] = Field("0.6.7")
+    schema_version: Literal["0.6.8"] = Field("0.6.8")
     protocol_id: List[str] = Field([], title="Protocol ID", description="DOI for protocols.io")
     experimenter_full_name: List[str] = Field(
         ...,

--- a/src/aind_data_schema/core/instrument.py
+++ b/src/aind_data_schema/core/instrument.py
@@ -35,7 +35,7 @@ class Instrument(AindCoreModel):
 
     _DESCRIBED_BY_URL = AindCoreModel._DESCRIBED_BY_BASE_URL.default + "aind_data_schema/core/instrument.py"
     describedBy: str = Field(_DESCRIBED_BY_URL, json_schema_extra={"const": _DESCRIBED_BY_URL})
-    schema_version: Literal["0.10.8"] = Field("0.10.8")
+    schema_version: Literal["0.10.9"] = Field("0.10.9")
 
     instrument_id: Optional[str] = Field(
         None,

--- a/src/aind_data_schema/core/metadata.py
+++ b/src/aind_data_schema/core/metadata.py
@@ -46,7 +46,7 @@ class Metadata(AindCoreModel):
 
     _DESCRIBED_BY_URL = AindCoreModel._DESCRIBED_BY_BASE_URL.default + "aind_data_schema/core/metadata.py"
     describedBy: str = Field(_DESCRIBED_BY_URL, json_schema_extra={"const": _DESCRIBED_BY_URL})
-    schema_version: Literal["0.1.28"] = Field("0.1.28")
+    schema_version: Literal["0.1.29"] = Field("0.1.29")
     id: UUID = Field(
         default_factory=uuid4,
         alias="_id",

--- a/src/aind_data_schema/core/mri_session.py
+++ b/src/aind_data_schema/core/mri_session.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from decimal import Decimal
 from enum import Enum
-from typing import Generic, List, Literal, Optional
+from typing import List, Literal, Optional
 
 from pydantic import Field, ValidationInfo, field_validator
 

--- a/src/aind_data_schema/core/mri_session.py
+++ b/src/aind_data_schema/core/mri_session.py
@@ -3,11 +3,11 @@
 from datetime import datetime
 from decimal import Decimal
 from enum import Enum
-from typing import Any, Dict, List, Literal, Optional
+from typing import Generic, List, Literal, Optional
 
 from pydantic import Field, ValidationInfo, field_validator
 
-from aind_data_schema.base import AindCoreModel, AindModel
+from aind_data_schema.base import AindCoreModel, AindGenericType, AindModel
 from aind_data_schema.core.procedures import Anaesthetic
 from aind_data_schema.models.coordinates import Rotation3dTransform, Scale3dTransform, Translation3dTransform
 from aind_data_schema.models.devices import Scanner
@@ -64,7 +64,12 @@ class MRIScan(AindModel):
             ProcessName.SKULL_STRIPPING,
         ]
     ] = Field([])
-    additional_scan_parameters: Dict[str, Any] = Field(..., title="Parameters")
+    echo_time: Decimal = Field(..., title="Echo time (ms)")
+    effective_echo_time: Decimal = Field(..., title="Effective echo time (ms)")
+    echo_time_unit: TimeUnit = Field(TimeUnit.MS, title="Echo time unit")
+    repetition_time: Decimal = Field(..., title="Repetition time (ms)")
+    repetition_time_unit: TimeUnit = Field(TimeUnit.MS, title="Repetition time unit")
+    additional_scan_parameters: AindGenericType = Field(..., title="Parameters")
     notes: Optional[str] = Field(None, title="Notes", validate_default=True)
 
     @field_validator("notes", mode="after")

--- a/src/aind_data_schema/core/mri_session.py
+++ b/src/aind_data_schema/core/mri_session.py
@@ -89,7 +89,7 @@ class MriSession(AindCoreModel):
 
     _DESCRIBED_BY_URL = AindCoreModel._DESCRIBED_BY_BASE_URL.default + "aind_data_schema/core/mri_session.py"
     describedBy: str = Field(_DESCRIBED_BY_URL, json_schema_extra={"const": _DESCRIBED_BY_URL})
-    schema_version: Literal["0.3.0"] = Field("0.3.0")
+    schema_version: Literal["0.3.1"] = Field("0.3.1")
     subject_id: str = Field(
         ...,
         description="Unique identifier for the subject. If this is not a Allen LAS ID, indicate this in the Notes.",

--- a/src/aind_data_schema/core/mri_session.py
+++ b/src/aind_data_schema/core/mri_session.py
@@ -64,11 +64,6 @@ class MRIScan(AindModel):
             ProcessName.SKULL_STRIPPING,
         ]
     ] = Field([])
-    echo_time: Decimal = Field(..., title="Echo time (ms)")
-    effective_echo_time: Decimal = Field(..., title="Effective echo time (ms)")
-    echo_time_unit: TimeUnit = Field(TimeUnit.MS, title="Echo time unit")
-    repetition_time: Decimal = Field(..., title="Repetition time (ms)")
-    repetition_time_unit: TimeUnit = Field(TimeUnit.MS, title="Repetition time unit")
     additional_scan_parameters: AindGenericType = Field(..., title="Parameters")
     notes: Optional[str] = Field(None, title="Notes", validate_default=True)
 

--- a/src/aind_data_schema/core/procedures.py
+++ b/src/aind_data_schema/core/procedures.py
@@ -573,7 +573,7 @@ class Procedures(AindCoreModel):
     _DESCRIBED_BY_URL = AindCoreModel._DESCRIBED_BY_BASE_URL.default + "aind_data_schema/core/procedures.py"
     describedBy: str = Field(_DESCRIBED_BY_URL, json_schema_extra={"const": _DESCRIBED_BY_URL})
 
-    schema_version: Literal["0.12.2"] = Field("0.12.2", description="schema version", title="Version")
+    schema_version: Literal["0.12.3"] = Field("0.12.3", description="schema version", title="Version")
     subject_id: str = Field(
         ...,
         description="Unique identifier for the subject. If this is not a Allen LAS ID, indicate this in the Notes.",

--- a/src/aind_data_schema/core/processing.py
+++ b/src/aind_data_schema/core/processing.py
@@ -2,11 +2,11 @@
 
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, List, Literal, Optional
+from typing import Generic, List, Literal, Optional
 
 from pydantic import Field, ValidationInfo, field_validator
 
-from aind_data_schema.base import AindCoreModel, AindModel
+from aind_data_schema.base import AindCoreModel, AindGeneric, AindGenericType, AindModel
 from aind_data_schema.imaging.tile import Tile
 from aind_data_schema.models.process_names import ProcessName
 
@@ -29,8 +29,8 @@ class DataProcess(AindModel):
     output_location: str = Field(..., description="Path to data outputs", title="Output location")
     code_url: str = Field(..., description="Path to code repository", title="Code URL")
     code_version: Optional[str] = Field(None, description="Version of the code", title="Code version")
-    parameters: Dict[str, Any] = Field(..., title="Parameters")
-    outputs: Dict[str, Any] = Field(dict(), description="Output parameters", title="Outputs")
+    parameters: AindGenericType = Field(..., title="Parameters")
+    outputs: AindGenericType = Field(AindGeneric(), description="Output parameters", title="Outputs")
     notes: Optional[str] = Field(None, title="Notes", validate_default=True)
 
     @field_validator("notes", mode="after")

--- a/src/aind_data_schema/core/processing.py
+++ b/src/aind_data_schema/core/processing.py
@@ -86,7 +86,7 @@ class Processing(AindCoreModel):
 
     _DESCRIBED_BY_URL: str = AindCoreModel._DESCRIBED_BY_BASE_URL.default + "aind_data_schema/core/processing.py"
     describedBy: str = Field(_DESCRIBED_BY_URL, json_schema_extra={"const": _DESCRIBED_BY_URL})
-    schema_version: Literal["0.4.3"] = Field("0.4.3")
+    schema_version: Literal["0.4.4"] = Field("0.4.4")
 
     processing_pipeline: PipelineProcess = Field(
         ..., description="Pipeline used to process data", title="Processing Pipeline"

--- a/src/aind_data_schema/core/processing.py
+++ b/src/aind_data_schema/core/processing.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 from enum import Enum
-from typing import Generic, List, Literal, Optional
+from typing import List, Literal, Optional
 
 from pydantic import Field, ValidationInfo, field_validator
 

--- a/src/aind_data_schema/core/rig.py
+++ b/src/aind_data_schema/core/rig.py
@@ -49,7 +49,7 @@ class Rig(AindCoreModel):
 
     _DESCRIBED_BY_URL = AindCoreModel._DESCRIBED_BY_BASE_URL.default + "aind_data_schema/core/rig.py"
     describedBy: str = Field(_DESCRIBED_BY_URL, json_schema_extra={"const": _DESCRIBED_BY_URL})
-    schema_version: Literal["0.2.13"] = Field("0.2.13")
+    schema_version: Literal["0.2.14"] = Field("0.2.14")
     rig_id: str = Field(..., description="room_stim apparatus_version", title="Rig ID")
     modification_date: date = Field(..., title="Date of modification")
     mouse_platform: MOUSE_PLATFORMS

--- a/src/aind_data_schema/core/session.py
+++ b/src/aind_data_schema/core/session.py
@@ -339,7 +339,7 @@ class Session(AindCoreModel):
 
     _DESCRIBED_BY_URL = AindCoreModel._DESCRIBED_BY_BASE_URL.default + "aind_data_schema/core/session.py"
     describedBy: str = Field(_DESCRIBED_BY_URL, json_schema_extra={"const": _DESCRIBED_BY_URL})
-    schema_version: Literal["0.1.7"] = Field("0.1.7")
+    schema_version: Literal["0.1.8"] = Field("0.1.8")
     protocol_id: List[str] = Field([], title="Protocol ID", description="DOI for protocols.io")
     experimenter_full_name: List[str] = Field(
         ...,

--- a/src/aind_data_schema/models/devices.py
+++ b/src/aind_data_schema/models/devices.py
@@ -3,7 +3,7 @@
 from datetime import date, datetime
 from decimal import Decimal
 from enum import Enum
-from typing import Generic, List, Literal, Optional, Union
+from typing import List, Literal, Optional, Union
 
 from pydantic import Field
 from typing_extensions import Annotated

--- a/src/aind_data_schema/models/devices.py
+++ b/src/aind_data_schema/models/devices.py
@@ -3,12 +3,12 @@
 from datetime import date, datetime
 from decimal import Decimal
 from enum import Enum
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Generic, List, Literal, Optional, Union
 
 from pydantic import Field
 from typing_extensions import Annotated
 
-from aind_data_schema.base import AindModel
+from aind_data_schema.base import AindGeneric, AindGenericType, AindModel
 from aind_data_schema.models.coordinates import RelativePosition, Size3d
 from aind_data_schema.models.harp_types import HarpDeviceType
 from aind_data_schema.models.organizations import Organization
@@ -243,7 +243,7 @@ class Device(AindModel):
     model: Optional[str] = Field(None, title="Model")
     path_to_cad: Optional[str] = Field(None, title="Path to CAD diagram", description="For CUSTOM manufactured devices")
     port_index: Optional[str] = Field(None, title="Port index")
-    additional_settings: Optional[Dict[str, Any]] = Field(dict(), title="Additional parameters")
+    additional_settings: AindGenericType = Field(AindGeneric(), title="Additional parameters")
     notes: Optional[str] = Field(None, title="Notes")
 
 
@@ -253,7 +253,7 @@ class Software(AindModel):
     name: str = Field(..., title="Software name")
     version: str = Field(..., title="Software version")
     url: Optional[str] = Field(None, title="URL to commit being used")
-    parameters: Dict[str, Any] = Field(dict(), title="Software parameters")
+    parameters: AindGenericType = Field(AindGeneric(), title="Software parameters")
 
 
 class Calibration(AindModel):
@@ -262,8 +262,8 @@ class Calibration(AindModel):
     calibration_date: datetime = Field(..., title="Date and time of calibration")
     device_name: str = Field(..., title="Device name", description="Must match a device name in rig/instrument")
     description: str = Field(..., title="Description", description="Brief description of what is being calibrated")
-    input: Dict[str, Any] = Field(dict(), description="Calibration input", title="inputs")
-    output: Dict[str, Any] = Field(dict(), description="Calibration output", title="outputs")
+    input: AindGenericType = Field(AindGeneric(), description="Calibration input", title="inputs")
+    output: AindGenericType = Field(AindGeneric(), description="Calibration output", title="outputs")
     notes: Optional[str] = Field(None, title="Notes")
 
 

--- a/src/aind_data_schema/models/modalities.py
+++ b/src/aind_data_schema/models/modalities.py
@@ -52,9 +52,9 @@ class Electromyography(_Modality):
 class Fmost(_Modality):
     """Fmost"""
 
-    name: Literal[
+    name: Literal["Fluorescence micro-optical sectioning tomography"] = (
         "Fluorescence micro-optical sectioning tomography"
-    ] = "Fluorescence micro-optical sectioning tomography"
+    )
     abbreviation: Literal["fMOST"] = "fMOST"
 
 
@@ -82,9 +82,9 @@ class Fib(_Modality):
 class Merfish(_Modality):
     """Merfish"""
 
-    name: Literal[
+    name: Literal["Multiplexed error-robust fluorescence in situ hybridization"] = (
         "Multiplexed error-robust fluorescence in situ hybridization"
-    ] = "Multiplexed error-robust fluorescence in situ hybridization"
+    )
     abbreviation: Literal["merfish"] = "merfish"
 
 

--- a/src/aind_data_schema/models/organizations.py
+++ b/src/aind_data_schema/models/organizations.py
@@ -414,9 +414,9 @@ class Mpi(_Organization):
 class NationalInstituteOfNeurologicalDisordersAndStroke(_Organization):
     """NationalInstituteOfNeurologicalDisordersAndStroke"""
 
-    name: Literal[
+    name: Literal["National Institute of Neurological Disorders and Stroke"] = (
         "National Institute of Neurological Disorders and Stroke"
-    ] = "National Institute of Neurological Disorders and Stroke"
+    )
     abbreviation: Literal["NINDS"] = "NINDS"
     registry: Annotated[Union[ResearchOrganizationRegistry], Field(default=Registry.ROR, discriminator="name")]
     registry_identifier: Literal["01s5ya894"] = "01s5ya894"

--- a/src/aind_data_schema/models/platforms.py
+++ b/src/aind_data_schema/models/platforms.py
@@ -45,9 +45,9 @@ class ExaSpim(_Platform):
 class Fip(_Platform):
     """Fip"""
 
-    name: Literal[
+    name: Literal["Frame-projected independent-fiber photometry platform"] = (
         "Frame-projected independent-fiber photometry platform"
-    ] = "Frame-projected independent-fiber photometry platform"
+    )
     abbreviation: Literal["FIP"] = "FIP"
 
 

--- a/src/aind_data_schema/models/stimulus.py
+++ b/src/aind_data_schema/models/stimulus.py
@@ -3,12 +3,12 @@
 from datetime import datetime
 from decimal import Decimal
 from enum import Enum
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Generic, List, Literal, Optional, Union
 
 from pydantic import Field
 from typing_extensions import Annotated
 
-from aind_data_schema.base import AindModel
+from aind_data_schema.base import AindGeneric, AindGenericType, AindModel
 from aind_data_schema.models.devices import Software
 from aind_data_schema.models.units import ConcentrationUnit, FrequencyUnit, PowerUnit, TimeUnit, VolumeUnit
 
@@ -45,7 +45,7 @@ class OptoStimulation(AindModel):
         description="Duration of baseline recording prior to first pulse train",
     )
     baseline_duration_unit: TimeUnit = Field(TimeUnit.S, title="Baseline duration unit")
-    other_parameters: Dict[str, Any] = Field(dict())
+    other_parameters: AindGenericType = Field(AindGeneric(), title="Other parameters")
     notes: Optional[str] = Field(None, title="Notes")
 
 
@@ -54,8 +54,8 @@ class VisualStimulation(AindModel):
 
     stimulus_type: Literal["Visual"] = "Visual"
     stimulus_name: str = Field(..., title="Stimulus name")
-    stimulus_parameters: Dict[str, Any] = Field(
-        dict(),
+    stimulus_parameters: AindGenericType = Field(
+        AindGeneric(),
         title="Stimulus parameters",
         description="Define and list the parameter values used (e.g. all TF or orientation values)",
     )
@@ -95,7 +95,7 @@ class BehaviorStimulation(AindModel):
         title="Behavior script",
         description="provide URL to the commit of the script and the parameters used",
     )
-    output_parameters: Dict[str, Any] = Field(
+    output_parameters: AindGenericType = Field(
         ...,
         title="Performance parameters",
         description="Performance metrics from session",
@@ -121,7 +121,7 @@ class PhotoStimulationGroup(AindModel):
     spiral_duration_unit: TimeUnit = Field(TimeUnit.S, title="Spiral duration unit")
     inter_spiral_interval: Decimal = Field(..., title="Inter trial interval (s)")
     inter_spiral_interval_unit: TimeUnit = Field(TimeUnit.S, title="Inter trial interval unit")
-    other_parameters: Dict[str, Any] = Field({})
+    other_parameters: AindGenericType = Field(AindGeneric(), title="Other parameters")
     notes: Optional[str] = Field(None, title="Notes")
 
 
@@ -134,7 +134,7 @@ class PhotoStimulation(AindModel):
     groups: List[PhotoStimulationGroup] = Field(..., title="Groups")
     inter_trial_interval: Decimal = Field(..., title="Inter trial interval (s)")
     inter_trial_interval_unit: TimeUnit = Field(TimeUnit.S, title="Inter trial interval unit")
-    other_parameters: Dict[str, Any] = Field(dict())
+    other_parameters: AindGenericType = Field(AindGeneric(), title="Other parameters")
     notes: Optional[str] = Field(None, title="Notes")
 
 

--- a/src/aind_data_schema/models/stimulus.py
+++ b/src/aind_data_schema/models/stimulus.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from decimal import Decimal
 from enum import Enum
-from typing import Generic, List, Literal, Optional, Union
+from typing import List, Literal, Optional, Union
 
 from pydantic import Field
 from typing_extensions import Annotated

--- a/tests/test_imaging.py
+++ b/tests/test_imaging.py
@@ -14,7 +14,6 @@ from aind_data_schema.core.processing import Registration
 from aind_data_schema.imaging import tile
 from aind_data_schema.models.coordinates import (
     Affine3dTransform,
-    ImageAxis,
     Rotation3dTransform,
     Scale3dTransform,
     Translation3dTransform,


### PR DESCRIPTION
This PR replaces all the instances of the type `Dict[str, Any]` with the new Generic base class added to the core module. This class, `AindGeneric`, will allow easy sub-classing while guaranteeing consistent dict-like deserialization from the original base class.

The recommend pattern is:

```python
from pydantic import Field
from aind_data_schema.base import AindGeneric, AindGenericType, AindModel

class Foo(AindModel, Generic[AindGenericType]):
    """Generic Foo class"""
    Bar: AindGenericType = Field(..., description="Baz", title="bar")
```

For more information see #692 

---

Additionally, a small change to the `Device` class was made to ensure consistency across the `additional_settings` schema pattern.
