### PR TITLE
fix error in ephys_rig.json

### DIFF
--- a/examples/ephys_rig.json
+++ b/examples/ephys_rig.json
@@ -621,7 +621,6 @@
    ],
    "ccf_coordinate_transform": null,
    "origin": null,
-   "rig_axes": [],
    "modalities": [
       {
          "name": "Extracellular electrophysiology",


### PR DESCRIPTION
"rig_axes: []" violates the schema, which specifies a minimum length of 3. The underlying issue is the model, which has [] as a default where the default should instead be `None`.