### PR TITLE
bugfix to MRIScan.validate_primary_scan, add return self

### DIFF
--- a/src/aind_data_schema/core/mri_session.py
+++ b/src/aind_data_schema/core/mri_session.py
@@ -85,6 +85,8 @@ class MRIScan(AindModel):
         if self.primary_scan:
             if not self.vc_orientation or not self.vc_position or not self.voxel_sizes:
                 raise ValueError("Primary scan must have vc_orientation, vc_position, and voxel_sizes fields")
+            
+        return self
 
 
 class MriSession(AindCoreModel):

--- a/src/aind_data_schema/core/mri_session.py
+++ b/src/aind_data_schema/core/mri_session.py
@@ -85,7 +85,7 @@ class MRIScan(AindModel):
         if self.primary_scan:
             if not self.vc_orientation or not self.vc_position or not self.voxel_sizes:
                 raise ValueError("Primary scan must have vc_orientation, vc_position, and voxel_sizes fields")
-            
+
         return self
 
 


### PR DESCRIPTION
closes #825 

adds a line to `return self` to the end of `MRIScan.validate_primary_scan`