### PR TITLE
adding example for MRISession

### DIFF
--- a/examples/mri_session.json
+++ b/examples/mri_session.json
@@ -5,17 +5,17 @@
    "session_start_time": "2024-03-12T16:27:55.584892",
    "session_end_time": "2024-03-12T16:27:55.584892",
    "experimenter_full_name": [
-      "test"
+      "Allen Brain"
    ],
-   "protocol_id": "",
-   "iacuc_protocol": "",
+   "protocol_id": "dx.doi.org/10.57824/protocols.io.bh7kl4n6",
+   "iacuc_protocol": "12345",
    "animal_weight_prior": null,
    "animal_weight_post": null,
    "weight_unit": "gram",
    "anaesthesia": null,
    "mri_scanner": {
       "device_type": "Scanner",
-      "name": "test_scanner",
+      "name": "Scanner 72",
       "serial_number": null,
       "manufacturer": null,
       "model": null,
@@ -31,5 +31,5 @@
       null,
       null
    ],
-   "notes": "none"
+   "notes": "There was some information about this scan session"
 }

--- a/examples/mri_session.json
+++ b/examples/mri_session.json
@@ -1,0 +1,35 @@
+{
+   "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/mri_session.py",
+   "schema_version": "0.3.4",
+   "subject_id": "",
+   "session_start_time": "2024-03-12T16:27:55.584892",
+   "session_end_time": "2024-03-12T16:27:55.584892",
+   "experimenter_full_name": [
+      "test"
+   ],
+   "protocol_id": "",
+   "iacuc_protocol": "",
+   "animal_weight_prior": null,
+   "animal_weight_post": null,
+   "weight_unit": "gram",
+   "anaesthesia": null,
+   "mri_scanner": {
+      "device_type": "Scanner",
+      "name": "test_scanner",
+      "serial_number": null,
+      "manufacturer": null,
+      "model": null,
+      "path_to_cad": null,
+      "port_index": null,
+      "additional_settings": {},
+      "notes": null,
+      "scanner_location": "Fred Hutch",
+      "magnetic_strength": 7,
+      "magnetic_strength_unit": "T"
+   },
+   "scans": [
+      null,
+      null
+   ],
+   "notes": "none"
+}

--- a/examples/mri_session.py
+++ b/examples/mri_session.py
@@ -1,0 +1,64 @@
+from aind_data_schema.models.coordinates import Rotation3dTransform, Scale3dTransform, Translation3dTransform
+from aind_data_schema.core.mri_session import MRIScan, MriSession, MriScanSequence, ScanType, SubjectPosition
+from decimal import Decimal
+from aind_data_schema.models.units import MassUnit, TimeUnit
+from aind_data_schema.models.devices import Scanner, ScannerLocation, MagneticStrength
+from datetime import datetime
+
+import traceback
+
+
+scan1 = MRIScan(
+    scan_index="1",
+    scan_type=ScanType.SETUP,
+    primary_scan=False,
+    scan_sequence_type=MriScanSequence.RARE,
+    rare_factor=8,
+    echo_time=Decimal(3.42),
+    repetition_time=Decimal(100.0),
+    subject_position=SubjectPosition.SUPINE,
+    voxel_sizes=Scale3dTransform(scale=[0.5, 0.4375, 0.52]),
+    processing_steps=[],
+    additional_scan_parameters={},
+    notes=None,
+)  
+
+scan2 = MRIScan(
+    scan_index="2",
+    scan_type=ScanType.SCAN_3D,
+    primary_scan=True,
+    scan_sequence_type=MriScanSequence.RARE,
+    rare_factor=4,
+    echo_time=Decimal(5.33333333333333),
+    effective_echo_time=Decimal(10.6666666666666998253276688046753406524658203125),
+    repetition_time=Decimal(500.0),
+    vc_orientation=Rotation3dTransform(rotation=[1.0, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1.0, 0.0]),
+    vc_position=Translation3dTransform(translation=[-6.1, -7.0, 7.9]),
+    subject_position=SubjectPosition.SUPINE,
+    voxel_sizes=Scale3dTransform(scale=[0.1, 0.1, 0.1]),
+    processing_steps=[],
+    additional_scan_parameters={},
+    notes=None,
+)
+
+scans = [scan1, scan2]
+
+
+
+sess = MriSession(
+    subject_id="",
+    session_start_time="2024-03-12T16:27:55.584892", 
+    session_end_time="2024-03-12T16:27:55.584892",
+    experimenter_full_name=["test"], 
+    protocol_id="",
+    iacuc_protocol="",
+    mri_scanner=Scanner(
+        name="test_scanner",
+        scanner_location="Fred Hutch",
+        magnetic_strength="7", 
+    ),
+    scans=scans,
+    notes="none"
+)
+
+sess.write_standard_file()

--- a/examples/mri_session.py
+++ b/examples/mri_session.py
@@ -1,3 +1,4 @@
+"""example MRISession and MRIScan"""
 from decimal import Decimal
 
 from aind_data_schema.core.mri_session import MRIScan, MriScanSequence, MriSession, ScanType, SubjectPosition

--- a/examples/mri_session.py
+++ b/examples/mri_session.py
@@ -1,12 +1,8 @@
-from aind_data_schema.models.coordinates import Rotation3dTransform, Scale3dTransform, Translation3dTransform
-from aind_data_schema.core.mri_session import MRIScan, MriSession, MriScanSequence, ScanType, SubjectPosition
 from decimal import Decimal
-from aind_data_schema.models.units import MassUnit, TimeUnit
-from aind_data_schema.models.devices import Scanner, ScannerLocation, MagneticStrength
-from datetime import datetime
 
-import traceback
-
+from aind_data_schema.core.mri_session import MRIScan, MriScanSequence, MriSession, ScanType, SubjectPosition
+from aind_data_schema.models.coordinates import Rotation3dTransform, Scale3dTransform, Translation3dTransform
+from aind_data_schema.models.devices import Scanner
 
 scan1 = MRIScan(
     scan_index="1",
@@ -21,7 +17,7 @@ scan1 = MRIScan(
     processing_steps=[],
     additional_scan_parameters={},
     notes=None,
-)  
+)
 
 scan2 = MRIScan(
     scan_index="2",
@@ -43,19 +39,17 @@ scan2 = MRIScan(
 
 scans = [scan1, scan2]
 
-
-
 sess = MriSession(
     subject_id="",
-    session_start_time="2024-03-12T16:27:55.584892", 
+    session_start_time="2024-03-12T16:27:55.584892",
     session_end_time="2024-03-12T16:27:55.584892",
-    experimenter_full_name=["test"], 
+    experimenter_full_name=["test"],
     protocol_id="",
     iacuc_protocol="",
     mri_scanner=Scanner(
         name="test_scanner",
         scanner_location="Fred Hutch",
-        magnetic_strength="7", 
+        magnetic_strength="7",
     ),
     scans=scans,
     notes="none"

--- a/examples/mri_session.py
+++ b/examples/mri_session.py
@@ -17,7 +17,7 @@ scan1 = MRIScan(
     voxel_sizes=Scale3dTransform(scale=[0.5, 0.4375, 0.52]),
     processing_steps=[],
     additional_scan_parameters={},
-    notes=None,
+    notes="Set up scan for the 3D scan.",
 )
 
 scan2 = MRIScan(
@@ -44,16 +44,16 @@ sess = MriSession(
     subject_id="",
     session_start_time="2024-03-12T16:27:55.584892",
     session_end_time="2024-03-12T16:27:55.584892",
-    experimenter_full_name=["test"],
-    protocol_id="",
-    iacuc_protocol="",
+    experimenter_full_name=["Allen Brain"],
+    protocol_id="dx.doi.org/10.57824/protocols.io.bh7kl4n6",
+    iacuc_protocol="12345",
     mri_scanner=Scanner(
-        name="test_scanner",
+        name="Scanner 72",
         scanner_location="Fred Hutch",
         magnetic_strength="7",
     ),
     scans=scans,
-    notes="none"
+    notes="There was some information about this scan session"
 )
 
 sess.write_standard_file()

--- a/examples/multiplane_ophys_session.py
+++ b/examples/multiplane_ophys_session.py
@@ -2,9 +2,9 @@
 
 import datetime
 
-from aind_data_schema.core.session import FieldOfView, Session, Stream, LaserConfig
+from aind_data_schema.core.session import FieldOfView, LaserConfig, Session, Stream
 from aind_data_schema.models.modalities import Modality
-from aind_data_schema.models.units import SizeUnit, PowerUnit
+from aind_data_schema.models.units import PowerUnit, SizeUnit
 
 t = datetime.datetime(2022, 7, 12, 7, 00, 00)
 


### PR DESCRIPTION
closes #827 

Adds an example for `MRISession`, which includes examples of `MRIScan`. Will need to be updated when the validator change in #825 goes through, to include non-null scans.