### PR TITLE
Feat: Add Harp.StepperDriver device metadata

### DIFF
--- a/src/aind_data_schema/models/harp_types.py
+++ b/src/aind_data_schema/models/harp_types.py
@@ -119,6 +119,13 @@ class Cuttlefish(_HarpDeviceType):
     whoami: Literal[1403] = 1403
 
 
+class StepperDriver(_HarpDeviceType):
+    """Stepper Driver"""
+
+    name: Literal["Stepper Driver"] = "Stepper Driver"
+    whoami: Literal[1130] = 1130
+
+
 class HarpDeviceType:
     """Harp device type definitions"""
 
@@ -137,6 +144,7 @@ class HarpDeviceType:
     SNIFF_DETECTOR = SniffDetector()
     TREADMILL = Treadmill()
     CUTTLEFISH = Cuttlefish()
+    STEPPER_DRIVER = StepperDriver()
 
     _ALL = tuple(_HarpDeviceType.__subclasses__())
     ONE_OF = Annotated[Union[_ALL], Field(discriminator="name")]


### PR DESCRIPTION
This PR adds metadata information on the new stepper driver motor we are using to drive the new AIND manipulators. 

Relevant documentation can be found here: https://github.com/harp-tech/device.stepperdriver

Additional internal documentation will be posted and maintained in the Bonsai-Aind website (https://allenneuraldynamics.github.io/Bonsai.AllenNeuralDynamics/index.html)
