### PR TITLE
fix: removes erd tests from local cov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,4 @@ jobs:
         sudo apt install graphviz libgraphviz-dev -y
         python -m pip install -e .[dev] -e .[docs] --no-cache-dir
     - name: Run tests and coverage
-      run: coverage run -m unittest discover && coverage report
+      run: coverage run --omit "*__init__*" -m unittest discover && coverage report

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,11 @@ exclude = '''
 '''
 
 [tool.coverage.run]
-omit = ["*__init__*"]
+omit = [
+    "*__init__*",
+    "*/aind_data_schema/utils/diagrams.py",
+    "*/tests/test_diagram_builder.py"
+]
 source = ["aind_data_schema", "tests"]
 
 [tool.coverage.report]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ docs = [
     'Sphinx',
     'sphinx-jinja',
     'furo',
-    'erdantic>=0.7.0',
+    'erdantic>=0.7.0,<1.0',
     'autodoc_pydantic'
 ]
 


### PR DESCRIPTION
Closes #878 

- Omits running erdantic tests locally
- Still runs erdantic tests during Pull Requests
- Adds constraint to erdantic version since >=1.0 seems to break things