### PR TITLE
feat 933 removing SpecimenProcedureType from procedures

### DIFF
--- a/src/aind_data_schema/core/procedures.py
+++ b/src/aind_data_schema/core/procedures.py
@@ -18,6 +18,8 @@ from aind_data_schema_models.units import (
     VolumeUnit,
     create_unit_with_value,
 )
+from aind_data_schema_models.specimen_procedure_types import SpecimenProcedureType
+
 from pydantic import Field, field_validator, model_validator
 from pydantic_core.core_schema import ValidationInfo
 from typing_extensions import Annotated
@@ -25,27 +27,6 @@ from typing_extensions import Annotated
 from aind_data_schema.base import AindCoreModel, AindModel, AwareDatetimeWithDefault
 from aind_data_schema.components.devices import FiberProbe
 from aind_data_schema.components.reagent import Reagent
-
-
-class SpecimenProcedureType(str, Enum):
-    """Names for general specimen procedures"""
-
-    DELIPIDATION = "Delipidation"
-    CLEARING = "Clearing"
-    EMBEDDING = "Embedding"
-    FIXATION = "Fixation"
-    FIXATION_PERMEABILIZATION = "Fixation and permeabilization"
-    GELATION = "Gelation"
-    HYBRIDIZATION_AMPLIFICATION = "Hybridication and amplification"
-    HCR = "Hybridization Chain Reaction"
-    IMMUNOLABELING = "Immunolabeling"
-    MOUNTING = "Mounting"
-    SECTIONING = "Sectioning"
-    SOAK = "Soak"
-    STORAGE = "Storage"
-    STRIPPING = "Stripping"
-    REFRACTIVE_INDEX_MATCHING = "Refractive index matching"
-    OTHER = "Other - see notes"
 
 
 class ImmunolabelClass(str, Enum):


### PR DESCRIPTION
closes #933 

Paired with PR: https://github.com/AllenNeuralDynamics/aind-data-schema-models/pull/8

Removes the `SpecimenProcedureType` enum from `aind-data-schema` and places it in `aind-data-schema-models`