### PR TITLE
Feat 952 examples generator

### DIFF
--- a/examples/aibs_smartspim_instrument.py
+++ b/examples/aibs_smartspim_instrument.py
@@ -16,6 +16,8 @@ from aind_data_schema.components.devices import (
 )
 from aind_data_schema.core.instrument import Com, Instrument
 
+OUTPUT_PATH = "examples/"
+
 inst = Instrument(
     instrument_id="440_SmartSPIM2_20231004",
     modification_date=datetime.date(2023, 10, 4),
@@ -211,4 +213,4 @@ inst = Instrument(
 )
 serialized = inst.model_dump_json()
 deserialized = Instrument.model_validate_json(serialized)
-deserialized.write_standard_file(prefix="aibs_smartspim")
+deserialized.write_standard_file(prefix="aibs_smartspim", output_directory=OUTPUT_PATH)

--- a/examples/aibs_smartspim_procedures.py
+++ b/examples/aibs_smartspim_procedures.py
@@ -6,6 +6,8 @@ from aind_data_schema_models.organizations import Organization
 
 from aind_data_schema.core import procedures
 
+OUTPUT_PATH = "examples/"
+
 experimenter = "John Smith"
 # subject and specimen id can be the same?
 specimen_id = "651286"
@@ -161,4 +163,4 @@ all_procedures = procedures.Procedures(
 
 serialized = all_procedures.model_dump_json()
 deserialized = procedures.Procedures.model_validate_json(serialized)
-deserialized.write_standard_file(prefix="aibs_smartspim")
+deserialized.write_standard_file(prefix="aibs_smartspim", output_directory=OUTPUT_PATH)

--- a/examples/aind_smartspim_instrument.py
+++ b/examples/aind_smartspim_instrument.py
@@ -7,6 +7,8 @@ from aind_data_schema_models.organizations import Organization
 from aind_data_schema.components.devices import Filter, Laser, MotorizedStage, OpticalTable, ScanningStage
 from aind_data_schema.core.instrument import Com, Detector, Instrument, Objective
 
+OUTPUT_PATH = "examples/"
+
 inst = Instrument(
     instrument_id="440_SmartSPIM1_20231004",
     instrument_type="SmartSPIM",
@@ -255,4 +257,4 @@ inst = Instrument(
 
 serialized = inst.model_dump_json()
 deserialized = Instrument.model_validate_json(serialized)
-deserialized.write_standard_file(prefix="aind_smartspim")
+deserialized.write_standard_file(prefix="aind_smartspim", output_directory=OUTPUT_PATH)

--- a/examples/bergamo_ophys_session.py
+++ b/examples/bergamo_ophys_session.py
@@ -15,6 +15,8 @@ from aind_data_schema.core.session import (
     Stream,
 )
 
+OUTPUT_PATH = "examples/"
+
 # If a timezone isn't specified, the timezone of the computer running this
 # script will be used as default
 t = datetime(2022, 7, 12, 7, 00, 00, tzinfo=timezone.utc)
@@ -107,4 +109,4 @@ s = Session(
 
 serialized = s.model_dump_json()
 deserialized = Session.model_validate_json(serialized)
-deserialized.write_standard_file(prefix="bergamo_ophys")
+deserialized.write_standard_file(prefix="bergamo_ophys", output_directory=OUTPUT_PATH)

--- a/examples/data_description.py
+++ b/examples/data_description.py
@@ -9,6 +9,8 @@ from aind_data_schema_models.platforms import Platform
 
 from aind_data_schema.core.data_description import Funding, RawDataDescription
 
+OUTPUT_PATH = "examples/"
+
 d = RawDataDescription(
     modality=[Modality.ECEPHYS, Modality.BEHAVIOR_VIDEOS],
     platform=Platform.ECEPHYS,
@@ -21,4 +23,4 @@ d = RawDataDescription(
 
 serialized = d.model_dump_json()
 deserialized = RawDataDescription.model_validate_json(serialized)
-deserialized.write_standard_file()
+deserialized.write_standard_file(output_directory=OUTPUT_PATH)

--- a/examples/ephys_rig.py
+++ b/examples/ephys_rig.py
@@ -28,6 +28,8 @@ from aind_data_schema.components.devices import (
 )
 from aind_data_schema.core.rig import Rig
 
+OUTPUT_PATH = "examples/"
+
 # Describes a rig with running wheel, 2 behavior cameras, one Harp Behavior board,
 # one dual-color laser module, one stick microscope, and 2 Neuropixels probes
 
@@ -213,4 +215,4 @@ rig = Rig(
 )
 serialized = rig.model_dump_json()
 deserialized = Rig.model_validate_json(serialized)
-deserialized.write_standard_file(prefix="ephys")
+deserialized.write_standard_file(prefix="ephys", output_directory=OUTPUT_PATH)

--- a/examples/ephys_session.py
+++ b/examples/ephys_session.py
@@ -17,6 +17,8 @@ from aind_data_schema.core.session import (
     VisualStimulation,
 )
 
+OUTPUT_PATH = "examples/"
+
 session = Session(
     experimenter_full_name=["Max Quibble", "Finn Tickle"],
     subject_id="664484",
@@ -221,4 +223,4 @@ session = Session(
 
 serialized = session.model_dump_json()
 deserialized = Session.model_validate_json(serialized)
-deserialized.write_standard_file(prefix="ephys")
+deserialized.write_standard_file(prefix="ephys", output_directory=OUTPUT_PATH)

--- a/examples/exaspim_acquisition.py
+++ b/examples/exaspim_acquisition.py
@@ -13,6 +13,8 @@ from aind_data_schema.components.devices import Calibration, Maintenance
 from aind_data_schema.core import acquisition
 from aind_data_schema.core.procedures import Reagent
 
+OUTPUT_PATH = "examples/"
+
 # If a timezone isn't specified, the timezone of the computer running this
 # script will be used as default
 t = datetime(2022, 11, 22, 8, 43, 00, tzinfo=timezone.utc)
@@ -113,4 +115,4 @@ acq = acquisition.Acquisition(
 
 serialized = acq.model_dump_json()
 deserialized = acquisition.Acquisition.model_validate_json(serialized)
-deserialized.write_standard_file(prefix="exaspim")
+deserialized.write_standard_file(prefix="exaspim", output_directory=OUTPUT_PATH)

--- a/examples/exaspim_instrument.py
+++ b/examples/exaspim_instrument.py
@@ -7,6 +7,8 @@ from aind_data_schema_models.organizations import Organization
 from aind_data_schema.components.devices import DAQChannel, DAQDevice, Detector, Filter, Laser
 from aind_data_schema.core import instrument
 
+OUTPUT_PATH = "examples/"
+
 inst = instrument.Instrument(
     instrument_id="440_exaSPIM1-20231004",
     instrument_type="exaSPIM",
@@ -205,4 +207,4 @@ inst = instrument.Instrument(
 )
 serialized = inst.model_dump_json()
 deserialized = instrument.Instrument.model_validate_json(serialized)
-deserialized.write_standard_file(prefix="exaspim")
+deserialized.write_standard_file(prefix="exaspim", output_directory=OUTPUT_PATH)

--- a/examples/fip_behavior_rig.py
+++ b/examples/fip_behavior_rig.py
@@ -8,6 +8,8 @@ from aind_data_schema_models.modalities import Modality
 import aind_data_schema.components.devices as d
 import aind_data_schema.core.rig as r
 
+OUTPUT_PATH = "examples/"
+
 r = r.Rig(
     rig_id="447_FIP_Behavior_20000101",
     modification_date=date(2000, 1, 1),
@@ -340,4 +342,4 @@ r = r.Rig(
     ],
 )
 
-r.write_standard_file(prefix="fip_behavior")
+r.write_standard_file(prefix="fip_behavior", output_directory=OUTPUT_PATH)

--- a/examples/fip_ophys_rig.py
+++ b/examples/fip_ophys_rig.py
@@ -7,6 +7,8 @@ from aind_data_schema_models.modalities import Modality
 import aind_data_schema.components.devices as d
 import aind_data_schema.core.rig as r
 
+OUTPUT_PATH = "examples/"
+
 rig = r.Rig(
     rig_id="428_FIP1_20231003",
     modification_date=date(2023, 10, 3),
@@ -284,4 +286,4 @@ rig = r.Rig(
 )
 serialized = rig.model_dump_json()
 deserialized = r.Rig.model_validate_json(serialized)
-deserialized.write_standard_file(prefix="fip_ophys")
+deserialized.write_standard_file(prefix="fip_ophys", output_directory=OUTPUT_PATH)

--- a/examples/mri_session.py
+++ b/examples/mri_session.py
@@ -8,6 +8,8 @@ from aind_data_schema.components.coordinates import Rotation3dTransform, Scale3d
 from aind_data_schema.components.devices import Scanner
 from aind_data_schema.core.session import MRIScan, MriScanSequence, ScanType, Session, Stream, SubjectPosition
 
+OUTPUT_PATH = "examples/"
+
 scan1 = MRIScan(
     scan_index="1",
     mri_scanner=Scanner(
@@ -74,4 +76,4 @@ sess = Session(
 )
 serialized = sess.model_dump_json()
 deserialized = Session.model_validate_json(serialized)
-deserialized.write_standard_file(prefix="mri")
+deserialized.write_standard_file(prefix="mri", output_directory=OUTPUT_PATH)

--- a/examples/multiplane_ophys_session.py
+++ b/examples/multiplane_ophys_session.py
@@ -7,6 +7,8 @@ from aind_data_schema_models.units import PowerUnit, SizeUnit
 
 from aind_data_schema.core.session import FieldOfView, LaserConfig, Session, Stream
 
+OUTPUT_PATH = "examples/"
+
 # If a timezone isn't specified, the timezone of the computer running this
 # script will be used as default
 t = datetime(2022, 7, 12, 7, 00, 00, tzinfo=timezone.utc)
@@ -202,4 +204,4 @@ s = Session(
 )
 serialized = s.model_dump_json()
 deserialized = Session.model_validate_json(serialized)
-deserialized.write_standard_file(prefix="multiplane_ophys")
+deserialized.write_standard_file(prefix="multiplane_ophys", output_directory=OUTPUT_PATH)

--- a/examples/ophys_procedures.py
+++ b/examples/ophys_procedures.py
@@ -22,6 +22,8 @@ from aind_data_schema.core.procedures import (
     WaterRestriction,
 )
 
+OUTPUT_PATH = "examples/"
+
 t = datetime.datetime(2022, 7, 12, 7, 00, 00)
 t2 = datetime.datetime(2022, 9, 23, 10, 22, 00)
 
@@ -164,4 +166,4 @@ p = Procedures(
 )
 serialized = p.model_dump_json()
 deserialized = Procedures.model_validate_json(serialized)
-deserialized.write_standard_file(prefix="ophys")
+deserialized.write_standard_file(prefix="ophys", output_directory=OUTPUT_PATH)

--- a/examples/ophys_session.py
+++ b/examples/ophys_session.py
@@ -6,6 +6,8 @@ from aind_data_schema_models.modalities import Modality
 
 from aind_data_schema.core.session import DetectorConfig, FiberConnectionConfig, LaserConfig, Session, Stream
 
+OUTPUT_PATH = "examples/"
+
 t = datetime(2022, 7, 12, 7, 00, 00, tzinfo=timezone.utc)
 
 s = Session(
@@ -60,4 +62,4 @@ s = Session(
 )
 serialized = s.model_dump_json()
 deserialized = Session.model_validate_json(serialized)
-deserialized.write_standard_file(prefix="ophys")
+deserialized.write_standard_file(prefix="ophys", output_directory=OUTPUT_PATH)

--- a/examples/procedures.py
+++ b/examples/procedures.py
@@ -13,6 +13,8 @@ from aind_data_schema.core.procedures import (
     ViralMaterial,
 )
 
+OUTPUT_PATH = "examples/"
+
 # If a timezone isn't specified, the timezone of the computer running this
 # script will be used as default
 t = datetime(2022, 7, 12, 7, 00, 00, tzinfo=timezone.utc)
@@ -81,4 +83,4 @@ p = Procedures(
 )
 serialized = p.model_dump_json()
 deserialized = Procedures.model_validate_json(serialized)
-deserialized.write_standard_file()
+deserialized.write_standard_file(output_directory=OUTPUT_PATH)

--- a/examples/processing.py
+++ b/examples/processing.py
@@ -4,6 +4,8 @@ from datetime import datetime, timezone
 
 from aind_data_schema.core.processing import AnalysisProcess, DataProcess, PipelineProcess, Processing, ProcessName
 
+OUTPUT_PATH = "examples/"
+
 # If a timezone isn't specified, the timezone of the computer running this
 # script will be used as default
 t = datetime(2022, 11, 22, 8, 43, 00, tzinfo=timezone.utc)
@@ -80,4 +82,4 @@ p = Processing(
 )
 serialized = p.model_dump_json()
 deserialized = Processing.model_validate_json(serialized)
-p.write_standard_file()
+p.write_standard_file(output_directory=OUTPUT_PATH)

--- a/examples/subject.json
+++ b/examples/subject.json
@@ -12,7 +12,7 @@
          "name": "National Center for Biotechnology Information",
          "abbreviation": "NCBI"
       },
-      "registry_identifier": "10090"
+      "registry_identifier": "NCBI:txid10090"
    },
    "alleles": [],
    "background_strain": "C57BL/6J",

--- a/examples/subject.py
+++ b/examples/subject.py
@@ -7,6 +7,8 @@ from aind_data_schema_models.species import Species
 
 from aind_data_schema.core.subject import BreedingInfo, Housing, Sex, Subject
 
+OUTPUT_PATH = "examples/"
+
 # If a timezone isn't specified, the timezone of the computer running this
 # script will be used as default
 t = datetime(2022, 11, 22, 8, 43, 00, tzinfo=timezone.utc)
@@ -30,4 +32,4 @@ s = Subject(
 )
 serialized = s.model_dump_json()
 deserialized = Subject.model_validate_json(serialized)
-deserialized.write_standard_file()
+deserialized.write_standard_file(output_directory=OUTPUT_PATH)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 dynamic = ["version"]
 
 dependencies = [
-    'aind-data-schema-models>=0.1.1',
+    'aind-data-schema-models>=0.1.7',
     'dictdiffer',
     'pydantic>2.0,<2.7',
     'inflection',

--- a/src/aind_data_schema/core/procedures.py
+++ b/src/aind_data_schema/core/procedures.py
@@ -19,8 +19,7 @@ from aind_data_schema_models.units import (
     VolumeUnit,
     create_unit_with_value,
 )
-from pydantic import Field, field_validator, model_validator, field_serializer
-
+from pydantic import Field, field_serializer, field_validator, model_validator
 from pydantic_core.core_schema import ValidationInfo
 from typing_extensions import Annotated
 

--- a/src/aind_data_schema/core/rig.py
+++ b/src/aind_data_schema/core/rig.py
@@ -4,7 +4,7 @@ from datetime import date
 from typing import List, Literal, Optional, Set, Union
 
 from aind_data_schema_models.modalities import Modality
-from pydantic import Field, ValidationInfo, field_validator, model_validator, field_serializer
+from pydantic import Field, ValidationInfo, field_serializer, field_validator, model_validator
 from typing_extensions import Annotated
 
 from aind_data_schema.base import AindCoreModel

--- a/src/aind_data_schema/core/session.py
+++ b/src/aind_data_schema/core/session.py
@@ -514,8 +514,9 @@ class StimulusEpoch(AindModel):
     ] = Field(None, title="Stimulus parameters")
     stimulus_device_names: List[str] = Field(default=[], title="Stimulus devices")
     speaker_config: Optional[SpeakerConfig] = Field(default=None, title="Speaker Config")
-    light_source_config: Optional[List[LIGHT_SOURCE_CONFIGS]] = Field(default=[], title="Light source config",
-                                                                      description="Light sources for stimulation")
+    light_source_config: Optional[List[LIGHT_SOURCE_CONFIGS]] = Field(
+        default=[], title="Light source config", description="Light sources for stimulation"
+    )
     output_parameters: AindGenericType = Field(AindGeneric(), title="Performance metrics")
     reward_consumed_during_epoch: Optional[Decimal] = Field(default=None, title="Reward consumed during training (uL)")
     reward_consumed_unit: VolumeUnit = Field(VolumeUnit.UL, title="Reward consumed unit")

--- a/src/aind_data_schema/utils/examples_generator.py
+++ b/src/aind_data_schema/utils/examples_generator.py
@@ -15,4 +15,3 @@ if __name__ == '__main__':
     for example_file in glob(f"{EXAMPLES_DIR}/*.py"):
         print(f"Running {example_file}")
         runpy.run_path(path_name=example_file)
-

--- a/src/aind_data_schema/utils/examples_generator.py
+++ b/src/aind_data_schema/utils/examples_generator.py
@@ -9,8 +9,22 @@ CURRENT_DIR = Path(os.path.dirname(os.path.realpath(__file__)))
 ROOT_DIR = CURRENT_DIR.parents[2]
 EXAMPLES_DIR = ROOT_DIR / "examples"
 
-if __name__ == "__main__":
-    print(f"Running all examples in {EXAMPLES_DIR}")
-    for example_file in glob(f"{EXAMPLES_DIR}/*.py"):
+class ExamplesGenerator():
+    def __init__(self):
+        pass
+
+    def generate_all_examples(self):
+        print(f"Running all examples in {EXAMPLES_DIR}")
+        for example_file in glob(f"{EXAMPLES_DIR}/*.py"):
+            print(f"Running {example_file}")
+            runpy.run_path(path_name=example_file)
+    
+    def generate_example(self, example_file):
         print(f"Running {example_file}")
-        runpy.run_path(path_name=example_file)
+        try:
+            runpy.run_path(path_name=example_file)
+        except Exception as e:
+            print(f"Error running {example_file}: {e}")
+
+if __name__ == "__main__":
+    ExamplesGenerator().generate_all_examples()

--- a/src/aind_data_schema/utils/examples_generator.py
+++ b/src/aind_data_schema/utils/examples_generator.py
@@ -1,0 +1,18 @@
+"""script for re-generating all examples"""
+
+import runpy
+from glob import glob
+from pathlib import Path
+import os
+
+CURRENT_DIR = Path(os.path.dirname(os.path.realpath(__file__)))
+ROOT_DIR = CURRENT_DIR.parents[2]
+EXAMPLES_DIR = ROOT_DIR / "examples"
+
+if __name__ == '__main__':
+
+    print(f"Running all examples in {EXAMPLES_DIR}")
+    for example_file in glob(f"{EXAMPLES_DIR}/*.py"):
+        print(f"Running {example_file}")
+        runpy.run_path(path_name=example_file)
+

--- a/src/aind_data_schema/utils/examples_generator.py
+++ b/src/aind_data_schema/utils/examples_generator.py
@@ -4,6 +4,7 @@ import os
 import runpy
 from glob import glob
 from pathlib import Path
+import logging
 
 CURRENT_DIR = Path(os.path.dirname(os.path.realpath(__file__)))
 ROOT_DIR = CURRENT_DIR.parents[2]
@@ -16,19 +17,19 @@ class ExamplesGenerator:
     def generate_all_examples(self):
         """Generate all examples in EXAMPLES_DIR"""
 
-        print(f"Running all examples in {EXAMPLES_DIR}")
+        logging.info(f"Running all examples in {EXAMPLES_DIR}")
         for example_file in glob(f"{EXAMPLES_DIR}/*.py"):
-            print(f"Running {example_file}")
+            logging.info(f"Running {example_file}")
             runpy.run_path(path_name=example_file)
 
     def generate_example(self, example_file):
         """Generate example from example_file"""
 
-        print(f"Running {example_file}")
+        logging.info(f"Running {example_file}")
         try:
             runpy.run_path(path_name=example_file)
         except Exception as e:
-            print(f"Error running {example_file}: {e}")
+            logging.info(f"Error running {example_file}: {e}")
 
 
 if __name__ == "__main__":

--- a/src/aind_data_schema/utils/examples_generator.py
+++ b/src/aind_data_schema/utils/examples_generator.py
@@ -1,16 +1,15 @@
 """script for re-generating all examples"""
 
+import os
 import runpy
 from glob import glob
 from pathlib import Path
-import os
 
 CURRENT_DIR = Path(os.path.dirname(os.path.realpath(__file__)))
 ROOT_DIR = CURRENT_DIR.parents[2]
 EXAMPLES_DIR = ROOT_DIR / "examples"
 
-if __name__ == '__main__':
-
+if __name__ == "__main__":
     print(f"Running all examples in {EXAMPLES_DIR}")
     for example_file in glob(f"{EXAMPLES_DIR}/*.py"):
         print(f"Running {example_file}")

--- a/src/aind_data_schema/utils/examples_generator.py
+++ b/src/aind_data_schema/utils/examples_generator.py
@@ -9,22 +9,28 @@ CURRENT_DIR = Path(os.path.dirname(os.path.realpath(__file__)))
 ROOT_DIR = CURRENT_DIR.parents[2]
 EXAMPLES_DIR = ROOT_DIR / "examples"
 
-class ExamplesGenerator():
-    def __init__(self):
-        pass
+
+class ExamplesGenerator:
+    """Class to generate example files from .py files in examples directory"""
 
     def generate_all_examples(self):
+        """Generate all examples in EXAMPLES_DIR"""
+
         print(f"Running all examples in {EXAMPLES_DIR}")
         for example_file in glob(f"{EXAMPLES_DIR}/*.py"):
             print(f"Running {example_file}")
             runpy.run_path(path_name=example_file)
-    
+
     def generate_example(self, example_file):
+        """Generate example from example_file"""
+
         print(f"Running {example_file}")
         try:
             runpy.run_path(path_name=example_file)
         except Exception as e:
             print(f"Error running {example_file}: {e}")
 
+
 if __name__ == "__main__":
+    """Run all examples in EXAMPLES_DIR"""
     ExamplesGenerator().generate_all_examples()

--- a/tests/test_examples_generator.py
+++ b/tests/test_examples_generator.py
@@ -9,15 +9,20 @@ from aind_data_schema.utils.examples_generator import ExamplesGenerator
 class ExamplesGeneratorTest(unittest.TestCase):
     """Tests for ExamplesGenerator methods"""
 
-    @patch("AindCoreModel.write_standard_file()")
-    def test_generate_all_files(self):
+    @patch("aind_data_schema.base.AindCoreModel.write_standard_file")
+    def test_generate_all_files(self, mocked_run_path):
         """Test generate_all_examples method"""
 
         ExamplesGenerator().generate_all_examples()
 
-    def test_generate_example(self):
+    @patch("aind_data_schema.base.AindCoreModel.write_standard_file")
+    def test_generate_example(self, mocked_run_path):
         """Test generate_example method"""
 
         ExamplesGenerator().generate_example(
             "C:/Users/mae.moninghoff/Documents/GitHub/aind-data-schema/examples/subject.py"
+        )
+
+        ExamplesGenerator().generate_example(
+            "fake/path/to/example.py"
         )

--- a/tests/test_examples_generator.py
+++ b/tests/test_examples_generator.py
@@ -1,0 +1,15 @@
+"""Module to test the examples_generator.py script"""
+
+import json
+import os
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, call, mock_open, patch
+from aind_data_schema.utils.examples_generator import ExamplesGenerator
+
+class ExamplesGeneratorTest(unittest.TestCase):
+    """Tests for ExamplesGenerator methods"""
+
+    @patch("AindCoreModel.write_standard_file()")
+    def test_generate_all_files(self):
+        ExamplesGenerator().generate_all_examples()

--- a/tests/test_examples_generator.py
+++ b/tests/test_examples_generator.py
@@ -1,15 +1,23 @@
 """Module to test the examples_generator.py script"""
 
-import json
-import os
 import unittest
-from pathlib import Path
-from unittest.mock import MagicMock, call, mock_open, patch
+from unittest.mock import patch
+
 from aind_data_schema.utils.examples_generator import ExamplesGenerator
+
 
 class ExamplesGeneratorTest(unittest.TestCase):
     """Tests for ExamplesGenerator methods"""
 
     @patch("AindCoreModel.write_standard_file()")
     def test_generate_all_files(self):
+        """Test generate_all_examples method"""
+
         ExamplesGenerator().generate_all_examples()
+
+    def test_generate_example(self):
+        """Test generate_example method"""
+
+        ExamplesGenerator().generate_example(
+            "C:/Users/mae.moninghoff/Documents/GitHub/aind-data-schema/examples/subject.py"
+        )

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -18,12 +18,12 @@ from aind_data_schema.components.coordinates import (
 )
 from aind_data_schema.core.session import (
     DomeModule,
+    ManipulatorModule,
     MRIScan,
     RewardDeliveryConfig,
     Scanner,
     Session,
     Stream,
-    ManipulatorModule
 )
 
 PYD_VERSION = re.match(r"(\d+.\d+).\d+", pyd_version).group(1)


### PR DESCRIPTION
closes #952 
closes #967 

Adds a script to `aind-data-schema.utils` that allows all examples to be re-generated at once, by running the script.

All example generator `.py` files have been edited to use the output directory `examples/`