### PR TITLE
Adding start + end times to AcquisitionTile

### DIFF
--- a/examples/exaspim_acquisition.json
+++ b/examples/exaspim_acquisition.json
@@ -102,7 +102,9 @@
          },
          "notes": "these are my notes",
          "imaging_angle": 0,
-         "imaging_angle_unit": "degrees"
+         "imaging_angle_unit": "degrees",
+         "acquisition_start_time": null,
+         "acquisition_end_time": null
       },
       {
          "coordinate_transformations": [
@@ -143,7 +145,9 @@
          },
          "notes": "these are my notes",
          "imaging_angle": 0,
-         "imaging_angle_unit": "degrees"
+         "imaging_angle_unit": "degrees",
+         "acquisition_start_time": null,
+         "acquisition_end_time": null
       }
    ],
    "axes": [

--- a/examples/subject.json
+++ b/examples/subject.json
@@ -12,7 +12,7 @@
          "name": "National Center for Biotechnology Information",
          "abbreviation": "NCBI"
       },
-      "registry_identifier": "10090"
+      "registry_identifier": "NCBI:txid10090"
    },
    "alleles": [],
    "background_strain": "C57BL/6J",

--- a/src/aind_data_schema/components/tile.py
+++ b/src/aind_data_schema/components/tile.py
@@ -60,5 +60,5 @@ class AcquisitionTile(Tile):
     notes: Optional[str] = Field(default=None, title="Notes")
     imaging_angle: int = Field(default=0, title="Imaging angle")
     imaging_angle_unit: AngleUnit = Field(default=AngleUnit.DEG, title="Imaging angle unit")
-    acquisition_start_time: Optional[AwareDatetimeWithDefault] = Field(..., title="Acquisition start time")
-    acquisition_end_time: Optional[AwareDatetimeWithDefault] = Field(..., title="Acquisition end time")
+    acquisition_start_time: Optional[AwareDatetimeWithDefault] = Field(None, title="Acquisition start time")
+    acquisition_end_time: Optional[AwareDatetimeWithDefault] = Field(None, title="Acquisition end time")

--- a/src/aind_data_schema/components/tile.py
+++ b/src/aind_data_schema/components/tile.py
@@ -6,8 +6,6 @@ from aind_data_schema_models.units import AngleUnit, PowerUnit, SizeUnit
 from pydantic import Field
 from typing_extensions import Annotated
 
-
-
 from aind_data_schema.base import AindModel, AwareDatetimeWithDefault
 from aind_data_schema.components.coordinates import (
     Affine3dTransform,

--- a/src/aind_data_schema/components/tile.py
+++ b/src/aind_data_schema/components/tile.py
@@ -6,7 +6,9 @@ from aind_data_schema_models.units import AngleUnit, PowerUnit, SizeUnit
 from pydantic import Field
 from typing_extensions import Annotated
 
-from aind_data_schema.base import AindModel
+
+
+from aind_data_schema.base import AindModel, AwareDatetimeWithDefault
 from aind_data_schema.components.coordinates import (
     Affine3dTransform,
     Rotation3dTransform,
@@ -60,3 +62,5 @@ class AcquisitionTile(Tile):
     notes: Optional[str] = Field(default=None, title="Notes")
     imaging_angle: int = Field(default=0, title="Imaging angle")
     imaging_angle_unit: AngleUnit = Field(default=AngleUnit.DEG, title="Imaging angle unit")
+    acquisition_start_time: Optional[AwareDatetimeWithDefault] = Field(..., title="Acquisition start time")
+    acquisition_end_time: Optional[AwareDatetimeWithDefault] = Field(..., title="Acquisition end time")


### PR DESCRIPTION
closes #940 

Adds the fields:
`AcquisitionTile.acquisition_start_time` -> `Optional[AwareDateTimeWithDefault]`
`AcquisitionTile.acquisition_end_time` -> `Optional[AwareDateTimeWithDefault]`