### PR TITLE
ci: removes pydantic upper bound

### DIFF
--- a/.github/workflows/tag_and_publish.yml
+++ b/.github/workflows/tag_and_publish.yml
@@ -22,7 +22,9 @@ jobs:
         with:
           python-version: 3.8
       - name: Install dependencies
-        run: python -m pip install -e .[dev] --no-cache-dir
+        run: |
+          python -m pip install -e .[dev] --no-cache-dir
+          python -m pip install pydantic==2.6.4
       - name: Bump schema versions
         run: |
           python -m aind_data_schema.utils.schema_version_bump
@@ -31,6 +33,7 @@ jobs:
         run: |
           rm -rf $OUTPUT_DIR
           python -m pip install -e .
+          python -m pip install pydantic==2.6.4
           python -m aind_data_schema.utils.json_writer --output $OUTPUT_DIR
       - name: Create example schemas
         run: |
@@ -65,6 +68,7 @@ jobs:
         run: |
           sudo apt install graphviz libgraphviz-dev -y
           python -m pip install -e .[dev] -e .[docs] --no-cache-dir
+          python -m pip install pydantic==2.6.4
       - name: Generate new rst files
         run: |
           sphinx-apidoc -o docs/source/ src
@@ -160,6 +164,7 @@ jobs:
       - name: Create and upload schemas
         run: |
           python -m pip install -e .
+          python -m pip install pydantic==2.6.4
           python -m aind_data_schema.utils.json_writer --output $TEMP_DIR --attach-version
           python -m pip install awscli
           aws s3 sync $TEMP_DIR s3://${AWS_DATA_SCHEMA_BUCKET}/$S3_PREFIX
@@ -193,6 +198,7 @@ jobs:
       - name: Create and upload schemas
         run: | 
           python -m pip install -e .
+          python -m pip install pydantic==2.6.4
           python -m aind_data_schema.utils.json_writer --output $TEMP_DIR --attach-version
           python -m pip install awscli
           aws s3 sync $TEMP_DIR s3://${AWS_DATA_SCHEMA_BUCKET}/$S3_PREFIX
@@ -220,6 +226,7 @@ jobs:
         run: |
           sudo apt install graphviz libgraphviz-dev -y
           python -m pip install -e .[docs] --no-cache-dir
+          python -m pip install pydantic==2.6.4
           python -m pip install awscli
       - name: Generate erdantic diagrams
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,9 @@ readme = "README.md"
 dynamic = ["version"]
 
 dependencies = [
-    'aind-data-schema-models>=0.1.1',
+    'aind-data-schema-models>=0.1.7',
     'dictdiffer',
-    'pydantic>2.0,<2.7',
+    'pydantic>2.0',
     'inflection',
     'jsonschema',
     'semver'


### PR DESCRIPTION
Closes #888 

- Removes upper bound to pydantic
- Adds lower bound for aind-data-schema-models
- pins version of pydantic that we're using to publish jsonschema