### PR TITLE
compare daq names

### DIFF
--- a/src/aind_data_schema/components/devices.py
+++ b/src/aind_data_schema/components/devices.py
@@ -15,7 +15,7 @@ from aind_data_schema_models.units import (
     SpeedUnit,
     TemperatureUnit,
     UnitlessUnit,
-    VoltageUnit
+    VoltageUnit,
 )
 from pydantic import Field, ValidationInfo, field_validator, model_validator
 from typing_extensions import Annotated
@@ -694,8 +694,9 @@ class PockelsCell(Device):
     """Description of a Pockels Cell"""
 
     device_type: Literal["Pockels cell"] = "Pockels cell"
-    polygonal_scanner: Optional[str] = Field(default=None, title="Polygonal scanner",
-                                             description="Must match name of Polygonal scanner")
+    polygonal_scanner: Optional[str] = Field(
+        default=None, title="Polygonal scanner", description="Must match name of Polygonal scanner"
+    )
     on_time: Optional[Decimal] = Field(default=None, title="On time (fraction of cycle)")
     off_time: Optional[Decimal] = Field(default=None, title="Off time (fraction of cycle)")
     time_setting_unit: UnitlessUnit = Field(default=UnitlessUnit.FC, title="Time setting unit")

--- a/src/aind_data_schema/utils/compatibility_check.py
+++ b/src/aind_data_schema/utils/compatibility_check.py
@@ -34,10 +34,10 @@ class RigSessionCompatibility:
             daq for stream in getattr(self.session, "data_streams", []) for daq in getattr(stream, "daq_names", [])
         ]
         rig_daqs = [getattr(daq, "name", None) for daq in getattr(self.rig, "daqs", [])]
-        if set(session_daqs) != set(rig_daqs):
+        if not set(session_daqs).issubset(set(rig_daqs)):
             return ValueError(
                 f"daq names in session do not match daq names in rig. "
-                f"session_daqs: {session_daqs} rig_daqs: {rig_daqs}"
+                f"session_daqs: {set(session_daqs)} rig_daqs: {set(rig_daqs)}"
             )
 
     def run_compatibility_check(self) -> None:

--- a/src/aind_data_schema/utils/compatibility_check.py
+++ b/src/aind_data_schema/utils/compatibility_check.py
@@ -28,9 +28,21 @@ class RigSessionCompatibility:
                 f"does not match the rig's {self.rig.mouse_platform.name}"
             )
 
+    def _compare_daq_names(self) -> Optional[ValueError]:
+        """Compares daq names"""
+        session_daqs = [
+            daq for stream in getattr(self.session, "data_streams", []) for daq in getattr(stream, "daq_names", [])
+        ]
+        rig_daqs = [getattr(daq, "name", None) for daq in getattr(self.rig, "daqs", [])]
+        if set(session_daqs) != set(rig_daqs):
+            return ValueError(
+                f"daq names in session do not match daq names in rig. "
+                f"session_daqs: {session_daqs} rig_daqs: {rig_daqs}"
+            )
+
     def run_compatibility_check(self) -> None:
         """Runs compatibility check.Creates a dictionary of fields and whether it matches in rig and session."""
-        comparisons = [self._compare_rig_id(), self._compare_mouse_platform_name()]
+        comparisons = [self._compare_rig_id(), self._compare_mouse_platform_name(), self._compare_daq_names()]
         error_messages = [str(error) for error in comparisons if error]
         if error_messages:
             raise ValueError(error_messages)

--- a/tests/test_examples_generator.py
+++ b/tests/test_examples_generator.py
@@ -23,6 +23,4 @@ class ExamplesGeneratorTest(unittest.TestCase):
             "C:/Users/mae.moninghoff/Documents/GitHub/aind-data-schema/examples/subject.py"
         )
 
-        ExamplesGenerator().generate_example(
-            "fake/path/to/example.py"
-        )
+        ExamplesGenerator().generate_example("fake/path/to/example.py")

--- a/tests/test_rig_session_compatibility.py
+++ b/tests/test_rig_session_compatibility.py
@@ -16,13 +16,13 @@ class TestRigSessionCompatibility(unittest.TestCase):
     stream2 = Stream.model_construct(daq_names=["daq3", "daq4"])
     daq1 = DAQDevice.model_construct(name="daq1")
     daq2 = DAQDevice.model_construct(name="daq2")
-    rig = Rig.model_construct(rig_id="some_rig_id", mouse_platform=mouse_platform, daqs=[daq1, daq2])
+    daq3 = DAQDevice.model_construct(name="daq3")
+    rig = Rig.model_construct(rig_id="some_rig_id", mouse_platform=mouse_platform, daqs=[daq1, daq2, daq3])
     compatible_session = Session.model_construct(
         rig_id="some_rig_id", mouse_platform_name="some_mouse_platform", data_streams=[stream1, stream1]
     )
     noncompatible_session = Session.model_construct(
-        rig_id="some_other_rig_id",
-        mouse_platform_name="some_other_mouse_platform",
+        rig_id="some_other_rig_id", mouse_platform_name="some_other_mouse_platform", data_streams=[stream1, stream2]
     )
     checker = RigSessionCompatibility(rig=rig, session=compatible_session)
     noncompatible_checker = RigSessionCompatibility(rig=rig, session=noncompatible_session)

--- a/tests/test_rig_session_compatibility.py
+++ b/tests/test_rig_session_compatibility.py
@@ -1,9 +1,9 @@
 """Tests rig session compatibility check"""
 import unittest
 
-from aind_data_schema.components.devices import MousePlatform
+from aind_data_schema.components.devices import MousePlatform, DAQDevice
 from aind_data_schema.core.rig import Rig
-from aind_data_schema.core.session import Session
+from aind_data_schema.core.session import Session, Stream
 from aind_data_schema.utils.compatibility_check import RigSessionCompatibility
 
 
@@ -12,12 +12,18 @@ class TestRigSessionCompatibility(unittest.TestCase):
 
     # TODO: use example rig and session once examples are synced
     mouse_platform = MousePlatform.model_construct(name="some_mouse_platform")
-    rig = Rig.model_construct(rig_id="some_rig_id", mouse_platform=mouse_platform)
-    compatible_session = Session.model_construct(rig_id="some_rig_id", mouse_platform_name="some_mouse_platform")
-    noncompatible_session = Session.model_construct(
-        rig_id="some_other_rig_id", mouse_platform_name="some_other_mouse_platform"
+    stream1 = Stream.model_construct(daq_names=["daq1", "daq2"])
+    stream2 = Stream.model_construct(daq_names=["daq3", "daq4"])
+    daq1 = DAQDevice.model_construct(name="daq1")
+    daq2 = DAQDevice.model_construct(name="daq2")
+    rig = Rig.model_construct(rig_id="some_rig_id", mouse_platform=mouse_platform, daqs=[daq1, daq2])
+    compatible_session = Session.model_construct(
+        rig_id="some_rig_id", mouse_platform_name="some_mouse_platform", data_streams=[stream1, stream1]
     )
-
+    noncompatible_session = Session.model_construct(
+        rig_id="some_other_rig_id",
+        mouse_platform_name="some_other_mouse_platform",
+    )
     checker = RigSessionCompatibility(rig=rig, session=compatible_session)
     noncompatible_checker = RigSessionCompatibility(rig=rig, session=noncompatible_session)
 
@@ -30,6 +36,11 @@ class TestRigSessionCompatibility(unittest.TestCase):
         """Tests compare mouse platform"""
         self.assertIsNone(self.checker._compare_mouse_platform_name())
         self.assertIsInstance(self.noncompatible_checker._compare_mouse_platform_name(), ValueError)
+
+    def test_compare_daq_names(self):
+        """Tests compare daq names"""
+        self.assertIsNone(self.checker._compare_daq_names())
+        self.assertIsInstance(self.noncompatible_checker._compare_daq_names(), ValueError)
 
     def test_run_compatibility_check(self):
         """Tests compatibility check"""


### PR DESCRIPTION
closes #964 

- Checks that the unique values of daq names in session all exist in rig's daq names. 
- Uses getattr in case that field names are missing

Will be using our decisions on ^^ for all the Stream fields compatibility checks
