### PR TITLE
Feat 986 change external links to list of dicts

### DIFF
--- a/src/aind_data_schema/core/metadata.py
+++ b/src/aind_data_schema/core/metadata.py
@@ -78,7 +78,7 @@ class Metadata(AindCoreModel):
     metadata_status: MetadataStatus = Field(
         default=MetadataStatus.UNKNOWN, title=" Metadata Status", description="The status of the metadata."
     )
-    external_links: List[Dict[ExternalPlatforms, str]] = Field(
+    external_links: Dict[ExternalPlatforms, Dict[str]] = Field(
         default=[], title="External Links", description="Links to the data asset on different platforms."
     )
     # We can make the AindCoreModel fields optional for now and do more

--- a/src/aind_data_schema/core/metadata.py
+++ b/src/aind_data_schema/core/metadata.py
@@ -78,7 +78,7 @@ class Metadata(AindCoreModel):
     metadata_status: MetadataStatus = Field(
         default=MetadataStatus.UNKNOWN, title=" Metadata Status", description="The status of the metadata."
     )
-    external_links: Dict[ExternalPlatforms, Dict[str]] = Field(
+    external_links: Dict[ExternalPlatforms, List[str]] = Field(
         default=[], title="External Links", description="Links to the data asset on different platforms."
     )
     # We can make the AindCoreModel fields optional for now and do more


### PR DESCRIPTION
closes #986 

`Metadata.external_links` input changed: `List[Dict[Platform, str]]` --> `Dict[Platform, List[str]]`

This might impact how data is drawn from the metadata service / how data is indexed, so @helen-m-lin and @mekhlakapoor should asses those effects.