### PR TITLE
feat validator for rig/session compatibility

### DIFF
--- a/docs/source/example_workflow/example_workflow.py
+++ b/docs/source/example_workflow/example_workflow.py
@@ -1,20 +1,14 @@
-import pandas as pd
 import os
 
+import pandas as pd
 from aind_data_schema_models.modalities import Modality
 from aind_data_schema_models.organizations import Organization
 from aind_data_schema_models.pid_names import PIDName
 from aind_data_schema_models.platforms import Platform
 
 from aind_data_schema.core.data_description import Funding, RawDataDescription
-from aind_data_schema.core.subject import Subject, Species, BreedingInfo, Housing
-from aind_data_schema.core.procedures import (
-    NanojectInjection,
-    Procedures,
-    Surgery,
-    ViralMaterial,
-    Perfusion,
-)
+from aind_data_schema.core.procedures import NanojectInjection, Perfusion, Procedures, Surgery, ViralMaterial
+from aind_data_schema.core.subject import BreedingInfo, Housing, Species, Subject
 
 sessions_df = pd.read_excel("example_workflow.xlsx", sheet_name="sessions")
 mice_df = pd.read_excel("example_workflow.xlsx", sheet_name="mice")
@@ -34,7 +28,6 @@ iacuc_protocol = "2109"
 
 # loop through all of the sessions
 for session_idx, session in sessions_df.iterrows():
-
     # our data always contains planar optical physiology and behavior videos
     d = RawDataDescription(
         modality=[Modality.POPHYS, Modality.BEHAVIOR_VIDEOS],

--- a/src/aind_data_schema/core/metadata.py
+++ b/src/aind_data_schema/core/metadata.py
@@ -18,6 +18,7 @@ from aind_data_schema.core.processing import Processing
 from aind_data_schema.core.rig import Rig
 from aind_data_schema.core.session import Session
 from aind_data_schema.core.subject import Subject
+from aind_data_schema.utils.compatibility_check import RigSessionCompatibility
 
 
 class MetadataStatus(Enum):
@@ -231,4 +232,12 @@ class Metadata(AindCoreModel):
             )
         ):
             raise ValueError("Injection is missing injection_materials.")
+        return self
+
+    @model_validator(mode="after")
+    def validate_rig_session_compatibility(self):
+        """Validator for metadata"""
+        if self.rig and self.session:
+            check = RigSessionCompatibility(self.rig, self.session)
+            check.run_compatibility_check()
         return self

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -10,6 +10,7 @@ from aind_data_schema_models.platforms import Ecephys, SmartSpim
 from pydantic import ValidationError
 from pydantic import __version__ as pyd_version
 
+from aind_data_schema.components.devices import MousePlatform
 from aind_data_schema.core.acquisition import Acquisition
 from aind_data_schema.core.data_description import DataDescription
 from aind_data_schema.core.instrument import Instrument
@@ -25,7 +26,6 @@ from aind_data_schema.core.processing import Processing
 from aind_data_schema.core.rig import Rig
 from aind_data_schema.core.session import Session
 from aind_data_schema.core.subject import BreedingInfo, Sex, Species, Subject
-from aind_data_schema.components.devices import MousePlatform
 
 PYD_VERSION = re.match(r"(\d+.\d+).\d+", pyd_version).group(1)
 
@@ -224,7 +224,10 @@ class TestMetadata(unittest.TestCase):
                 processing=Processing.model_construct(),
                 session=session,
             )
-        self.assertIn("Rig ID in session 123_EPHYS2_20230101 does not match the rig's 123_EPHYS1_20220101.", str(context.exception))
+        self.assertIn(
+            "Rig ID in session 123_EPHYS2_20230101 does not match the rig's 123_EPHYS1_20220101.",
+            str(context.exception),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
closes #966 

- runs compatibility check if rig and session exist, let me know if it should also do a modality check (for example, do we want this to only run for ecephys?)