### PR TITLE
Add (de)serialization tests for AindGeneric

### DIFF
--- a/tests/test_aind_generic.py
+++ b/tests/test_aind_generic.py
@@ -1,4 +1,4 @@
-""" test Device models"""
+""" test round trip (de)serialization behavior of AindGeneric models"""
 
 import unittest
 

--- a/tests/test_aind_generic.py
+++ b/tests/test_aind_generic.py
@@ -38,7 +38,7 @@ class AindGenericTests(unittest.TestCase):
             contains_dict={"foodict": 1, "bardict": "bar"},
         )
         deserialized = SubGenericContainer.model_validate_json(sub_generic_container.model_dump_json())
-        self.assertTrue(sub_generic_container == deserialized)
+        self.assertEqual(sub_generic_container, deserialized)
 
     def test_sub_generic_container_from_parent_round_trip(self):
         """tests a round trip (de)serialization of the SubGenericContainer from the parent"""
@@ -48,7 +48,7 @@ class AindGenericTests(unittest.TestCase):
         )
         deserialized_parent = GenericContainer.model_validate_json(sub_generic_container.model_dump_json())
         deserialized = SubGenericContainer.model_validate_json(deserialized_parent.model_dump_json())
-        self.assertTrue(sub_generic_container == deserialized)
+        self.assertEqual(sub_generic_container, deserialized)
 
     def test_sub_container_from_container(self):
         """tests if a model created directly from GenericContainer can be deserialized from the SubGenericContainer"""
@@ -62,4 +62,4 @@ class AindGenericTests(unittest.TestCase):
             contains_dict={"foodict": 1, "bardict": "bar"},
         )
         deserialized = SubGenericContainer.model_validate_json(parent_container.model_dump_json())
-        self.assertTrue(sub_generic_container == deserialized)
+        self.assertEqual(sub_generic_container, deserialized)

--- a/tests/test_aind_generic.py
+++ b/tests/test_aind_generic.py
@@ -1,0 +1,65 @@
+""" test Device models"""
+
+import unittest
+
+from pydantic import BaseModel, Field
+
+from aind_data_schema.base import AindGeneric, AindModel
+
+
+class GenericContainer(AindModel):
+    """Represents a generic container"""
+
+    contains_model: AindGeneric
+    contains_dict: AindGeneric
+
+
+class Bar(BaseModel):
+    """Represents a mock model"""
+
+    bar: str = Field(default="bar")
+    foo: int = Field(default=1)
+
+
+class SubGenericContainer(GenericContainer):
+    """Represents a subclass of GenericContainer where contains_model is typed to Bar"""
+
+    contains_model: Bar
+
+
+class AindGenericTests(unittest.TestCase):
+    """tests device schemas"""
+
+    def test_sub_generic_container_round_trip(self):
+        """tests a round trip (de)serialization of the SubGenericContainer"""
+
+        sub_generic_container = SubGenericContainer(
+            contains_model=Bar(bar="baz", foo=2),
+            contains_dict={"foodict": 1, "bardict": "bar"},
+        )
+        deserialized = SubGenericContainer.model_validate_json(sub_generic_container.model_dump_json())
+        self.assertTrue(sub_generic_container == deserialized)
+
+    def test_sub_generic_container_from_parent_round_trip(self):
+        """tests a round trip (de)serialization of the SubGenericContainer from the parent"""
+        sub_generic_container = SubGenericContainer(
+            contains_model=Bar(bar="baz", foo=2),
+            contains_dict={"foodict": 1, "bardict": "bar"},
+        )
+        deserialized_parent = GenericContainer.model_validate_json(sub_generic_container.model_dump_json())
+        deserialized = SubGenericContainer.model_validate_json(deserialized_parent.model_dump_json())
+        self.assertTrue(sub_generic_container == deserialized)
+
+    def test_sub_container_from_container(self):
+        """tests if a model created directly from GenericContainer can be deserialized from the SubGenericContainer"""
+
+        sub_generic_container = SubGenericContainer(
+            contains_model=Bar(bar="baz", foo=2),
+            contains_dict={"foodict": 1, "bardict": "bar"},
+        )
+        parent_container = GenericContainer(
+            contains_model=Bar(bar="baz", foo=2).model_dump(),
+            contains_dict={"foodict": 1, "bardict": "bar"},
+        )
+        deserialized = SubGenericContainer.model_validate_json(parent_container.model_dump_json())
+        self.assertTrue(sub_generic_container == deserialized)


### PR DESCRIPTION
This PR adds serialization and deserialization tests for the AindGeneric class. This is to ensure that round-trip conversions are not lossy and can be recovered from the subclasses as well as the AindGeneric type.