### PR TITLE
Fix feat 926 coordinates

### DIFF
--- a/src/aind_data_schema/core/session.py
+++ b/src/aind_data_schema/core/session.py
@@ -219,7 +219,7 @@ class ManipulatorModule(DomeModule):
     )
     anatomical_coordinates: Optional[Coordinates3d] = Field(None, title="Anatomical coordinates relative to reference")
     anatomical_reference: Optional[
-        Union[CoordinateReferenceLocation.BREGMA, CoordinateReferenceLocation.LAMBDA]
+        Literal[CoordinateReferenceLocation.BREGMA, CoordinateReferenceLocation.LAMBDA]
                                    ] = Field(None, title="Anatomical coordinate reference")
     surface_z: Optional[Decimal] = Field(None, title="Surface z")
     surface_z_unit: SizeUnit = Field(SizeUnit.UM, title="Surface z unit")

--- a/src/aind_data_schema/core/session.py
+++ b/src/aind_data_schema/core/session.py
@@ -278,6 +278,7 @@ class RewardDeliveryConfig(AindModel):
     notes: Optional[str] = Field(default=None, title="Notes", validate_default=True)
 
     @field_validator("notes", mode="after")
+    @classmethod
     def validate_other(cls, value: Optional[str], info: ValidationInfo) -> Optional[str]:
         """Validator for other/notes"""
 
@@ -351,6 +352,7 @@ class MRIScan(AindModel):
     notes: Optional[str] = Field(default=None, title="Notes", validate_default=True)
 
     @field_validator("notes", mode="after")
+    @classmethod
     def validate_other(cls, value: Optional[str], info: ValidationInfo) -> Optional[str]:
         """Validator for other/notes"""
 
@@ -456,6 +458,7 @@ class Stream(AindModel):
             return None
 
     @field_validator("stream_modalities", mode="after")
+    @classmethod
     def validate_stream_modalities(cls, value: List[Modality.ONE_OF], info: ValidationInfo) -> List[Modality.ONE_OF]:
         """Validate each modality in stream_modalities field has associated data"""
         errors = []

--- a/src/aind_data_schema/core/session.py
+++ b/src/aind_data_schema/core/session.py
@@ -278,7 +278,6 @@ class RewardDeliveryConfig(AindModel):
     notes: Optional[str] = Field(default=None, title="Notes", validate_default=True)
 
     @field_validator("notes", mode="after")
-    @classmethod
     def validate_other(cls, value: Optional[str], info: ValidationInfo) -> Optional[str]:
         """Validator for other/notes"""
 
@@ -352,7 +351,6 @@ class MRIScan(AindModel):
     notes: Optional[str] = Field(default=None, title="Notes", validate_default=True)
 
     @field_validator("notes", mode="after")
-    @classmethod
     def validate_other(cls, value: Optional[str], info: ValidationInfo) -> Optional[str]:
         """Validator for other/notes"""
 
@@ -458,7 +456,6 @@ class Stream(AindModel):
             return None
 
     @field_validator("stream_modalities", mode="after")
-    @classmethod
     def validate_stream_modalities(cls, value: List[Modality.ONE_OF], info: ValidationInfo) -> List[Modality.ONE_OF]:
         """Validate each modality in stream_modalities field has associated data"""
         errors = []


### PR DESCRIPTION
This PR tries to fix #1011/#1012 errors. The issue was related to using enumerator instances (which should be treated as value-types) as inputs to an Union/type signature. If you want to limit the choices users have in terms of value types, use a Literal type instead.
 
Test errors related to the "Bregma" error it was throwing before seem to disappear but couple of other errors remain related with missing fields that I didn't take a look at.

Additionally, following #945 and #770 it would be great if the `default` keyword was preserved in the current schemas if possible.

Hope it helps!