### PR TITLE
1043 enforce default formatting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,3 +5,7 @@ exclude =
     build
 max-complexity = 10
 max-line-length = 120
+
+[flake8:local-plugins]
+extension =
+    PF = aind_flake8_extensions.plugin:run_ast_checks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    'aind_data_schema[linters]'
+    'aind_data_schema[linters]',
+    'aind-flake8-extensions'
 ]
 
 linters = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    'aind_data_schema[linters]',
-    'aind-flake8-extensions'
+    'aind_data_schema[linters]'
 ]
 
 linters = [
@@ -34,7 +33,8 @@ linters = [
     'coverage',
     'flake8',
     'interrogate',
-    'isort'
+    'isort',
+    'aind-flake8-extensions'
 ]
 
 docs = [

--- a/src/aind_data_schema/components/devices.py
+++ b/src/aind_data_schema/components/devices.py
@@ -528,7 +528,7 @@ class Laser(Device):
     power_unit: PowerUnit = Field(default=PowerUnit.MW, title="Power unit")
     coupling: Optional[Coupling] = Field(default=None, title="Coupling")
     coupling_efficiency: Optional[Decimal] = Field(
-        None,
+        default=None,
         title="Coupling efficiency (percent)",
         ge=0,
         le=100,

--- a/src/aind_data_schema/components/stimulus.py
+++ b/src/aind_data_schema/components/stimulus.py
@@ -40,7 +40,7 @@ class OptoStimulation(AindModel):
     pulse_train_duration_unit: TimeUnit = Field(default=TimeUnit.S, title="Pulse train duration unit")
     fixed_pulse_train_interval: bool = Field(..., title="Fixed pulse train interval")
     pulse_train_interval: Optional[Decimal] = Field(
-        None, title="Pulse train interval (s)", description="Time between pulse trains"
+        default=None, title="Pulse train interval (s)", description="Time between pulse trains"
     )
     pulse_train_interval_unit: TimeUnit = Field(default=TimeUnit.S, title="Pulse train interval unit")
     baseline_duration: Decimal = Field(

--- a/src/aind_data_schema/core/instrument.py
+++ b/src/aind_data_schema/core/instrument.py
@@ -38,7 +38,7 @@ class Instrument(AindCoreModel):
     schema_version: Literal["1.0.0"] = Field("1.0.0")
 
     instrument_id: Optional[str] = Field(
-        None,
+        default=None,
         description="Unique instrument identifier, name convention: <room>-<apparatus name>-<date modified YYYYMMDD>",
         title="Instrument ID",
     )
@@ -58,12 +58,12 @@ class Instrument(AindCoreModel):
     scanning_stages: List[ScanningStage] = Field(default=[], title="Scanning motorized stages")
     additional_devices: List[AdditionalImagingDevice] = Field(default=[], title="Additional devices")
     calibration_date: Optional[date] = Field(
-        None,
+        default=None,
         description="Date of most recent calibration",
         title="Calibration date",
     )
     calibration_data: Optional[str] = Field(
-        None,
+        default=None,
         description="Path to calibration data from most recent calibration",
         title="Calibration data",
     )

--- a/src/aind_data_schema/core/procedures.py
+++ b/src/aind_data_schema/core/procedures.py
@@ -241,7 +241,7 @@ class SpecimenProcedure(AindModel):
 
     procedure_type: SpecimenProcedureType = Field(..., title="Procedure type")
     procedure_name: Optional[str] = Field(
-        None, title="Procedure name", description="Name to clarify specific procedure used as needed"
+        default=None, title="Procedure name", description="Name to clarify specific procedure used as needed"
     )
     specimen_id: str = Field(..., title="Specimen ID")
     start_date: date = Field(..., title="Start date")

--- a/src/aind_data_schema/core/subject.py
+++ b/src/aind_data_schema/core/subject.py
@@ -98,7 +98,7 @@ class Subject(AindCoreModel):
     sex: Sex = Field(..., title="Sex")
     date_of_birth: date_type = Field(..., title="Date of birth")
     genotype: Optional[str] = Field(
-        None,
+        default=None,
         description="Genotype of the animal providing both alleles",
         title="Genotype",
     )
@@ -112,12 +112,12 @@ class Subject(AindCoreModel):
         title="Source",
     )
     rrid: Optional[PIDName] = Field(
-        None,
+        default=None,
         description="RRID of mouse if acquired from supplier",
         title="RRID",
     )
     restrictions: Optional[str] = Field(
-        None,
+        default=None,
         description="Any restrictions on use or publishing based on subject source",
         title="Restrictions",
     )


### PR DESCRIPTION
@saskiad requested that I get this working, and as long as I limit it to checking for default= and not required fields that are missing Field(...) it seems to work well.

This PR installs a [dev] package `aind-flake8-extensions` published on pypi as a flake8 extension. The extension generates warnings like these:

```
src/aind_data_schema/components/devices.py:530:5: PF001 Field 'coupling_efficiency' should use 'default=None' for optional fields
src/aind_data_schema/components/stimulus.py:42:5: PF001 Field 'pulse_train_interval' should use 'default=None' for optional fields
src/aind_data_schema/core/instrument.py:40:5: PF001 Field 'instrument_id' should use 'default=None' for optional fields
src/aind_data_schema/core/instrument.py:60:5: PF001 Field 'calibration_date' should use 'default=None' for optional fields
src/aind_data_schema/core/instrument.py:65:5: PF001 Field 'calibration_data' should use 'default=None' for optional fields
src/aind_data_schema/core/procedures.py:243:5: PF001 Field 'procedure_name' should use 'default=None' for optional fields
src/aind_data_schema/core/subject.py:100:5: PF001 Field 'genotype' should use 'default=None' for optional fields
src/aind_data_schema/core/subject.py:114:5: PF001 Field 'rrid' should use 'default=None' for optional fields
src/aind_data_schema/core/subject.py:119:5: PF001 Field 'restrictions' should use 'default=None' for optional fields
```

When it sees code like this (from devices.py:530):

```
    coupling_efficiency: Optional[Decimal] = Field(
        None,
        title="Coupling efficiency (percent)",
        ge=0,
        le=100,
    )
```

It also auto-highlights this issue in your editor as you code, if you have a flake8 extension in your IDE.

The extension doesn't fix the issue for you (I've gone through and fixed all of the above). 