### PR TITLE
Blocking pydantic versions 2.9.0/2.9.1 in [dev]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dynamic = ["version"]
 dependencies = [
     'aind-data-schema-models>=0.3.2',
     'dictdiffer',
-    'pydantic>=2.7,<2.9',
+    'pydantic>=2.7',
     'inflection',
     'jsonschema',
     'semver'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dynamic = ["version"]
 dependencies = [
     'aind-data-schema-models>=0.3.2',
     'dictdiffer',
-    'pydantic>=2.7',
+    'pydantic>=2.9.2',
     'inflection',
     'jsonschema',
     'semver'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dynamic = ["version"]
 dependencies = [
     'aind-data-schema-models>=0.3.2',
     'dictdiffer',
-    'pydantic>=2.7, !=2.9.0, !=2.9.1',
+    'pydantic>=2.7',
     'inflection',
     'jsonschema',
     'semver'
@@ -24,7 +24,8 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    'aind_data_schema[linters]'
+    'aind_data_schema[linters]',
+    'pydantic>=2.7, !=2.9.0, !=2.9.1'
 ]
 
 linters = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dynamic = ["version"]
 dependencies = [
     'aind-data-schema-models>=0.3.2',
     'dictdiffer',
-    'pydantic>=2.9.2',
+    'pydantic>=2.7, !=2.9.0, !=2.9.1',
     'inflection',
     'jsonschema',
     'semver'


### PR DESCRIPTION
This PR ~~increases the pydantic minimum to 2.9.2~~ sets two versions of pydantic to ignore now that 2.9.2 is released, only on the [dev] dependencies

In versions 2.9.0 and 2.9.1 errors are thrown when model_construct() is used on models with Unions. 

Closes #1058 