### PR TITLE
ci: pin aind-flake8-extensions version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ linters = [
     'flake8',
     'interrogate',
     'isort',
-    'aind-flake8-extensions'
+    'aind-flake8-extensions==0.5.2'
 ]
 
 docs = [


### PR DESCRIPTION
PR pins the version of aind-flake8-extensions so it only warns about missing default= and doesn't add the new extension I put in v0.6.0 (which currently causes the linter tests to fail in aind-data-schema and aind-data-schema-models)

(fyi until this is merged it breaks all other PRs)