### PR TITLE
Support multi session quality control by tracking metric provenance

### DIFF
--- a/examples/quality_control.json
+++ b/examples/quality_control.json
@@ -27,15 +27,16 @@
                   ],
                   "type": "dropdown"
                },
-               "description": null,
-               "reference": "ecephys-drift-map",
                "status_history": [
                   {
                      "evaluator": "",
                      "status": "Pending",
                      "timestamp": "2022-11-22T00:00:00Z"
                   }
-               ]
+               ],
+               "description": null,
+               "reference": "ecephys-drift-map",
+               "provenance": null
             },
             {
                "name": "Probe B drift",
@@ -53,28 +54,30 @@
                   ],
                   "type": "checkbox"
                },
-               "description": null,
-               "reference": "ecephys-drift-map",
                "status_history": [
                   {
                      "evaluator": "",
                      "status": "Pending",
                      "timestamp": "2022-11-22T00:00:00Z"
                   }
-               ]
+               ],
+               "description": null,
+               "reference": "ecephys-drift-map",
+               "provenance": null
             },
             {
                "name": "Probe C drift",
                "value": "Low",
-               "description": null,
-               "reference": "ecephys-drift-map",
                "status_history": [
                   {
                      "evaluator": "Automated",
                      "status": "Pass",
                      "timestamp": "2022-11-22T00:00:00Z"
                   }
-               ]
+               ],
+               "description": null,
+               "reference": "ecephys-drift-map",
+               "provenance": null
             }
          ],
          "notes": "",
@@ -92,28 +95,30 @@
             {
                "name": "video_1_num_frames",
                "value": 662,
-               "description": null,
-               "reference": null,
                "status_history": [
                   {
                      "evaluator": "Automated",
                      "status": "Pass",
                      "timestamp": "2022-11-22T00:00:00Z"
                   }
-               ]
+               ],
+               "description": null,
+               "reference": null,
+               "provenance": null
             },
             {
                "name": "video_2_num_frames",
                "value": 662,
-               "description": null,
-               "reference": null,
                "status_history": [
                   {
                      "evaluator": "Automated",
                      "status": "Pass",
                      "timestamp": "2022-11-22T00:00:00Z"
                   }
-               ]
+               ],
+               "description": null,
+               "reference": null,
+               "provenance": null
             }
          ],
          "notes": "Pass when video_1_num_frames==video_2_num_frames",
@@ -131,41 +136,44 @@
             {
                "name": "ProbeA_success",
                "value": true,
-               "description": null,
-               "reference": null,
                "status_history": [
                   {
                      "evaluator": "Automated",
                      "status": "Pass",
                      "timestamp": "2022-11-22T00:00:00Z"
                   }
-               ]
+               ],
+               "description": null,
+               "reference": null,
+               "provenance": null
             },
             {
                "name": "ProbeB_success",
                "value": true,
-               "description": null,
-               "reference": null,
                "status_history": [
                   {
                      "evaluator": "Automated",
                      "status": "Pass",
                      "timestamp": "2022-11-22T00:00:00Z"
                   }
-               ]
+               ],
+               "description": null,
+               "reference": null,
+               "provenance": null
             },
             {
                "name": "ProbeC_success",
                "value": true,
-               "description": null,
-               "reference": null,
                "status_history": [
                   {
                      "evaluator": "Automated",
                      "status": "Pass",
                      "timestamp": "2022-11-22T00:00:00Z"
                   }
-               ]
+               ],
+               "description": null,
+               "reference": null,
+               "provenance": null
             }
          ],
          "notes": null,

--- a/examples/quality_control.json
+++ b/examples/quality_control.json
@@ -36,7 +36,7 @@
                ],
                "description": null,
                "reference": "ecephys-drift-map",
-               "provenance": null
+               "evaluated_assets": null
             },
             {
                "name": "Probe B drift",
@@ -63,7 +63,7 @@
                ],
                "description": null,
                "reference": "ecephys-drift-map",
-               "provenance": null
+               "evaluated_assets": null
             },
             {
                "name": "Probe C drift",
@@ -77,7 +77,7 @@
                ],
                "description": null,
                "reference": "ecephys-drift-map",
-               "provenance": null
+               "evaluated_assets": null
             }
          ],
          "notes": "",
@@ -104,7 +104,7 @@
                ],
                "description": null,
                "reference": null,
-               "provenance": null
+               "evaluated_assets": null
             },
             {
                "name": "video_2_num_frames",
@@ -118,7 +118,7 @@
                ],
                "description": null,
                "reference": null,
-               "provenance": null
+               "evaluated_assets": null
             }
          ],
          "notes": "Pass when video_1_num_frames==video_2_num_frames",
@@ -145,7 +145,7 @@
                ],
                "description": null,
                "reference": null,
-               "provenance": null
+               "evaluated_assets": null
             },
             {
                "name": "ProbeB_success",
@@ -159,7 +159,7 @@
                ],
                "description": null,
                "reference": null,
-               "provenance": null
+               "evaluated_assets": null
             },
             {
                "name": "ProbeC_success",
@@ -173,7 +173,7 @@
                ],
                "description": null,
                "reference": null,
-               "provenance": null
+               "evaluated_assets": null
             }
          ],
          "notes": null,

--- a/src/aind_data_schema/core/quality_control.py
+++ b/src/aind_data_schema/core/quality_control.py
@@ -47,7 +47,7 @@ class QCMetric(BaseModel):
     provenance: Optional[List[str]] = Field(
         default=None,
         title="List of asset names that this metric depends on",
-        description="Set to None except when a metric is calculated relative data coming from a different data asset."
+        description="Set to None except when a metric is calculated relative data coming from a different data asset.",
     )
 
     @property

--- a/src/aind_data_schema/core/quality_control.py
+++ b/src/aind_data_schema/core/quality_control.py
@@ -133,8 +133,9 @@ class QCEvaluation(AindModel):
 
     @model_validator(mode="after")
     def validate_multi_session(cls, v):
-        stage = v.get('stage')
-        metrics = v.get('metrics')
+        """Ensure that the evaluated_assets field in any attached metrics is set correctly"""
+        stage = v.stage
+        metrics = v.metrics
 
         if stage == Stage.MULTI_SESSION:
             for metric in metrics:
@@ -147,7 +148,8 @@ class QCEvaluation(AindModel):
             for metric in metrics:
                 if metric.evaluated_assets:
                     raise ValueError(
-                        f"Metric '{metric.name}' is in a single-session QCEvaluation and should not have evaluated_assets"
+                        f"Metric '{metric.name}' is in a single-session ",
+                        "QCEvaluation and should not have evaluated_assets",
                     )
         return v
 

--- a/src/aind_data_schema/core/quality_control.py
+++ b/src/aind_data_schema/core/quality_control.py
@@ -132,7 +132,7 @@ class QCEvaluation(AindModel):
             return failing_metrics
 
     @model_validator(mode="after")
-    def validate_multi_session(cls, v):
+    def validate_multi_asset(cls, v):
         """Ensure that the evaluated_assets field in any attached metrics is set correctly"""
         stage = v.stage
         metrics = v.metrics
@@ -141,7 +141,7 @@ class QCEvaluation(AindModel):
             for metric in metrics:
                 if not metric.evaluated_assets or len(metric.evaluated_assets) == 0:
                     raise ValueError(
-                        f"Metric '{metric.name}' is in a multi-session QCEvaluation and must have evaluated_assets set."
+                        f"Metric '{metric.name}' is in a multi-asset QCEvaluation and must have evaluated_assets set."
                     )
         else:
             # make sure all evaluated assets are None
@@ -149,7 +149,7 @@ class QCEvaluation(AindModel):
                 if metric.evaluated_assets:
                     raise ValueError(
                         (
-                            f"Metric '{metric.name}' is in a single-session QCEvaluation"
+                            f"Metric '{metric.name}' is in a single-asset QCEvaluation"
                             " and should not have evaluated_assets"
                         )
                     )

--- a/src/aind_data_schema/core/quality_control.py
+++ b/src/aind_data_schema/core/quality_control.py
@@ -26,6 +26,7 @@ class Stage(str, Enum):
     RAW = "Raw data"
     PROCESSING = "Processing"
     ANALYSIS = "Analysis"
+    MULTI_ASSET = "Multi-asset"
 
 
 class QCStatus(BaseModel):
@@ -47,7 +48,7 @@ class QCMetric(BaseModel):
     provenance: Optional[List[str]] = Field(
         default=None,
         title="List of asset names that this metric depends on",
-        description="Set to None except when a metric is calculated relative data coming from a different data asset.",
+        description="Set to None except when a metric's calculation required data coming from a different data asset.",
     )
 
     @property

--- a/src/aind_data_schema/core/quality_control.py
+++ b/src/aind_data_schema/core/quality_control.py
@@ -148,8 +148,10 @@ class QCEvaluation(AindModel):
             for metric in metrics:
                 if metric.evaluated_assets:
                     raise ValueError(
-                        f"Metric '{metric.name}' is in a single-session ",
-                        "QCEvaluation and should not have evaluated_assets",
+                        (
+                            f"Metric '{metric.name}' is in a single-session QCEvaluation"
+                            " and should not have evaluated_assets"
+                        )
                     )
         return v
 

--- a/src/aind_data_schema/core/quality_control.py
+++ b/src/aind_data_schema/core/quality_control.py
@@ -41,9 +41,14 @@ class QCMetric(BaseModel):
 
     name: str = Field(..., title="Metric name")
     value: Any = Field(..., title="Metric value")
+    status_history: List[QCStatus] = Field(default=[], title="Metric status history")
     description: Optional[str] = Field(default=None, title="Metric description")
     reference: Optional[str] = Field(default=None, title="Metric reference image URL or plot type")
-    status_history: List[QCStatus] = Field(default=[], title="Metric status history")
+    provenance: Optional[List[str]] = Field(
+        default=None,
+        title="List of asset names that this metric depends on",
+        description="Set to None except when a metric is calculated relative data coming from a different data asset."
+    )
 
     @property
     def status(self) -> QCStatus:

--- a/src/aind_data_schema/core/quality_control.py
+++ b/src/aind_data_schema/core/quality_control.py
@@ -26,7 +26,7 @@ class Stage(str, Enum):
     RAW = "Raw data"
     PROCESSING = "Processing"
     ANALYSIS = "Analysis"
-    MULTI_SESSION = "Multi-session"
+    MULTI_ASSET = "Multi-session"
 
 
 class QCStatus(BaseModel):
@@ -137,7 +137,7 @@ class QCEvaluation(AindModel):
         stage = v.stage
         metrics = v.metrics
 
-        if stage == Stage.MULTI_SESSION:
+        if stage == Stage.MULTI_ASSET:
             for metric in metrics:
                 if not metric.evaluated_assets or len(metric.evaluated_assets) == 0:
                     raise ValueError(

--- a/src/aind_data_schema/core/quality_control.py
+++ b/src/aind_data_schema/core/quality_control.py
@@ -26,7 +26,7 @@ class Stage(str, Enum):
     RAW = "Raw data"
     PROCESSING = "Processing"
     ANALYSIS = "Analysis"
-    MULTI_ASSET = "Multi-session"
+    MULTI_ASSET = "Multi-asset"
 
 
 class QCStatus(BaseModel):

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -285,19 +285,19 @@ class TestMetadata(unittest.TestCase):
         # Tests missing metadata
         surgery1 = Surgery.model_construct(procedures=[nano_inj, ionto_inj])
         m = Metadata(
-                name="ecephys_655019_2023-04-03_18-17-09",
-                location="bucket",
-                data_description=DataDescription.model_construct(
-                    label="some label",
-                    platform=Platform.ECEPHYS,
-                    creation_time=time(12, 12, 12),
-                    modality=[Modality.BEHAVIOR_VIDEOS],
-                ),
-                subject=Subject.model_construct(),
-                procedures=Procedures.model_construct(subject_procedures=[surgery1]),
-                rig=rig,
-                session=session,
-            )
+            name="ecephys_655019_2023-04-03_18-17-09",
+            location="bucket",
+            data_description=DataDescription.model_construct(
+                label="some label",
+                platform=Platform.ECEPHYS,
+                creation_time=time(12, 12, 12),
+                modality=[Modality.BEHAVIOR_VIDEOS],
+            ),
+            subject=Subject.model_construct(),
+            procedures=Procedures.model_construct(subject_procedures=[surgery1]),
+            rig=rig,
+            session=session,
+        )
         self.assertIsNotNone(m)
 
     def test_validate_rig_session_compatibility(self):

--- a/tests/test_quality_control.py
+++ b/tests/test_quality_control.py
@@ -302,7 +302,7 @@ class QualityControlTests(unittest.TestCase):
             ],
         )
 
-        self.assertTrue(evaluation.stage != Stage.MULTI_SESSION)
+        self.assertTrue(evaluation.stage != Stage.MULTI_ASSET)
         self.assertIsNone(evaluation.metrics[0].evaluated_assets)
 
         # Check that single-session QC with evaluated_assets throws a validation error
@@ -333,7 +333,7 @@ class QualityControlTests(unittest.TestCase):
             QCEvaluation(
                 name="Drift map",
                 modality=Modality.ECEPHYS,
-                stage=Stage.MULTI_SESSION,
+                stage=Stage.MULTI_ASSET,
                 metrics=[
                     QCMetric(
                         name="Multiple values example",
@@ -353,7 +353,7 @@ class QualityControlTests(unittest.TestCase):
             QCEvaluation(
                 name="Drift map",
                 modality=Modality.ECEPHYS,
-                stage=Stage.MULTI_SESSION,
+                stage=Stage.MULTI_ASSET,
                 metrics=[
                     QCMetric(
                         name="Multiple values example",

--- a/tests/test_quality_control.py
+++ b/tests/test_quality_control.py
@@ -283,7 +283,7 @@ class QualityControlTests(unittest.TestCase):
         self.assertTrue(expected_exception in repr(context.exception))
 
     def test_multi_session(self):
-        """Ensure that the multi-session QCEvaluation validator checks for evaluated_assets"""
+        """Ensure that the multi-asset QCEvaluation validator checks for evaluated_assets"""
         # Check for non-multi-session that all evaluated_assets are None
         t0 = datetime.fromisoformat("2020-10-10")
 
@@ -305,7 +305,7 @@ class QualityControlTests(unittest.TestCase):
         self.assertTrue(evaluation.stage != Stage.MULTI_ASSET)
         self.assertIsNone(evaluation.metrics[0].evaluated_assets)
 
-        # Check that single-session QC with evaluated_assets throws a validation error
+        # Check that single-asset QC with evaluated_assets throws a validation error
         with self.assertRaises(ValidationError) as context:
             QCEvaluation(
                 name="Drift map",
@@ -325,10 +325,10 @@ class QualityControlTests(unittest.TestCase):
 
         print(context.exception)
         self.assertTrue(
-            "is in a single-session QCEvaluation and should not have evaluated_assets" in repr(context.exception)
+            "is in a single-asset QCEvaluation and should not have evaluated_assets" in repr(context.exception)
         )
 
-        # Check that multi-session with empty evaluated_assets raises a validation error
+        # Check that multi-asset with empty evaluated_assets raises a validation error
         with self.assertRaises(ValidationError) as context:
             QCEvaluation(
                 name="Drift map",
@@ -346,9 +346,9 @@ class QualityControlTests(unittest.TestCase):
                 ],
             )
 
-        self.assertTrue("is in a multi-session QCEvaluation and must have evaluated_assets" in repr(context.exception))
+        self.assertTrue("is in a multi-asset QCEvaluation and must have evaluated_assets" in repr(context.exception))
 
-        # Check that multi-session with missing evaluated_assets raises a validation error
+        # Check that multi-asset with missing evaluated_assets raises a validation error
         with self.assertRaises(ValidationError) as context:
             QCEvaluation(
                 name="Drift map",
@@ -365,7 +365,7 @@ class QualityControlTests(unittest.TestCase):
                 ],
             )
 
-        self.assertTrue("is in a multi-session QCEvaluation and must have evaluated_assets" in repr(context.exception))
+        self.assertTrue("is in a multi-asset QCEvaluation and must have evaluated_assets" in repr(context.exception))
 
 
 if __name__ == "__main__":

--- a/tests/test_quality_control.py
+++ b/tests/test_quality_control.py
@@ -282,6 +282,12 @@ class QualityControlTests(unittest.TestCase):
 
         self.assertTrue(expected_exception in repr(context.exception))
 
+    def test_multi_session(self)
+    """Ensure that the multi-session QCEvaluation validator checks for evaluated_assets"""
+
+    # Check for non-multi-session that all evaluated_assets are None
+
+    # Check that for multi-session all evaluated_assets have at least one value
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_quality_control.py
+++ b/tests/test_quality_control.py
@@ -323,6 +323,7 @@ class QualityControlTests(unittest.TestCase):
                 ],
             )
 
+        print(context.exception)
         self.assertTrue(
             "is in a single-session QCEvaluation and should not have evaluated_assets" in repr(context.exception)
         )


### PR DESCRIPTION
This PR adds a new Stage "MULTI_SESSION" and `evaluated_assets` field that together differentiate QC that is about this data asset from QC that was calculated in a way that depended on some external data asset. The names of those assets are expected to be included in the evaluated_assets list.