### PR TITLE
chore: version limits on -models repo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 dynamic = ["version"]
 
 dependencies = [
-    'aind-data-schema-models>=0.3.2',
+    'aind-data-schema-models>=0.5.4, <1.0.0',
     'dictdiffer',
     'pydantic>=2.7',
     'inflection',


### PR DESCRIPTION
PR bumps the minimum version to 0.5.4 and sets a <1.0.0 upper limit so that we can update the models repo without causing issues here