### PR TITLE
Support modality and stage filters

### DIFF
--- a/src/aind_data_schema/core/quality_control.py
+++ b/src/aind_data_schema/core/quality_control.py
@@ -165,15 +165,29 @@ class QualityControl(AindCoreModel):
     evaluations: List[QCEvaluation] = Field(..., title="Evaluations")
     notes: Optional[str] = Field(default=None, title="Notes")
 
-    @property
-    def status(self) -> Status:
+    def status(self, modality: str = None, stage: Stage = None) -> Status:
         """Loop through all evaluations and return the overall status
 
         Any FAIL -> FAIL
         If no fails, then any PENDING -> PENDING
         All PASS -> PASS
+
+        Parameters
+        ----------
+        modality : str, optional
+            Modality.ONE_OF to filter by, by default None
+        stage : Stage, optional
+            Stage to filter by, by default None
+
+        Returns
+        -------
+        Status
         """
-        eval_statuses = [evaluation.status for evaluation in self.evaluations]
+        eval_statuses = [
+            evaluation.status
+            for evaluation in self.evaluations
+            if (not modality or evaluation.modality == modality) and (not stage or evaluation.stage == stage)
+        ]
 
         if any(status == Status.FAIL for status in eval_statuses):
             return Status.FAIL


### PR DESCRIPTION
This PR changes the `status` property to a function `status(modality, stage)` that can optionally filter the `QCEvaluations` in a `QualityControl` object based on their modality and/or stage.

This is a breaking change, but since nobody actively uses this code I don't think we need to push it off to v2. 