### PR TITLE
feat: adding tag field

### DIFF
--- a/examples/quality_control.json
+++ b/examples/quality_control.json
@@ -80,6 +80,7 @@
                "evaluated_assets": null
             }
          ],
+         "tags": null,
          "notes": "",
          "allow_failed_metrics": false
       },
@@ -121,6 +122,7 @@
                "evaluated_assets": null
             }
          ],
+         "tags": null,
          "notes": "Pass when video_1_num_frames==video_2_num_frames",
          "allow_failed_metrics": false
       },
@@ -176,6 +178,7 @@
                "evaluated_assets": null
             }
          ],
+         "tags": null,
          "notes": null,
          "allow_failed_metrics": false
       }

--- a/src/aind_data_schema/core/quality_control.py
+++ b/src/aind_data_schema/core/quality_control.py
@@ -78,6 +78,9 @@ class QCEvaluation(AindModel):
     name: str = Field(..., title="Evaluation name")
     description: Optional[str] = Field(default=None, title="Evaluation description")
     metrics: List[QCMetric] = Field(..., title="QC metrics")
+    tags: Optional[List[str]] = Field(
+        default=None, title="Tags", description="Tags can be used to group QCEvaluation objects into functional groups"
+    )
     notes: Optional[str] = Field(default=None, title="Notes")
     allow_failed_metrics: bool = Field(
         default=False,

--- a/src/aind_data_schema/core/quality_control.py
+++ b/src/aind_data_schema/core/quality_control.py
@@ -79,7 +79,7 @@ class QCEvaluation(AindModel):
     description: Optional[str] = Field(default=None, title="Evaluation description")
     metrics: List[QCMetric] = Field(..., title="QC metrics")
     tags: Optional[List[str]] = Field(
-        default=None, title="Tags", description="Tags can be used to group QCEvaluation objects into functional groups"
+        default=None, title="Tags", description="Tags can be used to group QCEvaluation objects into groups"
     )
     notes: Optional[str] = Field(default=None, title="Notes")
     allow_failed_metrics: bool = Field(


### PR DESCRIPTION
[backward compatible]

This PR adds a new field `tags` that accepts an optional list[str]. Tags are intended to be used by users to group `QCEvaluation` objects by features beyond modality/stage. The QCPortal will provide a filter dropdown for tags.

For example, during raw ecephys acquisition a user might collect 10 data streams and want to synchronize them, but also might have other evaluations related to the data streams not related to synchronization. The tags can be used to group both data streams (e.g. "data-stream-1" etc) as well as whether they are about synchronization or something else (e.g. "synchronization"), etc. 