### PR TITLE
docs: reference URL and link to example capsule

### DIFF
--- a/docs/source/quality_control.md
+++ b/docs/source/quality_control.md
@@ -72,7 +72,7 @@ We recommend that you write PNG files for images and static multi-panel figures,
 
 **Metadata**
 
-We'll post documentation on how to append `QCEvaluations` to pre-existing quality_control.json files, via DocDB using the `aind-data-access-api`, in the future.
+We'll post documentation on how to append `QCEvaluations` to pre-existing quality_control.json files, via DocDB using the `aind-data-access-api`, in the future. For now, you can refer to the code snippet in the [`aind-qc-capsule-example`](https://github.com/AllenNeuralDynamics/aind-qc-capsule-example/).
 
 **References**
 
@@ -90,17 +90,15 @@ The QC portal automatically calls ``QualityControl.evaluate_status()`` whenever 
 
 **Q: How do reference URLs get pulled into the QC Portal?**
 
-Each metric is associated with a reference figure, image, or video. The QC portal can interpret four ways of setting the reference field:
+Each metric is associated with a reference figure (PDF preferred), image (png preferred), or video (mp4 preferred). The QC portal can interpret four ways of setting the reference field:
 
-- Provide a relative path to a file in this data asset's S3 bucket
+- Provide a relative path to a file in this data asset's S3 bucket, i.e. "figures/my_figure.png". The mount/asset name should not be included.
 - Provide a url to a FigURL figure
 - Provide the name of one of the interactive plots, e.g. "ecephys-drift-map"
 
-<!-- There are many situations where it's helpful to be able to "swipe" between two images. If you have two identical images separated by a ';' the portal will allow users to swipe between them. For example, you might show snippets of the raw electrophysiology raster with detected spikes overlaid on the swipe. -->
-
 **Q: I saw fancy things like dropdowns in the QC Portal, how do I do that?**
 
-By default the QC portal displays dictionaries as tables where the values can be edited. We also support a few special cases to allow a bit more flexibility or to constrain the actions that manual annotators can take. Install the `aind-qcportal-schema` package and set the `value` field to the corresponding pydantic object to use these. 
+By default the QC portal displays dictionaries as tables where the values can be edited. We also support a few special cases to allow a bit more flexibility or to constrain the actions that manual annotators can take. Install the [`aind-qcportal-schema`](https://github.com/AllenNeuralDynamics/aind-qcportal-schema/blob/dev/src/aind_qcportal_schema/metric_value.py) package and set the `value` field to the corresponding pydantic object to use these. 
 
 ### Multi-asset QC
 


### PR DESCRIPTION
This PR adds more clarity about how reference URls should be used and also adds a link to the example capsule code.