### PR TITLE
fix: add default= to schema_version_bump.py

### DIFF
--- a/src/aind_data_schema/core/acquisition.py
+++ b/src/aind_data_schema/core/acquisition.py
@@ -45,7 +45,7 @@ class Acquisition(AindCoreModel):
 
     _DESCRIBED_BY_URL = AindCoreModel._DESCRIBED_BY_BASE_URL.default + "aind_data_schema/core/acquisition.py"
     describedBy: str = Field(default=_DESCRIBED_BY_URL, json_schema_extra={"const": _DESCRIBED_BY_URL})
-    schema_version: SkipValidation[Literal["1.0.3"]] = Field("1.0.3")
+    schema_version: SkipValidation[Literal["1.0.3"]] = Field(default="1.0.3")
     protocol_id: List[str] = Field(default=[], title="Protocol ID", description="DOI for protocols.io")
     experimenter_full_name: List[str] = Field(
         ...,

--- a/src/aind_data_schema/core/data_description.py
+++ b/src/aind_data_schema/core/data_description.py
@@ -40,7 +40,7 @@ class DataDescription(AindCoreModel):
 
     _DESCRIBED_BY_URL = AindCoreModel._DESCRIBED_BY_BASE_URL.default + "aind_data_schema/core/data_description.py"
     describedBy: str = Field(default=_DESCRIBED_BY_URL, json_schema_extra={"const": _DESCRIBED_BY_URL})
-    schema_version: SkipValidation[Literal["1.0.3"]] = Field("1.0.3")
+    schema_version: SkipValidation[Literal["1.0.3"]] = Field(default="1.0.3")
     license: Literal["CC-BY-4.0"] = Field("CC-BY-4.0", title="License")
 
     platform: Platform.ONE_OF = Field(

--- a/src/aind_data_schema/core/instrument.py
+++ b/src/aind_data_schema/core/instrument.py
@@ -35,7 +35,7 @@ class Instrument(AindCoreModel):
 
     _DESCRIBED_BY_URL = AindCoreModel._DESCRIBED_BY_BASE_URL.default + "aind_data_schema/core/instrument.py"
     describedBy: str = Field(default=_DESCRIBED_BY_URL, json_schema_extra={"const": _DESCRIBED_BY_URL})
-    schema_version: SkipValidation[Literal["1.0.3"]] = Field("1.0.3")
+    schema_version: SkipValidation[Literal["1.0.3"]] = Field(default="1.0.3")
 
     instrument_id: Optional[str] = Field(
         default=None,

--- a/src/aind_data_schema/core/metadata.py
+++ b/src/aind_data_schema/core/metadata.py
@@ -71,7 +71,7 @@ class Metadata(AindCoreModel):
 
     _DESCRIBED_BY_URL = AindCoreModel._DESCRIBED_BY_BASE_URL.default + "aind_data_schema/core/metadata.py"
     describedBy: str = Field(default=_DESCRIBED_BY_URL, json_schema_extra={"const": _DESCRIBED_BY_URL})
-    schema_version: SkipValidation[Literal["1.1.1"]] = Field("1.1.1")
+    schema_version: SkipValidation[Literal["1.1.1"]] = Field(default="1.1.1")
     id: UUID = Field(
         default_factory=uuid4,
         alias="_id",

--- a/src/aind_data_schema/core/procedures.py
+++ b/src/aind_data_schema/core/procedures.py
@@ -649,7 +649,7 @@ class Procedures(AindCoreModel):
     _DESCRIBED_BY_URL = AindCoreModel._DESCRIBED_BY_BASE_URL.default + "aind_data_schema/core/procedures.py"
     describedBy: str = Field(default=_DESCRIBED_BY_URL, json_schema_extra={"const": _DESCRIBED_BY_URL})
 
-    schema_version: SkipValidation[Literal["1.1.3"]] = Field("1.1.3")
+    schema_version: SkipValidation[Literal["1.1.3"]] = Field(default="1.1.3")
     subject_id: str = Field(
         ...,
         description="Unique identifier for the subject. If this is not a Allen LAS ID, indicate this in the Notes.",

--- a/src/aind_data_schema/core/processing.py
+++ b/src/aind_data_schema/core/processing.py
@@ -124,7 +124,7 @@ class Processing(AindCoreModel):
 
     _DESCRIBED_BY_URL: str = AindCoreModel._DESCRIBED_BY_BASE_URL.default + "aind_data_schema/core/processing.py"
     describedBy: str = Field(default=_DESCRIBED_BY_URL, json_schema_extra={"const": _DESCRIBED_BY_URL})
-    schema_version: SkipValidation[Literal["1.1.3"]] = Field("1.1.3")
+    schema_version: SkipValidation[Literal["1.1.3"]] = Field(default="1.1.3")
 
     processing_pipeline: PipelineProcess = Field(
         ..., description="Pipeline used to process data", title="Processing Pipeline"

--- a/src/aind_data_schema/core/quality_control.py
+++ b/src/aind_data_schema/core/quality_control.py
@@ -174,7 +174,7 @@ class QualityControl(AindCoreModel):
 
     _DESCRIBED_BY_URL = AindCoreModel._DESCRIBED_BY_BASE_URL.default + "aind_data_schema/core/quality_control.py"
     describedBy: str = Field(default=_DESCRIBED_BY_URL, json_schema_extra={"const": _DESCRIBED_BY_URL})
-    schema_version: SkipValidation[Literal["1.2.1"]] = Field("1.2.1")
+    schema_version: SkipValidation[Literal["1.2.1"]] = Field(default="1.2.1")
     evaluations: List[QCEvaluation] = Field(..., title="Evaluations")
     notes: Optional[str] = Field(default=None, title="Notes")
 

--- a/src/aind_data_schema/core/rig.py
+++ b/src/aind_data_schema/core/rig.py
@@ -51,7 +51,7 @@ class Rig(AindCoreModel):
 
     _DESCRIBED_BY_URL = AindCoreModel._DESCRIBED_BY_BASE_URL.default + "aind_data_schema/core/rig.py"
     describedBy: str = Field(default=_DESCRIBED_BY_URL, json_schema_extra={"const": _DESCRIBED_BY_URL})
-    schema_version: SkipValidation[Literal["1.0.3"]] = Field("1.0.3")
+    schema_version: SkipValidation[Literal["1.0.3"]] = Field(default="1.0.3")
     rig_id: str = Field(
         ...,
         description="Unique rig identifier, name convention: <room>-<apparatus name>-<date modified YYYYMMDD>",

--- a/src/aind_data_schema/core/session.py
+++ b/src/aind_data_schema/core/session.py
@@ -534,7 +534,7 @@ class Session(AindCoreModel):
 
     _DESCRIBED_BY_URL = AindCoreModel._DESCRIBED_BY_BASE_URL.default + "aind_data_schema/core/session.py"
     describedBy: str = Field(default=_DESCRIBED_BY_URL, json_schema_extra={"const": _DESCRIBED_BY_URL})
-    schema_version: SkipValidation[Literal["1.0.3"]] = Field("1.0.3")
+    schema_version: SkipValidation[Literal["1.0.3"]] = Field(default="1.0.3")
     protocol_id: List[str] = Field(default=[], title="Protocol ID", description="DOI for protocols.io")
     experimenter_full_name: List[str] = Field(
         ...,

--- a/src/aind_data_schema/core/subject.py
+++ b/src/aind_data_schema/core/subject.py
@@ -89,7 +89,7 @@ class Subject(AindCoreModel):
 
     _DESCRIBED_BY_URL = AindCoreModel._DESCRIBED_BY_BASE_URL.default + "aind_data_schema/core/subject.py"
     describedBy: str = Field(default=_DESCRIBED_BY_URL, json_schema_extra={"const": _DESCRIBED_BY_URL})
-    schema_version: SkipValidation[Literal["1.0.2"]] = Field("1.0.2")
+    schema_version: SkipValidation[Literal["1.0.2"]] = Field(default="1.0.2")
     subject_id: str = Field(
         ...,
         description="Unique identifier for the subject. If this is not a Allen LAS ID, indicate this in the Notes.",

--- a/src/aind_data_schema/utils/schema_version_bump.py
+++ b/src/aind_data_schema/utils/schema_version_bump.py
@@ -102,7 +102,7 @@ class SchemaVersionHandler:
             file_lines = f.readlines()
         for line in file_lines:
             if "schema_version: SkipValidation[Literal[" in str(line):
-                new_line_str = f'    schema_version: SkipValidation[Literal["{new_ver}"]] = Field("{new_ver}")\n'
+                new_line_str = f'    schema_version: SkipValidation[Literal["{new_ver}"]] = Field(default="{new_ver}")\n'
                 new_line = new_line_str.encode()
             else:
                 new_line = line

--- a/src/aind_data_schema/utils/schema_version_bump.py
+++ b/src/aind_data_schema/utils/schema_version_bump.py
@@ -102,7 +102,9 @@ class SchemaVersionHandler:
             file_lines = f.readlines()
         for line in file_lines:
             if "schema_version: SkipValidation[Literal[" in str(line):
-                new_line_str = f'    schema_version: SkipValidation[Literal["{new_ver}"]] = Field(default="{new_ver}")\n'
+                new_line_str = (
+                    f'    schema_version: SkipValidation[Literal["{new_ver}"]] = Field(default="{new_ver}")\n'
+                )
                 new_line = new_line_str.encode()
             else:
                 new_line = line

--- a/tests/test_bump_schema_versions.py
+++ b/tests/test_bump_schema_versions.py
@@ -77,10 +77,10 @@ class SchemaVersionTests(unittest.TestCase):
         handler._update_files({Subject: new_subject_version, Session: new_session_version})
 
         expected_line_change0 = (
-            f'schema_version: SkipValidation[Literal["{new_subject_version}"]] = Field("{new_subject_version}")'
+            f'schema_version: SkipValidation[Literal["{new_subject_version}"]] = Field(default="{new_subject_version}")'
         )
         expected_line_change1 = (
-            f'schema_version: SkipValidation[Literal["{new_session_version}"]] = Field("{new_session_version}")'
+            f'schema_version: SkipValidation[Literal["{new_session_version}"]] = Field(default="{new_session_version}")'
         )
 
         mock_write_args0 = mock_write.mock_calls[0].args


### PR DESCRIPTION
This PR adds the "default=" back onto schema_version and fixes the schema_version_bump script so it won't remove the field again. The defaults were added in v1.1.X https://github.com/AllenNeuralDynamics/aind-data-schema/pull/1102 and was removed by the schema_version_bump workflow script when the release-v1.2.0 branch was opened.