### PR TITLE
refactor: giving QCEvaluation a state

### DIFF
--- a/examples/quality_control.json
+++ b/examples/quality_control.json
@@ -82,7 +82,8 @@
          ],
          "tags": null,
          "notes": "",
-         "allow_failed_metrics": false
+         "allow_failed_metrics": false,
+         "latest_status": "Pending"
       },
       {
          "modality": {
@@ -124,7 +125,8 @@
          ],
          "tags": null,
          "notes": "Pass when video_1_num_frames==video_2_num_frames",
-         "allow_failed_metrics": false
+         "allow_failed_metrics": false,
+         "latest_status": "Pass"
       },
       {
          "modality": {
@@ -180,7 +182,8 @@
          ],
          "tags": null,
          "notes": null,
-         "allow_failed_metrics": false
+         "allow_failed_metrics": false,
+         "latest_status": "Pass"
       }
    ],
    "notes": null

--- a/src/aind_data_schema/core/quality_control.py
+++ b/src/aind_data_schema/core/quality_control.py
@@ -92,7 +92,7 @@ class QCEvaluation(AindModel):
             " will allow individual metrics to fail while still passing the evaluation."
         ),
     )
-    latest_status: Status = Field(default=None, title="Evaluation status", exclude=True)
+    latest_status: Status = Field(default=None, title="Evaluation status")
 
     def status(self, date: datetime = datetime.now(tz=timezone.utc)) -> Status:
         """DEPRECATED

--- a/tests/test_quality_control.py
+++ b/tests/test_quality_control.py
@@ -15,8 +15,7 @@ class QualityControlTests(unittest.TestCase):
     def test_constructors(self):
         """testing constructors"""
 
-        with self.assertRaises(ValidationError):
-            q = QualityControl()
+        self.assertRaises(ValidationError, QualityControl)
 
         test_eval = QCEvaluation(
             name="Drift map",
@@ -76,7 +75,7 @@ class QualityControlTests(unittest.TestCase):
         )
 
         # check that evaluation status gets auto-set if it has never been set before
-        self.assertEqual(test_eval.status(), Status.PASS)
+        self.assertEqual(test_eval.status, Status.PASS)
 
         q = QualityControl(
             evaluations=[test_eval, test_eval],
@@ -147,7 +146,7 @@ class QualityControlTests(unittest.TestCase):
             ],
         )
 
-        self.assertEqual(evaluation.status(), Status.PASS)
+        self.assertEqual(evaluation.status, Status.PASS)
 
         # Add a pending metric, evaluation should now evaluate to pending
         evaluation.metrics.append(
@@ -163,8 +162,9 @@ class QualityControlTests(unittest.TestCase):
                 ],
             )
         )
+        evaluation.status = evaluation.evaluate_status()
 
-        self.assertEqual(evaluation.status(), Status.PENDING)
+        self.assertEqual(evaluation.status, Status.PENDING)
 
         # Add a failing metric, evaluation should now evaluate to fail
         evaluation.metrics.append(
@@ -178,8 +178,9 @@ class QualityControlTests(unittest.TestCase):
                 ],
             )
         )
+        evaluation.status = evaluation.evaluate_status()
 
-        self.assertEqual(evaluation.status(), Status.FAIL)
+        self.assertEqual(evaluation.status, Status.FAIL)
 
     def test_allowed_failed_metrics(self):
         """Test that if you set the flag to allow failures that evaluations pass"""
@@ -218,14 +219,17 @@ class QualityControlTests(unittest.TestCase):
 
         evaluation.allow_failed_metrics = True
 
-        self.assertEqual(evaluation.status(), Status.PENDING)
+        self.assertEqual(evaluation.status, Status.PENDING)
 
         # Replace the pending evaluation with a fail, evaluation should not evaluate to pass
         evaluation.metrics[1].status_history[0].status = Status.FAIL
+        evaluation.status = evaluation.evaluate_status()
 
-        self.assertEqual(evaluation.status(), Status.PASS)
+        self.assertEqual(evaluation.status, Status.PASS)
 
         metric2.status_history[0].status = Status.FAIL
+        evaluation.status = evaluation.evaluate_status()
+
         self.assertEqual(evaluation.failed_metrics, [metric2])
 
     def test_metric_history_order(self):
@@ -484,10 +488,10 @@ class QualityControlTests(unittest.TestCase):
             metrics=[metric],
         )
 
-        self.assertRaises(ValueError, test_eval.status, date=t0_5)
-        self.assertEqual(test_eval.status(date=t1_5), Status.FAIL)
-        self.assertEqual(test_eval.status(date=t2_5), Status.PENDING)
-        self.assertEqual(test_eval.status(date=t3_5), Status.PASS)
+        self.assertRaises(ValueError, test_eval.evaluate_status, date=t0_5)
+        self.assertEqual(test_eval.evaluate_status(date=t1_5), Status.FAIL)
+        self.assertEqual(test_eval.evaluate_status(date=t2_5), Status.PENDING)
+        self.assertEqual(test_eval.evaluate_status(date=t3_5), Status.PASS)
 
         qc = QualityControl(evaluations=[test_eval])
 

--- a/tests/test_quality_control.py
+++ b/tests/test_quality_control.py
@@ -181,6 +181,7 @@ class QualityControlTests(unittest.TestCase):
         evaluation.latest_status = evaluation.evaluate_status()
 
         self.assertEqual(evaluation.latest_status, Status.FAIL)
+        self.assertEqual(evaluation.status(), evaluation.latest_status)
 
     def test_allowed_failed_metrics(self):
         """Test that if you set the flag to allow failures that evaluations pass"""

--- a/tests/test_quality_control.py
+++ b/tests/test_quality_control.py
@@ -75,7 +75,7 @@ class QualityControlTests(unittest.TestCase):
         )
 
         # check that evaluation status gets auto-set if it has never been set before
-        self.assertEqual(test_eval.status, Status.PASS)
+        self.assertEqual(test_eval.latest_status, Status.PASS)
 
         q = QualityControl(
             evaluations=[test_eval, test_eval],
@@ -146,7 +146,7 @@ class QualityControlTests(unittest.TestCase):
             ],
         )
 
-        self.assertEqual(evaluation.status, Status.PASS)
+        self.assertEqual(evaluation.latest_status, Status.PASS)
 
         # Add a pending metric, evaluation should now evaluate to pending
         evaluation.metrics.append(
@@ -162,9 +162,9 @@ class QualityControlTests(unittest.TestCase):
                 ],
             )
         )
-        evaluation.status = evaluation.evaluate_status()
+        evaluation.latest_status = evaluation.evaluate_status()
 
-        self.assertEqual(evaluation.status, Status.PENDING)
+        self.assertEqual(evaluation.latest_status, Status.PENDING)
 
         # Add a failing metric, evaluation should now evaluate to fail
         evaluation.metrics.append(
@@ -178,9 +178,9 @@ class QualityControlTests(unittest.TestCase):
                 ],
             )
         )
-        evaluation.status = evaluation.evaluate_status()
+        evaluation.latest_status = evaluation.evaluate_status()
 
-        self.assertEqual(evaluation.status, Status.FAIL)
+        self.assertEqual(evaluation.latest_status, Status.FAIL)
 
     def test_allowed_failed_metrics(self):
         """Test that if you set the flag to allow failures that evaluations pass"""
@@ -219,16 +219,16 @@ class QualityControlTests(unittest.TestCase):
 
         evaluation.allow_failed_metrics = True
 
-        self.assertEqual(evaluation.status, Status.PENDING)
+        self.assertEqual(evaluation.latest_status, Status.PENDING)
 
         # Replace the pending evaluation with a fail, evaluation should not evaluate to pass
         evaluation.metrics[1].status_history[0].status = Status.FAIL
-        evaluation.status = evaluation.evaluate_status()
+        evaluation.latest_status = evaluation.evaluate_status()
 
-        self.assertEqual(evaluation.status, Status.PASS)
+        self.assertEqual(evaluation.latest_status, Status.PASS)
 
         metric2.status_history[0].status = Status.FAIL
-        evaluation.status = evaluation.evaluate_status()
+        evaluation.latest_status = evaluation.evaluate_status()
 
         self.assertEqual(evaluation.failed_metrics, [metric2])
 


### PR DESCRIPTION
This PR adds a `QCEvaluation.latest_status` attribute and renames `QCEvaluation.status() to QCEvaluation.evaluate_status()`

This guarantees that QCEvaluation records have a human readable status field. Backward compatibility is maintained by deprecating the `.status()` function but redirecting it to `evaluate_status()`