### PR TITLE
feat: adding created field to QCEvaluation

### DIFF
--- a/examples/quality_control.json
+++ b/examples/quality_control.json
@@ -141,7 +141,7 @@
             }
          ],
          "tags": null,
-         "notes": null,
+         "notes": "Pass when video_1_num_frames==video_2_num_frames",
          "allow_failed_metrics": false,
          "latest_status": "Pass",
          "created": "2022-11-22T00:00:00Z"

--- a/examples/quality_control.json
+++ b/examples/quality_control.json
@@ -83,7 +83,8 @@
          "tags": null,
          "notes": "",
          "allow_failed_metrics": false,
-         "latest_status": "Pending"
+         "latest_status": "Pending",
+         "created": "2022-11-22T00:00:00Z"
       },
       {
          "modality": {
@@ -126,7 +127,8 @@
          "tags": null,
          "notes": "Pass when video_1_num_frames==video_2_num_frames",
          "allow_failed_metrics": false,
-         "latest_status": "Pass"
+         "latest_status": "Pass",
+         "created": "2022-11-22T00:00:00Z"
       },
       {
          "modality": {
@@ -183,7 +185,8 @@
          "tags": null,
          "notes": null,
          "allow_failed_metrics": false,
-         "latest_status": "Pass"
+         "latest_status": "Pass",
+         "created": "2022-11-22T00:00:00Z"
       }
    ],
    "notes": null

--- a/examples/quality_control.py
+++ b/examples/quality_control.py
@@ -52,6 +52,7 @@ eval0 = QCEvaluation(
         QCMetric(name="Probe C drift", value="Low", reference="ecephys-drift-map", status_history=[s]),
     ],
     notes="",
+    created=t,
 )
 
 eval1 = QCEvaluation(
@@ -63,6 +64,7 @@ eval1 = QCEvaluation(
         QCMetric(name="video_2_num_frames", value=662, status_history=[s]),
     ],
     notes="Pass when video_1_num_frames==video_2_num_frames",
+    created=t,
 )
 
 eval2 = QCEvaluation(
@@ -74,6 +76,7 @@ eval2 = QCEvaluation(
         QCMetric(name="ProbeB_success", value=True, status_history=[s]),
         QCMetric(name="ProbeC_success", value=True, status_history=[s]),
     ],
+    created=t,
 )
 
 q = QualityControl(evaluations=[eval0, eval1, eval2])

--- a/src/aind_data_schema/core/quality_control.py
+++ b/src/aind_data_schema/core/quality_control.py
@@ -93,7 +93,9 @@ class QCEvaluation(AindModel):
         ),
     )
     latest_status: Status = Field(default=None, title="Evaluation status")
-    created: AwareDatetimeWithDefault = Field(default_factory=lambda: datetime.now(tz=timezone.utc), title="Evaluation creation date")
+    created: AwareDatetimeWithDefault = Field(
+        default_factory=lambda: datetime.now(tz=timezone.utc), title="Evaluation creation date"
+    )
 
     def status(self, date: datetime = datetime.now(tz=timezone.utc)) -> Status:
         """DEPRECATED

--- a/src/aind_data_schema/core/quality_control.py
+++ b/src/aind_data_schema/core/quality_control.py
@@ -93,6 +93,7 @@ class QCEvaluation(AindModel):
         ),
     )
     latest_status: Status = Field(default=None, title="Evaluation status")
+    created: AwareDatetimeWithDefault = Field(default_factory=lambda: datetime.now(tz=timezone.utc), title="Evaluation creation date")
 
     def status(self, date: datetime = datetime.now(tz=timezone.utc)) -> Status:
         """DEPRECATED

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -118,6 +118,7 @@ class BaseTests(unittest.TestCase):
 
         class StructureModel(AindModel):
             """Test model with a targeted_structure"""
+
             targeted_structure: CCFStructure.ONE_OF
 
         self.assertRaises(ValueError, StructureModel, targeted_structure="invalid")


### PR DESCRIPTION
This PR adds `QCEvaluation.created` which automatically timestamps each evaluation object. This fixes a mistake in the original design, because we need this information to be able to override evaluations with newer copies of them. Downstream in the portal we'll use this information to display only the most recent copy of overridden evaluations (where the `name` field is identical). 

Note that in the tests I have to overwrite the created field, since we can't know in advance what the default_factory output will be when the tests are run.