### PR TITLE
feat: auto-bump schema versions to current version

### DIFF
--- a/src/aind_data_schema/base.py
+++ b/src/aind_data_schema/base.py
@@ -126,8 +126,7 @@ class AindCoreModel(AindModel):
     @field_validator("schema_version", mode="before")
     @classmethod
     def coerce_version(cls, v: str) -> str:
-        """Update the schema version to the latest version
-        """
+        """Update the schema version to the latest version"""
         return get_args(cls.model_fields["schema_version"].annotation)[0]
 
     @classmethod

--- a/src/aind_data_schema/base.py
+++ b/src/aind_data_schema/base.py
@@ -3,7 +3,7 @@
 import json
 import re
 from pathlib import Path
-from typing import Any, Generic, Optional, TypeVar
+from typing import Any, Generic, Optional, TypeVar, get_args
 
 from pydantic import (
     AwareDatetime,
@@ -16,6 +16,7 @@ from pydantic import (
     ValidatorFunctionWrapHandler,
     create_model,
     model_validator,
+    field_validator,
 )
 from pydantic.functional_validators import WrapValidator
 from typing_extensions import Annotated
@@ -121,6 +122,13 @@ class AindCoreModel(AindModel):
     schema_version: str = Field(
         ..., pattern=r"^\d+.\d+.\d+$", description="schema version", title="Version", frozen=True
     )
+
+    @field_validator("schema_version", mode="before")
+    @classmethod
+    def coerce_version(cls, v: str) -> str:
+        """Update the schema version to the latest version
+        """
+        return get_args(cls.model_fields["schema_version"].annotation)[0]
 
     @classmethod
     def default_filename(cls):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -129,10 +129,12 @@ class BaseTests(unittest.TestCase):
         and that validation errors prevent bumping"""
 
         class Modelv1(AindCoreModel):
+            """test class"""
             describedBy: str = "modelv1"
             schema_version: SkipValidation[Literal["1.0.0"]] = "1.0.0"
 
         class Modelv2(AindCoreModel):
+            """test class"""
             describedBy: str = "modelv2"
             schema_version: SkipValidation[Literal["1.0.1"]] = "1.0.1"
             extra_field: str = "extra_field"

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -119,6 +119,7 @@ class BaseTests(unittest.TestCase):
 
         class StructureModel(AindModel):
             """Test model with a targeted_structure"""
+
             targeted_structure: CCFStructure.ONE_OF
 
         self.assertRaises(ValueError, StructureModel, targeted_structure="invalid")
@@ -126,6 +127,7 @@ class BaseTests(unittest.TestCase):
     def test_schema_bump(self):
         """Test that schema version are bumped successfully
         and that validation errors prevent bumping"""
+
         class Modelv1(AindCoreModel):
             describedBy: str = "modelv1"
             schema_version: SkipValidation[Literal["1.0.0"]] = "1.0.0"
@@ -138,9 +140,7 @@ class BaseTests(unittest.TestCase):
         v1_init = Modelv1()
         self.assertEqual("1.0.0", v1_init.schema_version)
 
-        v2_from_v1 = Modelv2(
-            **v1_init.model_dump()
-        )
+        v2_from_v1 = Modelv2(**v1_init.model_dump())
         self.assertEqual("1.0.1", v2_from_v1.schema_version)
 
         # Check that adding additional fields still fails validation

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, call, mock_open, patch
 
-from pydantic import ValidationError, create_model, SkipValidation, field_validator
+from pydantic import ValidationError, create_model, SkipValidation
 from typing import Literal
 
 from aind_data_schema.base import AindGeneric, AwareDatetimeWithDefault, is_dict_corrupt, AindModel, AindCoreModel


### PR DESCRIPTION
This PR fixes a bug that we introduced by adding the `SkipValidation` wrapper on `schema_version`. Now if an `AindCoreModel` validates successfully it is guaranteed to have the correct schema version field.

I think the `SkipValidation` could now be removed? 