### PR TITLE
fix: make model modality into list

### DIFF
--- a/src/aind_data_schema/core/model.py
+++ b/src/aind_data_schema/core/model.py
@@ -62,7 +62,7 @@ class Model(AindCoreModel):
     license: str = Field(..., title="License")
     developer_full_name: Optional[List[str]] = Field(default=None, title="Name of developer")
     developer_institution: Optional[Organization.ONE_OF] = Field(default=None, title="Institute where developed")
-    modality: Modality.ONE_OF = Field(..., title="Modality")
+    modality: List[Modality.ONE_OF] = Field(..., title="Modality")
     architecture: ModelArchitecture = Field(..., title="Model architecture")
     intended_use: str = Field(..., title="Intended model use", description="Semantic description of intended use")
     limitations: Optional[str] = Field(default=None, title="Model limitations")

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -28,7 +28,7 @@ class ModelTests(unittest.TestCase):
             license="CC-BY-4.0",
             developer_full_name=["Joe Schmoe"],
             developer_institution=Organization.AIND,
-            modality=Modality.SPIM,
+            modality=[Modality.SPIM],
             pretrained_source_url="url pretrained weights are from",
             architecture=ModelArchitecture(
                 backbone=ModelBackbone.RESNET,


### PR DESCRIPTION
Minor fix to #1166 to change the modality field of models to a list of modalities.
Closes #1078 