### PR TITLE
feat: adding a max file size warning

### DIFF
--- a/src/aind_data_schema/base.py
+++ b/src/aind_data_schema/base.py
@@ -184,5 +184,6 @@ class AindCoreModel(AindModel):
         with open(filename, "w") as f:
             f.write(self.model_dump_json(indent=3))
 
-        if os.path.getsize(filename) > MAX_FILE_SIZE:
+        # Check that size doesn't exceed the maximum
+        if len(self.model_dump_json(indent=3)) > MAX_FILE_SIZE:
             logging.warning(f"File size exceeds {MAX_FILE_SIZE / 1024} KB: {filename}")

--- a/src/aind_data_schema/base.py
+++ b/src/aind_data_schema/base.py
@@ -2,7 +2,6 @@
 
 import json
 import re
-import os
 import logging
 from pathlib import Path
 from typing import Any, Generic, Optional, TypeVar, get_args

--- a/src/aind_data_schema/base.py
+++ b/src/aind_data_schema/base.py
@@ -2,6 +2,8 @@
 
 import json
 import re
+import os
+import logging
 from pathlib import Path
 from typing import Any, Generic, Optional, TypeVar, get_args
 
@@ -21,6 +23,9 @@ from pydantic import (
 from pydantic.functional_validators import WrapValidator
 from typing_extensions import Annotated
 from aind_data_schema_models.brain_atlas import CCFStructure
+
+
+MAX_FILE_SIZE = 500 * 1024  # 500KB
 
 
 def _coerce_naive_datetime(v: Any, handler: ValidatorFunctionWrapHandler) -> AwareDatetime:
@@ -178,3 +183,6 @@ class AindCoreModel(AindModel):
 
         with open(filename, "w") as f:
             f.write(self.model_dump_json(indent=3))
+
+        if os.path.getsize(filename) > MAX_FILE_SIZE:
+            logging.warning(f"File size exceeds {MAX_FILE_SIZE / 1024} KB: {filename}")

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -165,7 +165,7 @@ class BaseTests(unittest.TestCase):
         """Tests that a warning is logged if the file size exceeds MAX_FILE_SIZE"""
 
         s = Subject.model_construct()
-        s.subject_id = "s"*(MAX_FILE_SIZE + 1000)
+        s.subject_id = "s" * (MAX_FILE_SIZE + 1000)
         s.write_standard_file(output_directory=Path("dir"), suffix=".foo.bar")
 
         mock_open.assert_has_calls([call(Path("dir/subject.foo.bar"), "w")])

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -159,17 +159,13 @@ class BaseTests(unittest.TestCase):
         # this is to ensure you can't get a bumped schema_version without passing validation
         self.assertRaises(ValidationError, lambda: Modelv1(**v2_from_v1.model_dump()))
 
-    @patch("os.path.getsize")
     @patch("builtins.open", new_callable=mock_open)
     @patch("logging.warning")
-    def test_write_standard_file_size_warning(
-        self, mock_logging_warning: MagicMock, mock_open: MagicMock, mock_getsize: MagicMock
-    ):
+    def test_write_standard_file_size_warning(self, mock_logging_warning: MagicMock, mock_open: MagicMock):
         """Tests that a warning is logged if the file size exceeds MAX_FILE_SIZE"""
 
-        mock_getsize.return_value = MAX_FILE_SIZE + 1  # Simulate file size exceeding the limit
-
         s = Subject.model_construct()
+        s.subject_id = "s"*(MAX_FILE_SIZE + 1000)
         s.write_standard_file(output_directory=Path("dir"), suffix=".foo.bar")
 
         mock_open.assert_has_calls([call(Path("dir/subject.foo.bar"), "w")])

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -159,23 +159,23 @@ class BaseTests(unittest.TestCase):
         # this is to ensure you can't get a bumped schema_version without passing validation
         self.assertRaises(ValidationError, lambda: Modelv1(**v2_from_v1.model_dump()))
 
-        @patch("os.path.getsize")
-        @patch("builtins.open", new_callable=mock_open)
-        @patch("logging.warning")
-        def test_write_standard_file_size_warning(
-            self, mock_logging_warning: MagicMock, mock_open: MagicMock, mock_getsize: MagicMock
-        ):
-            """Tests that a warning is logged if the file size exceeds MAX_FILE_SIZE"""
+    @patch("os.path.getsize")
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("logging.warning")
+    def test_write_standard_file_size_warning(
+        self, mock_logging_warning: MagicMock, mock_open: MagicMock, mock_getsize: MagicMock
+    ):
+        """Tests that a warning is logged if the file size exceeds MAX_FILE_SIZE"""
 
-            mock_getsize.return_value = MAX_FILE_SIZE + 1  # Simulate file size exceeding the limit
+        mock_getsize.return_value = MAX_FILE_SIZE + 1  # Simulate file size exceeding the limit
 
-            s = Subject.model_construct()
-            s.write_standard_file(output_directory=Path("dir"), suffix=".foo.bar")
+        s = Subject.model_construct()
+        s.write_standard_file(output_directory=Path("dir"), suffix=".foo.bar")
 
-            mock_open.assert_has_calls([call(Path("dir/subject.foo.bar"), "w")])
-            mock_logging_warning.assert_called_once_with(
-                f"File size exceeds {MAX_FILE_SIZE / 1024} KB: dir/subject.foo.bar"
-            )
+        mock_open.assert_has_calls([call(Path("dir/subject.foo.bar"), "w")])
+        mock_logging_warning.assert_called_once_with(
+            f"File size exceeds {MAX_FILE_SIZE / 1024} KB: dir/subject.foo.bar"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -40,8 +40,7 @@ class BaseTests(unittest.TestCase):
         """Tests writer with suffix and output directory defined"""
 
         s = Subject.model_construct()
-        with patch("os.path.getsize", return_value=1):
-            s.write_standard_file(output_directory=Path("dir"), suffix=".foo.bar")
+        s.write_standard_file(output_directory=Path("dir"), suffix=".foo.bar")
         mock_open.assert_has_calls([call(Path("dir/subject.foo.bar"), "w")])
         self.assertEqual(1, 1)
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -32,7 +32,7 @@ class ExampleTests(unittest.TestCase):
             module = importlib.util.module_from_spec(spec)
             sys.modules["test_module"] = module
 
-            with patch("builtins.open", new_callable=mock_open) as mocked_file:
+            with patch("os.path.getsize", return_value=0), patch("builtins.open", new_callable=mock_open) as mocked_file:
                 spec.loader.exec_module(module)
                 h = mocked_file.return_value.__enter__()
                 call_args_list = h.write.call_args_list

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -32,7 +32,9 @@ class ExampleTests(unittest.TestCase):
             module = importlib.util.module_from_spec(spec)
             sys.modules["test_module"] = module
 
-            with patch("os.path.getsize", return_value=0), patch("builtins.open", new_callable=mock_open) as mocked_file:
+            with patch("os.path.getsize", return_value=0), patch(
+                "builtins.open", new_callable=mock_open
+            ) as mocked_file:
                 spec.loader.exec_module(module)
                 h = mocked_file.return_value.__enter__()
                 call_args_list = h.write.call_args_list

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -32,9 +32,7 @@ class ExampleTests(unittest.TestCase):
             module = importlib.util.module_from_spec(spec)
             sys.modules["test_module"] = module
 
-            with patch("os.path.getsize", return_value=0), patch(
-                "builtins.open", new_callable=mock_open
-            ) as mocked_file:
+            with patch("builtins.open", new_callable=mock_open) as mocked_file:
                 spec.loader.exec_module(module)
                 h = mocked_file.return_value.__enter__()
                 call_args_list = h.write.call_args_list


### PR DESCRIPTION
This PR adds a call to `logging.warning` when the file size generated by `write_standard_file` exceeds 500 KB