### PR TITLE
fix: pull datetime at runtime instead of at package import time

### DIFF
--- a/src/aind_data_schema/core/quality_control.py
+++ b/src/aind_data_schema/core/quality_control.py
@@ -135,7 +135,7 @@ class QCEvaluation(AindModel):
         self.latest_status = self.evaluate_status()
         return self
 
-    def evaluate_status(self, date: datetime = datetime.now(tz=timezone.utc)) -> Status:
+    def evaluate_status(self, date: Optional[datetime] = None) -> Status:
         """Loop through all metrics and return the evaluation's status
 
         Any fail -> FAIL
@@ -147,6 +147,9 @@ class QCEvaluation(AindModel):
         Status
             Current status of the evaluation
         """
+        if not date:
+            date = datetime.now(tz=timezone.utc)
+
         latest_metric_statuses = []
 
         for metric in self.metrics:
@@ -205,7 +208,7 @@ class QualityControl(AindCoreModel):
         modality: Union[Modality.ONE_OF, List[Modality.ONE_OF], None] = None,
         stage: Union[Stage, List[Stage], None] = None,
         tag: Union[str, List[str], None] = None,
-        date: datetime = datetime.now(tz=timezone.utc),
+        date: Optional[datetime] = None,
     ) -> Status:
         """Loop through all evaluations and return the overall status
 
@@ -213,6 +216,9 @@ class QualityControl(AindCoreModel):
         If no fails, then any PENDING -> PENDING
         All PASS -> PASS
         """
+        if not date:
+            date = datetime.now(tz=timezone.utc)
+
         if not modality and not stage and not tag:
             eval_statuses = [evaluation.evaluate_status(date=date) for evaluation in self.evaluations]
         else:


### PR DESCRIPTION
This PR fixes a bug in the `QualityControl.status()` function where the default `date` parameter was being set at package import time instead of at runtime. This causes an issue in downstream code where if a server doesn't get restarted fairly often then it flags QC data with dates in the future (from it's perspective) as being invalid.