### PR TITLE
feat: add LightAssembly class

### DIFF
--- a/src/aind_data_schema/components/devices.py
+++ b/src/aind_data_schema/components/devices.py
@@ -560,6 +560,17 @@ class Lamp(Device):
     temperature_unit: Optional[TemperatureUnit] = Field(default=None, title="Temperature unit")
 
 
+class LightAssembly(DataModel):
+    """Named assembly of a light source and lens"""
+
+    device_type: Literal["Light assembly"] = "Light assembly"
+
+    # required fields
+    name: str = Field(..., title="Light assembly name")
+    light: Annotated[Union[Laser, LightEmittingDiode, Lamp], Field(discriminator="device_type")]
+    lens: Lens = Field(..., title="Lens")
+
+
 class ProbePort(DataModel):
     """Port for a probe connection"""
 

--- a/src/aind_data_schema/components/devices.py
+++ b/src/aind_data_schema/components/devices.py
@@ -570,6 +570,9 @@ class LightAssembly(DataModel):
     light: Annotated[Union[Laser, LightEmittingDiode, Lamp], Field(discriminator="device_type")]
     lens: Lens = Field(..., title="Lens")
 
+    # optional fields
+    filter: Optional[Filter] = Field(default=None, title="Filter")
+
 
 class ProbePort(DataModel):
     """Port for a probe connection"""


### PR DESCRIPTION
This PR adds a LightAssembly class to a allow lights to be combined with a lens. It's possible other devices (filter?) should be allowed in a light assembly as well?