### PR TITLE
fix: fix incorrect use of model_validate_json

### DIFF
--- a/src/aind_data_schema/core/metadata.py
+++ b/src/aind_data_schema/core/metadata.py
@@ -147,7 +147,7 @@ class Metadata(AindCoreModel):
         # If the input is a json object, we will try to create the field
         if isinstance(value, dict):
             try:
-                core_model = field_class.model_validate_json(value)
+                core_model = field_class.model_validate(value)
             # If a validation error is raised,
             # we will construct the field without validation.
             except ValidationError:
@@ -203,7 +203,8 @@ class Metadata(AindCoreModel):
                 model_contents = model.model_dump()
                 try:
                     model_class(**model_contents)
-                except ValidationError:
+                except ValidationError as e:
+                    print(f"Error in {field_name}: {e}")
                     metadata_status = MetadataStatus.INVALID
         # For certain required fields, like subject, if they are not present,
         # mark the metadata record as missing

--- a/src/aind_data_schema/core/metadata.py
+++ b/src/aind_data_schema/core/metadata.py
@@ -150,7 +150,8 @@ class Metadata(AindCoreModel):
                 core_model = field_class.model_validate(value)
             # If a validation error is raised,
             # we will construct the field without validation.
-            except ValidationError:
+            except ValidationError as e:
+                print(f"Error in {field_name}: {e}")
                 core_model = field_class.model_construct(**value)
         else:
             core_model = value

--- a/src/aind_data_schema/core/metadata.py
+++ b/src/aind_data_schema/core/metadata.py
@@ -144,14 +144,11 @@ class Metadata(AindCoreModel):
         field_name = info.field_name
         field_class = [f for f in get_args(cls.model_fields[field_name].annotation) if inspect.isclass(f)][0]
 
-        # If the input is a json object, we will try to create the field
         if isinstance(value, dict):
             try:
                 core_model = field_class.model_validate(value)
-            # If a validation error is raised,
-            # we will construct the field without validation.
             except ValidationError as e:
-                print(f"Error in {field_name}: {e}")
+                print(f"Error in validating {field_name}: {e}")
                 core_model = field_class.model_construct(**value)
         else:
             core_model = value

--- a/src/aind_data_schema/core/metadata.py
+++ b/src/aind_data_schema/core/metadata.py
@@ -148,7 +148,7 @@ class Metadata(AindCoreModel):
             try:
                 core_model = field_class.model_validate(value)
             except ValidationError as e:
-                print(f"Error in validating {field_name}: {e}")
+                logging.warning(f"Error in validating {field_name}: {e}")
                 core_model = field_class.model_construct(**value)
         else:
             core_model = value
@@ -202,7 +202,7 @@ class Metadata(AindCoreModel):
                 try:
                     model_class(**model_contents)
                 except ValidationError as e:
-                    print(f"Error in {field_name}: {e}")
+                    logging.warning(f"Error in {field_name}: {e}")
                     metadata_status = MetadataStatus.INVALID
         # For certain required fields, like subject, if they are not present,
         # mark the metadata record as missing

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -418,12 +418,11 @@ class TestMetadata(unittest.TestCase):
         )
         expected_result = json.loads(expected_md.model_dump_json(by_alias=True))
         # there are some userwarnings when creating Subject from json
-        with self.assertWarns(UserWarning):
-            result = create_metadata_json(
-                name=self.sample_name,
-                location=self.sample_location,
-                core_jsons=core_jsons,
-            )
+        result = create_metadata_json(
+            name=self.sample_name,
+            location=self.sample_location,
+            core_jsons=core_jsons,
+        )
         # check that metadata was created with expected values
         self.assertEqual(self.sample_name, result["name"])
         self.assertEqual(self.sample_location, result["location"])
@@ -445,17 +444,15 @@ class TestMetadata(unittest.TestCase):
         external_links = {
             ExternalPlatforms.CODEOCEAN.value: ["123", "abc"],
         }
-        # there are some userwarnings when creating from json
-        with self.assertWarns(UserWarning):
-            result = create_metadata_json(
-                name=self.sample_name,
-                location=self.sample_location,
-                core_jsons={
-                    "subject": self.subject_json,
-                },
-                optional_created=created,
-                optional_external_links=external_links,
-            )
+        result = create_metadata_json(
+            name=self.sample_name,
+            location=self.sample_location,
+            core_jsons={
+                "subject": self.subject_json,
+            },
+            optional_created=created,
+            optional_external_links=external_links,
+        )
         self.assertEqual(self.sample_name, result["name"])
         self.assertEqual(self.sample_location, result["location"])
         self.assertEqual("2024-10-31T12:00:00Z", result["created"])
@@ -476,13 +473,11 @@ class TestMetadata(unittest.TestCase):
             "instrument": None,
             "quality_control": None,
         }
-        # there are some userwarnings when creating Subject from json
-        with self.assertWarns(UserWarning):
-            result = create_metadata_json(
-                name=self.sample_name,
-                location=self.sample_location,
-                core_jsons=core_jsons,
-            )
+        result = create_metadata_json(
+            name=self.sample_name,
+            location=self.sample_location,
+            core_jsons=core_jsons,
+        )
         # check that metadata was still created
         self.assertEqual(self.sample_name, result["name"])
         self.assertEqual(self.sample_location, result["location"])
@@ -513,13 +508,11 @@ class TestMetadata(unittest.TestCase):
             "instrument": None,
             "quality_control": None,
         }
-        # there are some userwarnings when creating Subject from json
-        with self.assertWarns(UserWarning):
-            result = create_metadata_json(
-                name=self.sample_name,
-                location=self.sample_location,
-                core_jsons=core_jsons,
-            )
+        result = create_metadata_json(
+            name=self.sample_name,
+            location=self.sample_location,
+            core_jsons=core_jsons,
+        )
         # check that metadata was still created
         self.assertEqual(self.sample_name, result["name"])
         self.assertEqual(self.sample_location, result["location"])


### PR DESCRIPTION
This PR fixes a bug where dictionaries were being passed to `model_validate_json` (which accepts a string) instead of `model_validate`.

Because some of the core files have model validators that run in "after" mode and depend on the model being an object and not a dictionary, this bug was causing attempts to validate a (valid) file using `Metadata.model_validate()` to fail. Using the core file directly, i.e. `Rig.model_validate()` always worked.

The bug was causing user warnings which no longer exist, so I had to remove some test assertions, I checked w/ Helen that these aren't important.

I also added two print statements so that these kinds of errors can be caught by users/developers. It was very confusing to debug this because the errors were being hidden.