### PR TITLE
refactor: replace ValueError in AindGeneric with warning for $/. char…

### DIFF
--- a/src/aind_data_schema/base.py
+++ b/src/aind_data_schema/base.py
@@ -87,7 +87,7 @@ class AindGeneric(BaseModel, extra="allow"):
     @model_validator(mode="after")
     def validate_fieldnames(self):
         """Warn users when field names contain forbidden characters
-        
+
         These characters will cause issues with MongoDB queries
         """
         model_dict = json.loads(self.model_dump_json(by_alias=True))

--- a/src/aind_data_schema/base.py
+++ b/src/aind_data_schema/base.py
@@ -3,6 +3,7 @@
 import json
 import re
 import logging
+import warnings
 from pathlib import Path
 from typing import Any, Generic, Optional, TypeVar, get_args
 
@@ -85,10 +86,13 @@ class AindGeneric(BaseModel, extra="allow"):
 
     @model_validator(mode="after")
     def validate_fieldnames(self):
-        """Ensure that field names do not contain forbidden characters"""
+        """Warn users when field names contain forbidden characters
+        
+        These characters will cause issues with MongoDB queries
+        """
         model_dict = json.loads(self.model_dump_json(by_alias=True))
         if is_dict_corrupt(model_dict):
-            raise ValueError("Field names cannot contain '.' or '$'")
+            warnings.warn("MongoDB queries will not work for fields that contain '.' or '$'")
         return self
 
 

--- a/src/aind_data_schema/base.py
+++ b/src/aind_data_schema/base.py
@@ -92,7 +92,7 @@ class AindGeneric(BaseModel, extra="allow"):
         """
         model_dict = json.loads(self.model_dump_json(by_alias=True))
         if is_dict_corrupt(model_dict):
-            warnings.warn("MongoDB queries will not work for fields that contain '.' or '$'")
+            warnings.warn("MongoDB queries may not work as expected for fields that contain '.' or '$'")
         return self
 
 

--- a/src/aind_data_schema/core/metadata.py
+++ b/src/aind_data_schema/core/metadata.py
@@ -21,7 +21,7 @@ from pydantic import (
     model_validator,
 )
 
-from aind_data_schema.base import AindCoreModel, is_dict_corrupt, AwareDatetimeWithDefault
+from aind_data_schema.base import AindCoreModel, AwareDatetimeWithDefault
 from aind_data_schema.core.acquisition import Acquisition
 from aind_data_schema.core.data_description import DataDescription
 from aind_data_schema.core.instrument import Instrument

--- a/src/aind_data_schema/core/metadata.py
+++ b/src/aind_data_schema/core/metadata.py
@@ -319,10 +319,7 @@ def create_metadata_json(
     core_fields = dict()
     for key, value in core_jsons.items():
         if key in CORE_FILES and value is not None:
-            if is_dict_corrupt(value):
-                logging.warning(f"Provided {key} is corrupt! It will be ignored.")
-            else:
-                core_fields[key] = value
+            core_fields[key] = value
     # Create Metadata object and convert to JSON
     # If there are any validation errors, still create it
     # but set MetadataStatus as Invalid

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -119,14 +119,14 @@ class BaseTests(unittest.TestCase):
                 AindGeneric(**params)
                 self.assertTrue(
                     any(
-                        "MongoDB queries will not work for fields that contain '.' or '$'" in str(warning.message)
+                        "fields that contain '.' or '$'" in str(warning.message)
                         for warning in w
                     )
                 )
                 AindGeneric.model_validate(params)
                 self.assertTrue(
                     any(
-                        "MongoDB queries will not work for fields that contain '.' or '$'" in str(warning.message)
+                        "fields that contain '.' or '$'" in str(warning.message)
                         for warning in w
                     )
                 )

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -117,19 +117,9 @@ class BaseTests(unittest.TestCase):
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter("always")
                 AindGeneric(**params)
-                self.assertTrue(
-                    any(
-                        "fields that contain '.' or '$'" in str(warning.message)
-                        for warning in w
-                    )
-                )
+                self.assertTrue(any("fields that contain '.' or '$'" in str(warning.message) for warning in w))
                 AindGeneric.model_validate(params)
-                self.assertTrue(
-                    any(
-                        "fields that contain '.' or '$'" in str(warning.message)
-                        for warning in w
-                    )
-                )
+                self.assertTrue(any("fields that contain '.' or '$'" in str(warning.message) for warning in w))
 
     def test_ccf_validator(self):
         """Tests that CCFStructure validator works"""

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,6 +1,7 @@
 """ tests for Subject """
 
 import json
+import warnings
 import unittest
 from datetime import datetime, timezone
 from pathlib import Path
@@ -108,18 +109,27 @@ class BaseTests(unittest.TestCase):
 
     def test_aind_generic_validate_fieldnames(self):
         """Tests that fieldnames are validated in AindGeneric"""
-        expected_error = "1 validation error for AindGeneric\n" "  Value error, Field names cannot contain '.' or '$' "
         invalid_params = [
             {"$foo": "bar"},
             {"foo": {"foo.name": "bar"}},
         ]
         for params in invalid_params:
-            with self.assertRaises(ValidationError) as e:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
                 AindGeneric(**params)
-            self.assertIn(expected_error, repr(e.exception))
-            with self.assertRaises(ValidationError) as e:
+                self.assertTrue(
+                    any(
+                        "MongoDB queries will not work for fields that contain '.' or '$'" in str(warning.message)
+                        for warning in w
+                    )
+                )
                 AindGeneric.model_validate(params)
-            self.assertIn(expected_error, repr(e.exception))
+                self.assertTrue(
+                    any(
+                        "MongoDB queries will not work for fields that contain '.' or '$'" in str(warning.message)
+                        for warning in w
+                    )
+                )
 
     def test_ccf_validator(self):
         """Tests that CCFStructure validator works"""

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -491,45 +491,6 @@ class TestMetadata(unittest.TestCase):
         mock_warning.assert_called_once()
         self.assertIn("Issue with metadata construction!", mock_warning.call_args_list[0].args[0])
 
-    @patch("logging.warning")
-    @patch("aind_data_schema.core.metadata.is_dict_corrupt")
-    def test_create_from_core_jsons_corrupt(self, mock_is_dict_corrupt: MagicMock, mock_warning: MagicMock):
-        """Tests metadata json creation ignores corrupt core jsons"""
-        # mock corrupt procedures and processing
-        mock_is_dict_corrupt.side_effect = lambda x: (x == self.procedures_json or x == self.processing_json)
-        core_jsons = {
-            "subject": self.subject_json,
-            "data_description": None,
-            "procedures": self.procedures_json,
-            "session": None,
-            "rig": None,
-            "processing": self.processing_json,
-            "acquisition": None,
-            "instrument": None,
-            "quality_control": None,
-        }
-        result = create_metadata_json(
-            name=self.sample_name,
-            location=self.sample_location,
-            core_jsons=core_jsons,
-        )
-        # check that metadata was still created
-        self.assertEqual(self.sample_name, result["name"])
-        self.assertEqual(self.sample_location, result["location"])
-        self.assertEqual(self.subject_json, result["subject"])
-        self.assertIsNone(result["acquisition"])
-        self.assertEqual(MetadataStatus.VALID.value, result["metadata_status"])
-        # check that corrupt core jsons were ignored
-        self.assertIsNone(result["procedures"])
-        self.assertIsNone(result["processing"])
-        mock_warning.assert_has_calls(
-            [
-                call("Provided processing is corrupt! It will be ignored."),
-                call("Provided procedures is corrupt! It will be ignored."),
-            ],
-            any_order=True,
-        )
-
     def test_last_modified(self):
         """Test that the last_modified field enforces timezones"""
         m = Metadata.model_construct(

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -4,7 +4,7 @@ import json
 import re
 import unittest
 from datetime import datetime, time, timezone
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 import uuid
 
 from aind_data_schema_models.modalities import Modality


### PR DESCRIPTION
This PR lowers the error for field names containing '$' and '.' to a warning, to tell users that these fields cause issues in MongoDB queries but still allow their use.