### PR TITLE
chore: move/remove unused dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,17 +15,15 @@ dynamic = ["version"]
 
 dependencies = [
     'aind-data-schema-models>=0.5.4, <1.0.0',
-    'dictdiffer',
     'pydantic>=2.7',
-    'inflection',
-    'jsonschema',
     'semver'
 ]
 
 [project.optional-dependencies]
 dev = [
     'aind_data_schema[linters]',
-    'pydantic>=2.7, !=2.9.0, !=2.9.1'
+    'pydantic>=2.7, !=2.9.0, !=2.9.1',
+    'dictdiffer',
 ]
 
 linters = [


### PR DESCRIPTION
This PR removes two unused dependencies and moves `dictdiffer` into the [dev] dependencies.