### PR TITLE
1279 replace data type with object type

### DIFF
--- a/examples/aibs_smartspim_instrument.json
+++ b/examples/aibs_smartspim_instrument.json
@@ -1,5 +1,5 @@
 {
-   "data_type": "Instrument",
+   "object_type": "Instrument",
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/instrument.py",
    "schema_version": "2.0.1",
    "instrument_id": "440_SmartSPIM2_20231004",
@@ -16,17 +16,17 @@
    ],
    "com_ports": [
       {
-         "data_type": "Com",
+         "object_type": "Com",
          "hardware_name": "Laser Launch",
          "com_port": "COM3"
       },
       {
-         "data_type": "Com",
+         "object_type": "Com",
          "hardware_name": "ASI Tiger",
          "com_port": "COM5"
       },
       {
-         "data_type": "Com",
+         "object_type": "Com",
          "hardware_name": "MightyZap",
          "com_port": "COM4"
       }
@@ -43,7 +43,7 @@
    "connections": [],
    "components": [
       {
-         "data_type": "Objective",
+         "object_type": "Objective",
          "name": "TLX Objective",
          "serial_number": null,
          "manufacturer": {
@@ -66,7 +66,7 @@
          "objective_type": null
       },
       {
-         "data_type": "Detector",
+         "object_type": "Detector",
          "name": "Camera 1",
          "serial_number": "001107",
          "manufacturer": {
@@ -112,7 +112,7 @@
          "driver_version": null
       },
       {
-         "data_type": "Laser",
+         "object_type": "Laser",
          "name": "Ex_488",
          "serial_number": "VL01222A11",
          "manufacturer": {
@@ -136,7 +136,7 @@
          "item_number": null
       },
       {
-         "data_type": "Laser",
+         "object_type": "Laser",
          "name": "Ex_561",
          "serial_number": "417927",
          "manufacturer": {
@@ -163,7 +163,7 @@
          "item_number": null
       },
       {
-         "data_type": "Laser",
+         "object_type": "Laser",
          "name": "Ex_647",
          "serial_number": "VL01222A10",
          "manufacturer": {
@@ -187,7 +187,7 @@
          "item_number": null
       },
       {
-         "data_type": "Motorized stage",
+         "object_type": "Motorized stage",
          "name": "Focus stage",
          "serial_number": null,
          "manufacturer": {
@@ -206,7 +206,7 @@
          "firmware": null
       },
       {
-         "data_type": "Motorized stage",
+         "object_type": "Motorized stage",
          "name": "Cylindrical lens #1",
          "serial_number": null,
          "manufacturer": {
@@ -225,7 +225,7 @@
          "firmware": null
       },
       {
-         "data_type": "Motorized stage",
+         "object_type": "Motorized stage",
          "name": "Cylindrical lens #2",
          "serial_number": null,
          "manufacturer": {
@@ -244,7 +244,7 @@
          "firmware": null
       },
       {
-         "data_type": "Motorized stage",
+         "object_type": "Motorized stage",
          "name": "Cylindrical lens #3",
          "serial_number": null,
          "manufacturer": {
@@ -263,7 +263,7 @@
          "firmware": null
       },
       {
-         "data_type": "Motorized stage",
+         "object_type": "Motorized stage",
          "name": "Cylindrical lens #4",
          "serial_number": null,
          "manufacturer": {
@@ -282,7 +282,7 @@
          "firmware": null
       },
       {
-         "data_type": "Scanning stage",
+         "object_type": "Scanning stage",
          "name": "Sample stage Z",
          "serial_number": null,
          "manufacturer": {
@@ -303,7 +303,7 @@
          "stage_axis_name": "Z"
       },
       {
-         "data_type": "Scanning stage",
+         "object_type": "Scanning stage",
          "name": "Sample stage X",
          "serial_number": null,
          "manufacturer": {
@@ -324,7 +324,7 @@
          "stage_axis_name": "X"
       },
       {
-         "data_type": "Scanning stage",
+         "object_type": "Scanning stage",
          "name": "Sample stage Y",
          "serial_number": null,
          "manufacturer": {
@@ -345,7 +345,7 @@
          "stage_axis_name": "Y"
       },
       {
-         "data_type": "Optical table",
+         "object_type": "Optical table",
          "name": "Table",
          "serial_number": null,
          "manufacturer": {
@@ -365,7 +365,7 @@
          "vibration_control": true
       },
       {
-         "data_type": "Filter",
+         "object_type": "Filter",
          "name": "Em_525",
          "serial_number": null,
          "manufacturer": {
@@ -394,7 +394,7 @@
          "description": null
       },
       {
-         "data_type": "Filter",
+         "object_type": "Filter",
          "name": "Em_600",
          "serial_number": null,
          "manufacturer": {
@@ -423,7 +423,7 @@
          "description": null
       },
       {
-         "data_type": "Filter",
+         "object_type": "Filter",
          "name": "Em_690",
          "serial_number": null,
          "manufacturer": {
@@ -452,7 +452,7 @@
          "description": null
       },
       {
-         "data_type": "Additional imaging device",
+         "object_type": "Additional imaging device",
          "name": "Lens 1",
          "serial_number": null,
          "manufacturer": {
@@ -469,7 +469,7 @@
          "imaging_device_type": "Tunable lens"
       },
       {
-         "data_type": "Additional imaging device",
+         "object_type": "Additional imaging device",
          "name": "Lens 2",
          "serial_number": null,
          "manufacturer": {
@@ -486,7 +486,7 @@
          "imaging_device_type": "Tunable lens"
       },
       {
-         "data_type": "Additional imaging device",
+         "object_type": "Additional imaging device",
          "name": "Sample chamber",
          "serial_number": null,
          "manufacturer": {

--- a/examples/aibs_smartspim_procedures.json
+++ b/examples/aibs_smartspim_procedures.json
@@ -1,11 +1,11 @@
 {
-   "data_type": "Procedures",
+   "object_type": "Procedures",
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/procedures.py",
    "schema_version": "2.0.1",
    "subject_id": "651286",
    "subject_procedures": [
       {
-         "data_type": "Surgery",
+         "object_type": "Surgery",
          "protocol_id": "doi_of_protocol_surgery",
          "start_date": "2022-11-17",
          "experimenters": [
@@ -26,7 +26,7 @@
          "workstation_id": null,
          "procedures": [
             {
-               "data_type": "Perfusion",
+               "object_type": "Perfusion",
                "protocol_id": "doi_of_protocol_perfusion",
                "output_specimen_ids": [
                   "651286"
@@ -38,7 +38,7 @@
    ],
    "specimen_procedures": [
       {
-         "data_type": "Specimen procedure",
+         "object_type": "Specimen procedure",
          "procedure_type": "Fixation",
          "procedure_name": "SHIELD OFF",
          "specimen_id": "651286",
@@ -59,7 +59,7 @@
          ],
          "reagents": [
             {
-               "data_type": "Reagent",
+               "object_type": "Reagent",
                "name": "SHIELD Buffer",
                "source": {
                   "name": "LifeCanvas",
@@ -72,7 +72,7 @@
                "expiration_date": null
             },
             {
-               "data_type": "Reagent",
+               "object_type": "Reagent",
                "name": "SHIELD Epoxy",
                "source": {
                   "name": "LifeCanvas",
@@ -91,7 +91,7 @@
          "notes": null
       },
       {
-         "data_type": "Specimen procedure",
+         "object_type": "Specimen procedure",
          "procedure_type": "Fixation",
          "procedure_name": "SHIELD ON",
          "specimen_id": "651286",
@@ -112,7 +112,7 @@
          ],
          "reagents": [
             {
-               "data_type": "Reagent",
+               "object_type": "Reagent",
                "name": "SHIELD On",
                "source": {
                   "name": "LifeCanvas",
@@ -131,7 +131,7 @@
          "notes": "40 deg. C"
       },
       {
-         "data_type": "Specimen procedure",
+         "object_type": "Specimen procedure",
          "procedure_type": "Soak",
          "procedure_name": null,
          "specimen_id": "651286",
@@ -152,7 +152,7 @@
          ],
          "reagents": [
             {
-               "data_type": "Reagent",
+               "object_type": "Reagent",
                "name": "Delipidation Buffer",
                "source": {
                   "name": "Other",
@@ -171,7 +171,7 @@
          "notes": null
       },
       {
-         "data_type": "Specimen procedure",
+         "object_type": "Specimen procedure",
          "procedure_type": "Delipidation",
          "procedure_name": "Active Delipidation",
          "specimen_id": "651286",
@@ -192,7 +192,7 @@
          ],
          "reagents": [
             {
-               "data_type": "Reagent",
+               "object_type": "Reagent",
                "name": "Delipidation Buffer",
                "source": {
                   "name": "Other",
@@ -205,7 +205,7 @@
                "expiration_date": null
             },
             {
-               "data_type": "Reagent",
+               "object_type": "Reagent",
                "name": "Conductivity Buffer",
                "source": {
                   "name": "Other",
@@ -224,7 +224,7 @@
          "notes": null
       },
       {
-         "data_type": "Specimen procedure",
+         "object_type": "Specimen procedure",
          "procedure_type": "Soak",
          "procedure_name": "EasyIndex 50%",
          "specimen_id": "651286",
@@ -245,7 +245,7 @@
          ],
          "reagents": [
             {
-               "data_type": "Reagent",
+               "object_type": "Reagent",
                "name": "Easy Index",
                "source": {
                   "name": "LifeCanvas",
@@ -258,7 +258,7 @@
                "expiration_date": null
             },
             {
-               "data_type": "Reagent",
+               "object_type": "Reagent",
                "name": "Deionized water",
                "source": {
                   "name": "Other",
@@ -277,7 +277,7 @@
          "notes": null
       },
       {
-         "data_type": "Specimen procedure",
+         "object_type": "Specimen procedure",
          "procedure_type": "Soak",
          "procedure_name": "EasyIndex 100%",
          "specimen_id": "651286",
@@ -298,7 +298,7 @@
          ],
          "reagents": [
             {
-               "data_type": "Reagent",
+               "object_type": "Reagent",
                "name": "Easy Index",
                "source": {
                   "name": "LifeCanvas",
@@ -317,7 +317,7 @@
          "notes": null
       },
       {
-         "data_type": "Specimen procedure",
+         "object_type": "Specimen procedure",
          "procedure_type": "Embedding",
          "procedure_name": null,
          "specimen_id": "651286",
@@ -338,7 +338,7 @@
          ],
          "reagents": [
             {
-               "data_type": "Reagent",
+               "object_type": "Reagent",
                "name": "Easy Index",
                "source": {
                   "name": "LifeCanvas",
@@ -351,7 +351,7 @@
                "expiration_date": null
             },
             {
-               "data_type": "Reagent",
+               "object_type": "Reagent",
                "name": "Agarose",
                "source": {
                   "name": "Other",

--- a/examples/aind_smartspim_instrument.json
+++ b/examples/aind_smartspim_instrument.json
@@ -1,5 +1,5 @@
 {
-   "data_type": "Instrument",
+   "object_type": "Instrument",
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/instrument.py",
    "schema_version": "2.0.1",
    "instrument_id": "440_SmartSPIM1_20231004",
@@ -16,17 +16,17 @@
    ],
    "com_ports": [
       {
-         "data_type": "Com",
+         "object_type": "Com",
          "hardware_name": "Laser Launch",
          "com_port": "COM4"
       },
       {
-         "data_type": "Com",
+         "object_type": "Com",
          "hardware_name": "ASI Tiger",
          "com_port": "COM3"
       },
       {
-         "data_type": "Com",
+         "object_type": "Com",
          "hardware_name": "MightyZap",
          "com_port": "COM9"
       }
@@ -43,7 +43,7 @@
    "connections": [],
    "components": [
       {
-         "data_type": "Objective",
+         "object_type": "Objective",
          "name": "TLX Objective 1",
          "serial_number": null,
          "manufacturer": {
@@ -63,7 +63,7 @@
          "objective_type": null
       },
       {
-         "data_type": "Objective",
+         "object_type": "Objective",
          "name": "TLX Objective 2",
          "serial_number": null,
          "manufacturer": {
@@ -83,7 +83,7 @@
          "objective_type": null
       },
       {
-         "data_type": "Detector",
+         "object_type": "Detector",
          "name": "Camera 1",
          "serial_number": "001284",
          "manufacturer": {
@@ -129,7 +129,7 @@
          "driver_version": null
       },
       {
-         "data_type": "Laser",
+         "object_type": "Laser",
          "name": "Ex_445",
          "serial_number": "VL08223M03",
          "manufacturer": {
@@ -153,7 +153,7 @@
          "item_number": null
       },
       {
-         "data_type": "Laser",
+         "object_type": "Laser",
          "name": "Ex_488",
          "serial_number": "VL08223M03",
          "manufacturer": {
@@ -177,7 +177,7 @@
          "item_number": null
       },
       {
-         "data_type": "Laser",
+         "object_type": "Laser",
          "name": "Ex_561",
          "serial_number": "VL08223M03",
          "manufacturer": {
@@ -201,7 +201,7 @@
          "item_number": null
       },
       {
-         "data_type": "Laser",
+         "object_type": "Laser",
          "name": "Ex_594",
          "serial_number": "VL08223M03",
          "manufacturer": {
@@ -225,7 +225,7 @@
          "item_number": null
       },
       {
-         "data_type": "Laser",
+         "object_type": "Laser",
          "name": "Ex_639",
          "serial_number": "VL08223M03",
          "manufacturer": {
@@ -249,7 +249,7 @@
          "item_number": null
       },
       {
-         "data_type": "Laser",
+         "object_type": "Laser",
          "name": "Ex_690",
          "serial_number": "VL08223M03",
          "manufacturer": {
@@ -273,7 +273,7 @@
          "item_number": null
       },
       {
-         "data_type": "Filter",
+         "object_type": "Filter",
          "name": "Em_469",
          "serial_number": null,
          "manufacturer": {
@@ -302,7 +302,7 @@
          "description": null
       },
       {
-         "data_type": "Filter",
+         "object_type": "Filter",
          "name": "Em_525",
          "serial_number": null,
          "manufacturer": {
@@ -331,7 +331,7 @@
          "description": null
       },
       {
-         "data_type": "Filter",
+         "object_type": "Filter",
          "name": "Em_593",
          "serial_number": null,
          "manufacturer": {
@@ -360,7 +360,7 @@
          "description": null
       },
       {
-         "data_type": "Filter",
+         "object_type": "Filter",
          "name": "Em_624",
          "serial_number": null,
          "manufacturer": {
@@ -389,7 +389,7 @@
          "description": null
       },
       {
-         "data_type": "Filter",
+         "object_type": "Filter",
          "name": "Em_667",
          "serial_number": null,
          "manufacturer": {
@@ -418,7 +418,7 @@
          "description": null
       },
       {
-         "data_type": "Filter",
+         "object_type": "Filter",
          "name": "Em_700",
          "serial_number": null,
          "manufacturer": {
@@ -450,7 +450,7 @@
          "description": null
       },
       {
-         "data_type": "Motorized stage",
+         "object_type": "Motorized stage",
          "name": "Focus stage",
          "serial_number": null,
          "manufacturer": {
@@ -469,7 +469,7 @@
          "firmware": null
       },
       {
-         "data_type": "Motorized stage",
+         "object_type": "Motorized stage",
          "name": "Cylindrical lens #1",
          "serial_number": null,
          "manufacturer": {
@@ -488,7 +488,7 @@
          "firmware": null
       },
       {
-         "data_type": "Motorized stage",
+         "object_type": "Motorized stage",
          "name": "Cylindrical lens #2",
          "serial_number": null,
          "manufacturer": {
@@ -507,7 +507,7 @@
          "firmware": null
       },
       {
-         "data_type": "Motorized stage",
+         "object_type": "Motorized stage",
          "name": "Cylindrical lens #3",
          "serial_number": null,
          "manufacturer": {
@@ -526,7 +526,7 @@
          "firmware": null
       },
       {
-         "data_type": "Motorized stage",
+         "object_type": "Motorized stage",
          "name": "Cylindrical lens #4",
          "serial_number": null,
          "manufacturer": {
@@ -545,7 +545,7 @@
          "firmware": null
       },
       {
-         "data_type": "Scanning stage",
+         "object_type": "Scanning stage",
          "name": "Sample stage Z",
          "serial_number": null,
          "manufacturer": {
@@ -566,7 +566,7 @@
          "stage_axis_name": "Z"
       },
       {
-         "data_type": "Scanning stage",
+         "object_type": "Scanning stage",
          "name": "Sample stage X",
          "serial_number": null,
          "manufacturer": {
@@ -587,7 +587,7 @@
          "stage_axis_name": "X"
       },
       {
-         "data_type": "Scanning stage",
+         "object_type": "Scanning stage",
          "name": "Sample stage Y",
          "serial_number": null,
          "manufacturer": {
@@ -608,7 +608,7 @@
          "stage_axis_name": "Y"
       },
       {
-         "data_type": "Optical table",
+         "object_type": "Optical table",
          "name": "Main optical table",
          "serial_number": null,
          "manufacturer": {

--- a/examples/bergamo_ophys_session.json
+++ b/examples/bergamo_ophys_session.json
@@ -1,5 +1,5 @@
 {
-   "data_type": "Session",
+   "object_type": "Session",
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/session.py",
    "schema_version": "2.0.1",
    "protocol_id": [],
@@ -27,7 +27,7 @@
    "anaesthesia": null,
    "data_streams": [
       {
-         "data_type": "Stream",
+         "object_type": "Stream",
          "stream_start_time": "2022-07-12T07:00:00Z",
          "stream_end_time": "2022-07-12T07:00:00Z",
          "daq_names": [],
@@ -36,7 +36,7 @@
          ],
          "light_sources": [
             {
-               "data_type": "Laser config",
+               "object_type": "Laser config",
                "name": "Laser A",
                "wavelength": 405,
                "wavelength_unit": "nanometer",
@@ -49,7 +49,7 @@
          "manipulator_modules": [],
          "detectors": [
             {
-               "data_type": "Detector config",
+               "object_type": "Detector config",
                "name": "PMT A",
                "exposure_time": "0.1",
                "exposure_time_unit": "millisecond",
@@ -60,7 +60,7 @@
          "fiber_modules": [],
          "ophys_fovs": [
             {
-               "data_type": "Field of view",
+               "object_type": "Field of view",
                "index": 0,
                "imaging_depth": 150,
                "imaging_depth_unit": "micrometer",
@@ -111,7 +111,7 @@
    ],
    "stimulus_epochs": [
       {
-         "data_type": "Stimulus epoch",
+         "object_type": "Stimulus epoch",
          "stimulus_start_time": "2022-07-12T07:00:00Z",
          "stimulus_end_time": "2022-07-12T07:00:00Z",
          "stimulus_name": "PhotoStimulation",
@@ -123,12 +123,12 @@
          ],
          "stimulus_parameters": [
             {
-               "data_type": "Photo stimulation",
+               "object_type": "Photo stimulation",
                "stimulus_name": "Two group stim",
                "number_groups": 2,
                "groups": [
                   {
-                     "data_type": "Photo stimulation group",
+                     "object_type": "Photo stimulation group",
                      "group_index": 0,
                      "number_of_neurons": 12,
                      "stimulation_laser_power": "10",
@@ -143,7 +143,7 @@
                      "notes": null
                   },
                   {
-                     "data_type": "Photo stimulation group",
+                     "object_type": "Photo stimulation group",
                      "group_index": 2,
                      "number_of_neurons": 20,
                      "stimulation_laser_power": "10",

--- a/examples/data_description.json
+++ b/examples/data_description.json
@@ -1,5 +1,5 @@
 {
-   "data_type": "Raw data description",
+   "object_type": "Raw data description",
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/data_description.py",
    "schema_version": "2.0.1",
    "license": "CC-BY-4.0",
@@ -18,7 +18,7 @@
    },
    "funding_source": [
       {
-         "data_type": "Funding",
+         "object_type": "Funding",
          "funder": {
             "name": "Allen Institute",
             "abbreviation": "AI",

--- a/examples/ephys_instrument.json
+++ b/examples/ephys_instrument.json
@@ -1,12 +1,12 @@
 {
-   "data_type": "Instrument",
+   "object_type": "Instrument",
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/instrument.py",
    "schema_version": "2.0.1",
    "instrument_id": "323_EPHYS1_20231003",
    "modification_date": "2023-10-03",
    "calibrations": [
       {
-         "data_type": "Calibration",
+         "object_type": "Calibration",
          "calibration_date": "2023-10-02T10:22:13Z",
          "device_name": "Red Laser",
          "description": "Laser power calibration",
@@ -27,7 +27,7 @@
          "notes": null
       },
       {
-         "data_type": "Calibration",
+         "object_type": "Calibration",
          "calibration_date": "2023-10-02T10:22:13Z",
          "device_name": "Blue Laser",
          "description": "Laser power calibration",
@@ -65,10 +65,10 @@
    "connections": [],
    "components": [
       {
-         "data_type": "Ephys assembly",
+         "object_type": "Ephys assembly",
          "name": "Ephys_assemblyA",
          "manipulator": {
-            "data_type": "Manipulator",
+            "object_type": "Manipulator",
             "name": "Manipulator 1",
             "serial_number": "SN2938",
             "manufacturer": {
@@ -85,7 +85,7 @@
          },
          "probes": [
             {
-               "data_type": "Ephys probe",
+               "object_type": "Ephys probe",
                "name": "Probe A",
                "serial_number": "9291019",
                "manufacturer": null,
@@ -101,10 +101,10 @@
          ]
       },
       {
-         "data_type": "Ephys assembly",
+         "object_type": "Ephys assembly",
          "name": "Ephys_assemblyB",
          "manipulator": {
-            "data_type": "Manipulator",
+            "object_type": "Manipulator",
             "name": "Manipulator B",
             "serial_number": "SN2939",
             "manufacturer": {
@@ -121,7 +121,7 @@
          },
          "probes": [
             {
-               "data_type": "Ephys probe",
+               "object_type": "Ephys probe",
                "name": "Probe B",
                "serial_number": "9291020",
                "manufacturer": null,
@@ -137,11 +137,11 @@
          ]
       },
       {
-         "data_type": "Camera assembly",
+         "object_type": "Camera assembly",
          "name": "Face Camera Assembly",
          "camera_target": "Face side left",
          "camera": {
-            "data_type": "Camera",
+            "object_type": "Camera",
             "name": "Face Camera",
             "serial_number": null,
             "manufacturer": {
@@ -187,7 +187,7 @@
             "driver_version": null
          },
          "lens": {
-            "data_type": "Lens",
+            "object_type": "Lens",
             "name": "Camera lens",
             "serial_number": null,
             "manufacturer": {
@@ -213,7 +213,7 @@
             "max_aperture": "f/2"
          },
          "filter": {
-            "data_type": "Filter",
+            "object_type": "Filter",
             "name": "LP filter",
             "serial_number": null,
             "manufacturer": {
@@ -247,11 +247,11 @@
          "position": null
       },
       {
-         "data_type": "Camera assembly",
+         "object_type": "Camera assembly",
          "name": "Body Camera Assembly",
          "camera_target": "Body",
          "camera": {
-            "data_type": "Camera",
+            "object_type": "Camera",
             "name": "Body Camera",
             "serial_number": null,
             "manufacturer": {
@@ -297,7 +297,7 @@
             "driver_version": null
          },
          "lens": {
-            "data_type": "Lens",
+            "object_type": "Lens",
             "name": "Camera lens",
             "serial_number": null,
             "manufacturer": {
@@ -323,7 +323,7 @@
             "max_aperture": "f/2"
          },
          "filter": {
-            "data_type": "Filter",
+            "object_type": "Filter",
             "name": "LP filter",
             "serial_number": null,
             "manufacturer": {
@@ -357,10 +357,10 @@
          "position": null
       },
       {
-         "data_type": "Laser assembly",
+         "object_type": "Laser assembly",
          "name": "Laser_assemblyA",
          "manipulator": {
-            "data_type": "Manipulator",
+            "object_type": "Manipulator",
             "name": "Manipulator A",
             "serial_number": "SN2937",
             "manufacturer": {
@@ -377,7 +377,7 @@
          },
          "lasers": [
             {
-               "data_type": "Laser",
+               "object_type": "Laser",
                "name": "Red Laser",
                "serial_number": null,
                "manufacturer": {
@@ -401,7 +401,7 @@
                "item_number": null
             },
             {
-               "data_type": "Laser",
+               "object_type": "Laser",
                "name": "Blue Laser",
                "serial_number": null,
                "manufacturer": {
@@ -426,7 +426,7 @@
             }
          ],
          "collimator": {
-            "data_type": "Device",
+            "object_type": "Device",
             "name": "Collimator A",
             "serial_number": null,
             "manufacturer": null,
@@ -437,7 +437,7 @@
             "notes": null
          },
          "fiber": {
-            "data_type": "Patch",
+            "object_type": "Patch",
             "name": "Bundle Branching Fiber-optic Patch Cord",
             "serial_number": null,
             "manufacturer": {
@@ -460,7 +460,7 @@
          }
       },
       {
-         "data_type": "Neuropixels basestation",
+         "object_type": "Neuropixels basestation",
          "name": "Basestation Slot 3",
          "serial_number": null,
          "manufacturer": {
@@ -487,14 +487,14 @@
          "slot": 3,
          "ports": [
             {
-               "data_type": "Probe port",
+               "object_type": "Probe port",
                "index": 1,
                "probes": [
                   "Probe A"
                ]
             },
             {
-               "data_type": "Probe port",
+               "object_type": "Probe port",
                "index": 2,
                "probes": [
                   "Probe B"
@@ -503,7 +503,7 @@
          ]
       },
       {
-         "data_type": "Harp device",
+         "object_type": "Harp device",
          "name": "Harp Behavior",
          "serial_number": null,
          "manufacturer": {
@@ -524,7 +524,7 @@
          "computer_name": "W10DT72941",
          "channels": [
             {
-               "data_type": "DAQ channel",
+               "object_type": "DAQ channel",
                "channel_name": "DO0",
                "device_name": "Face Camera",
                "channel_type": "Digital Output",
@@ -535,7 +535,7 @@
                "event_based_sampling": null
             },
             {
-               "data_type": "DAQ channel",
+               "object_type": "DAQ channel",
                "channel_name": "DO1",
                "device_name": "Body Camera",
                "channel_type": "Digital Output",
@@ -546,7 +546,7 @@
                "event_based_sampling": null
             },
             {
-               "data_type": "DAQ channel",
+               "object_type": "DAQ channel",
                "channel_name": "AI0",
                "device_name": "Running Wheel",
                "channel_type": "Analog Input",
@@ -568,11 +568,11 @@
          "is_clock_generator": false
       },
       {
-         "data_type": "Camera assembly",
+         "object_type": "Camera assembly",
          "name": "Stick_assembly_1",
          "camera_target": "Brain surface",
          "camera": {
-            "data_type": "Camera",
+            "object_type": "Camera",
             "name": "stick microscope 1",
             "serial_number": null,
             "manufacturer": {
@@ -618,7 +618,7 @@
             "driver_version": null
          },
          "lens": {
-            "data_type": "Lens",
+            "object_type": "Lens",
             "name": "Probe lens",
             "serial_number": null,
             "manufacturer": {
@@ -647,11 +647,11 @@
          "position": null
       },
       {
-         "data_type": "Camera assembly",
+         "object_type": "Camera assembly",
          "name": "Stick_assembly_2",
          "camera_target": "Brain surface",
          "camera": {
-            "data_type": "Camera",
+            "object_type": "Camera",
             "name": "stick microscope 2",
             "serial_number": null,
             "manufacturer": {
@@ -697,7 +697,7 @@
             "driver_version": null
          },
          "lens": {
-            "data_type": "Lens",
+            "object_type": "Lens",
             "name": "Probe lens",
             "serial_number": null,
             "manufacturer": {
@@ -726,11 +726,11 @@
          "position": null
       },
       {
-         "data_type": "Camera assembly",
+         "object_type": "Camera assembly",
          "name": "Stick_assembly_3",
          "camera_target": "Brain surface",
          "camera": {
-            "data_type": "Camera",
+            "object_type": "Camera",
             "name": "stick microscope 3",
             "serial_number": null,
             "manufacturer": {
@@ -776,7 +776,7 @@
             "driver_version": null
          },
          "lens": {
-            "data_type": "Lens",
+            "object_type": "Lens",
             "name": "Probe lens",
             "serial_number": null,
             "manufacturer": {
@@ -805,11 +805,11 @@
          "position": null
       },
       {
-         "data_type": "Camera assembly",
+         "object_type": "Camera assembly",
          "name": "Stick_assembly_4",
          "camera_target": "Brain surface",
          "camera": {
-            "data_type": "Camera",
+            "object_type": "Camera",
             "name": "stick microscope 4",
             "serial_number": null,
             "manufacturer": {
@@ -855,7 +855,7 @@
             "driver_version": null
          },
          "lens": {
-            "data_type": "Lens",
+            "object_type": "Lens",
             "name": "Probe lens",
             "serial_number": null,
             "manufacturer": {
@@ -884,7 +884,7 @@
          "position": null
       },
       {
-         "data_type": "Disc",
+         "object_type": "Disc",
          "name": "Running Wheel",
          "serial_number": null,
          "manufacturer": null,

--- a/examples/ephys_session.json
+++ b/examples/ephys_session.json
@@ -1,5 +1,5 @@
 {
-   "data_type": "Session",
+   "object_type": "Session",
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/session.py",
    "schema_version": "2.0.1",
    "protocol_id": [],
@@ -27,7 +27,7 @@
    "anaesthesia": null,
    "data_streams": [
       {
-         "data_type": "Stream",
+         "object_type": "Stream",
          "stream_start_time": "2023-04-25T02:45:00Z",
          "stream_end_time": "2023-04-25T03:16:00Z",
          "daq_names": [
@@ -37,7 +37,7 @@
          "light_sources": [],
          "ephys_modules": [
             {
-               "data_type": "Manipulator module",
+               "object_type": "Manipulator module",
                "assembly_name": "Ephys_assemblyA",
                "arc_angle": "5.2",
                "module_angle": "8",
@@ -55,7 +55,7 @@
                "other_targeted_structure": null,
                "targeted_ccf_coordinates": [
                   {
-                     "data_type": "Ccf coords",
+                     "object_type": "Ccf coords",
                      "ml": "8150",
                      "ap": "3250",
                      "dv": "7800",
@@ -64,7 +64,7 @@
                   }
                ],
                "manipulator_coordinates": {
-                  "data_type": "Coordinates3d",
+                  "object_type": "Coordinates3d",
                   "x": "8422",
                   "y": "4205",
                   "z": "11087.5",
@@ -78,7 +78,7 @@
                "implant_hole_number": null
             },
             {
-               "data_type": "Manipulator module",
+               "object_type": "Manipulator module",
                "assembly_name": "Ephys_assemblyB",
                "arc_angle": "25",
                "module_angle": "-22",
@@ -96,7 +96,7 @@
                "other_targeted_structure": null,
                "targeted_ccf_coordinates": [
                   {
-                     "data_type": "Ccf coords",
+                     "object_type": "Ccf coords",
                      "ml": "6637.28",
                      "ap": "4265.02",
                      "dv": "10707.35",
@@ -105,7 +105,7 @@
                   }
                ],
                "manipulator_coordinates": {
-                  "data_type": "Coordinates3d",
+                  "object_type": "Coordinates3d",
                   "x": "9015",
                   "y": "7144",
                   "z": "13262",
@@ -121,7 +121,7 @@
          ],
          "stick_microscopes": [
             {
-               "data_type": "Dome module",
+               "object_type": "Dome module",
                "assembly_name": "stick microscope 1",
                "arc_angle": "-180",
                "module_angle": "-180",
@@ -132,7 +132,7 @@
                "notes": "did not record angles, did not calibrate."
             },
             {
-               "data_type": "Dome module",
+               "object_type": "Dome module",
                "assembly_name": "stick microscope 2",
                "arc_angle": "-180",
                "module_angle": "-180",
@@ -143,7 +143,7 @@
                "notes": "Did not record angles, did not calibrate"
             },
             {
-               "data_type": "Dome module",
+               "object_type": "Dome module",
                "assembly_name": "stick microscope 3",
                "arc_angle": "-180",
                "module_angle": "-180",
@@ -154,7 +154,7 @@
                "notes": "Did not record angles, did not calibrate"
             },
             {
-               "data_type": "Dome module",
+               "object_type": "Dome module",
                "assembly_name": "stick microscope 4",
                "arc_angle": "-180",
                "module_angle": "-180",
@@ -183,7 +183,7 @@
          "notes": null
       },
       {
-         "data_type": "Stream",
+         "object_type": "Stream",
          "stream_start_time": "2023-04-25T02:35:00Z",
          "stream_end_time": "2023-04-25T02:45:00Z",
          "daq_names": [
@@ -193,7 +193,7 @@
          "light_sources": [],
          "ephys_modules": [
             {
-               "data_type": "Manipulator module",
+               "object_type": "Manipulator module",
                "assembly_name": "Ephys_assemblyA",
                "arc_angle": "5.2",
                "module_angle": "8",
@@ -211,7 +211,7 @@
                "other_targeted_structure": null,
                "targeted_ccf_coordinates": [
                   {
-                     "data_type": "Ccf coords",
+                     "object_type": "Ccf coords",
                      "ml": "8150",
                      "ap": "3250",
                      "dv": "7800",
@@ -220,7 +220,7 @@
                   }
                ],
                "manipulator_coordinates": {
-                  "data_type": "Coordinates3d",
+                  "object_type": "Coordinates3d",
                   "x": "8422",
                   "y": "4205",
                   "z": "11087.5",
@@ -234,7 +234,7 @@
                "implant_hole_number": null
             },
             {
-               "data_type": "Manipulator module",
+               "object_type": "Manipulator module",
                "assembly_name": "Ephys_assemblyB",
                "arc_angle": "25",
                "module_angle": "-22",
@@ -252,7 +252,7 @@
                "other_targeted_structure": null,
                "targeted_ccf_coordinates": [
                   {
-                     "data_type": "Ccf coords",
+                     "object_type": "Ccf coords",
                      "ml": "6637.28",
                      "ap": "4265.02",
                      "dv": "10707.35",
@@ -261,7 +261,7 @@
                   }
                ],
                "manipulator_coordinates": {
-                  "data_type": "Coordinates3d",
+                  "object_type": "Coordinates3d",
                   "x": "9015",
                   "y": "7144",
                   "z": "13262",
@@ -277,7 +277,7 @@
          ],
          "stick_microscopes": [
             {
-               "data_type": "Dome module",
+               "object_type": "Dome module",
                "assembly_name": "stick microscope 1",
                "arc_angle": "-180",
                "module_angle": "-180",
@@ -308,14 +308,14 @@
    ],
    "stimulus_epochs": [
       {
-         "data_type": "Stimulus epoch",
+         "object_type": "Stimulus epoch",
          "stimulus_start_time": "2023-04-25T02:45:00Z",
          "stimulus_end_time": "2023-04-25T03:10:00Z",
          "stimulus_name": "Visual Stimulation",
          "session_number": null,
          "software": [
             {
-               "data_type": "Software",
+               "object_type": "Software",
                "name": "Bonsai",
                "version": "2.7",
                "url": "https://github.com/fakeorg/GratingAndFlashes/gratings_and_flashes.bonsai",
@@ -328,7 +328,7 @@
          ],
          "stimulus_parameters": [
             {
-               "data_type": "Visual stimulation",
+               "object_type": "Visual stimulation",
                "stimulus_name": "Static Gratings",
                "stimulus_parameters": {
                   "grating_orientations": [
@@ -364,14 +364,14 @@
          "notes": null
       },
       {
-         "data_type": "Stimulus epoch",
+         "object_type": "Stimulus epoch",
          "stimulus_start_time": "2023-04-25T03:10:00Z",
          "stimulus_end_time": "2023-04-25T03:16:00Z",
          "stimulus_name": "Visual Stimulation",
          "session_number": null,
          "software": [
             {
-               "data_type": "Software",
+               "object_type": "Software",
                "name": "Bonsai",
                "version": "2.7",
                "url": "https://github.com/fakeorg/GratingAndFlashes/gratings_and_flashes.bonsai",
@@ -384,7 +384,7 @@
          ],
          "stimulus_parameters": [
             {
-               "data_type": "Visual stimulation",
+               "object_type": "Visual stimulation",
                "stimulus_name": "Flashes",
                "stimulus_parameters": {
                   "flash_interval": 5.0,

--- a/examples/exaspim_acquisition.json
+++ b/examples/exaspim_acquisition.json
@@ -1,5 +1,5 @@
 {
-   "data_type": "Acquisition",
+   "object_type": "Acquisition",
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/acquisition.py",
    "schema_version": "2.0.1",
    "protocol_id": [],
@@ -18,7 +18,7 @@
    "instrument_id": "###",
    "calibrations": [
       {
-         "data_type": "Calibration",
+         "object_type": "Calibration",
          "calibration_date": "2022-11-22T08:43:00Z",
          "device_name": "Laser_1",
          "description": "Laser power calibration",
@@ -35,14 +35,14 @@
    ],
    "maintenance": [
       {
-         "data_type": "Maintenance",
+         "object_type": "Maintenance",
          "maintenance_date": "2022-11-22T08:43:00Z",
          "device_name": "Chamber",
          "description": "Clean chamber",
          "protocol_id": null,
          "reagents": [
             {
-               "data_type": "Reagent",
+               "object_type": "Reagent",
                "name": "reagent1",
                "source": {
                   "name": "Other",
@@ -71,10 +71,10 @@
    "session_type": null,
    "tiles": [
       {
-         "data_type": "Acquisition tile",
+         "object_type": "Acquisition tile",
          "coordinate_transformations": [
             {
-               "data_type": "Scale3d transform",
+               "object_type": "Scale3d transform",
                "scale": [
                   "0.748",
                   "0.748",
@@ -82,7 +82,7 @@
                ]
             },
             {
-               "data_type": "Translation3d transform",
+               "object_type": "Translation3d transform",
                "translation": [
                   "0",
                   "0",
@@ -92,7 +92,7 @@
          ],
          "file_name": "tile_X_0000_Y_0000_Z_0000_CH_488.ims",
          "channel": {
-            "data_type": "Channel",
+            "object_type": "Channel",
             "channel_name": "488",
             "light_source_name": "Ex_488",
             "filter_names": [
@@ -116,10 +116,10 @@
          "acquisition_end_time": null
       },
       {
-         "data_type": "Acquisition tile",
+         "object_type": "Acquisition tile",
          "coordinate_transformations": [
             {
-               "data_type": "Scale3d transform",
+               "object_type": "Scale3d transform",
                "scale": [
                   "0.748",
                   "0.748",
@@ -127,7 +127,7 @@
                ]
             },
             {
-               "data_type": "Translation3d transform",
+               "object_type": "Translation3d transform",
                "translation": [
                   "0",
                   "0",
@@ -137,7 +137,7 @@
          ],
          "file_name": "tile_X_0000_Y_0000_Z_0000_CH_561.ims",
          "channel": {
-            "data_type": "Channel",
+            "object_type": "Channel",
             "channel_name": "561",
             "light_source_name": "Ex_561",
             "filter_names": [
@@ -163,21 +163,21 @@
    ],
    "axes": [
       {
-         "data_type": "Image axis",
+         "object_type": "Image axis",
          "name": "X",
          "direction": "Left_to_right",
          "dimension": 2,
          "unit": "micrometer"
       },
       {
-         "data_type": "Image axis",
+         "object_type": "Image axis",
          "name": "Y",
          "direction": "Anterior_to_posterior",
          "dimension": 1,
          "unit": "micrometer"
       },
       {
-         "data_type": "Image axis",
+         "object_type": "Image axis",
          "name": "Z",
          "direction": "Inferior_to_superior",
          "dimension": 0,
@@ -185,7 +185,7 @@
       }
    ],
    "chamber_immersion": {
-      "data_type": "Immersion",
+      "object_type": "Immersion",
       "medium": "PBS",
       "refractive_index": "1.33"
    },

--- a/examples/exaspim_instrument.json
+++ b/examples/exaspim_instrument.json
@@ -1,5 +1,5 @@
 {
-   "data_type": "Instrument",
+   "object_type": "Instrument",
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/instrument.py",
    "schema_version": "2.0.1",
    "instrument_id": "440_exaSPIM1_20231004",
@@ -16,12 +16,12 @@
    ],
    "com_ports": [
       {
-         "data_type": "Com",
+         "object_type": "Com",
          "hardware_name": "Laser Launch",
          "com_port": "COM2"
       },
       {
-         "data_type": "Com",
+         "object_type": "Com",
          "hardware_name": "ASI Tiger",
          "com_port": "COM5"
       }
@@ -38,7 +38,7 @@
    "connections": [],
    "components": [
       {
-         "data_type": "Objective",
+         "object_type": "Objective",
          "name": "Custom Objective",
          "serial_number": null,
          "manufacturer": {
@@ -58,7 +58,7 @@
          "objective_type": null
       },
       {
-         "data_type": "Detector",
+         "object_type": "Detector",
          "name": "Camera 1",
          "serial_number": "MB151BAY001",
          "manufacturer": {
@@ -101,7 +101,7 @@
          "driver_version": null
       },
       {
-         "data_type": "Laser",
+         "object_type": "Laser",
          "name": "LAS-08307",
          "serial_number": "LAS-08307",
          "manufacturer": {
@@ -125,7 +125,7 @@
          "item_number": null
       },
       {
-         "data_type": "Laser",
+         "object_type": "Laser",
          "name": "LAS-08308",
          "serial_number": "LAS-08308",
          "manufacturer": {
@@ -149,7 +149,7 @@
          "item_number": null
       },
       {
-         "data_type": "Laser",
+         "object_type": "Laser",
          "name": "539251",
          "serial_number": "539251",
          "manufacturer": {
@@ -173,7 +173,7 @@
          "item_number": null
       },
       {
-         "data_type": "Laser",
+         "object_type": "Laser",
          "name": "LAS-08309",
          "serial_number": "LAS-08309",
          "manufacturer": {
@@ -197,7 +197,7 @@
          "item_number": null
       },
       {
-         "data_type": "Filter",
+         "object_type": "Filter",
          "name": "Multiband filter",
          "serial_number": null,
          "manufacturer": {
@@ -226,7 +226,7 @@
          "description": null
       },
       {
-         "data_type": "DAQ device",
+         "object_type": "DAQ device",
          "name": "Dev2",
          "serial_number": null,
          "manufacturer": {
@@ -247,7 +247,7 @@
          "computer_name": "Dev2",
          "channels": [
             {
-               "data_type": "DAQ channel",
+               "object_type": "DAQ channel",
                "channel_name": "3",
                "device_name": "LAS-08308",
                "channel_type": "Analog Output",
@@ -258,7 +258,7 @@
                "event_based_sampling": null
             },
             {
-               "data_type": "DAQ channel",
+               "object_type": "DAQ channel",
                "channel_name": "5",
                "device_name": "539251",
                "channel_type": "Analog Output",
@@ -269,7 +269,7 @@
                "event_based_sampling": null
             },
             {
-               "data_type": "DAQ channel",
+               "object_type": "DAQ channel",
                "channel_name": "4",
                "device_name": "LAS-08309",
                "channel_type": "Analog Output",
@@ -280,7 +280,7 @@
                "event_based_sampling": null
             },
             {
-               "data_type": "DAQ channel",
+               "object_type": "DAQ channel",
                "channel_name": "2",
                "device_name": "stage-x",
                "channel_type": "Analog Output",
@@ -291,7 +291,7 @@
                "event_based_sampling": null
             },
             {
-               "data_type": "DAQ channel",
+               "object_type": "DAQ channel",
                "channel_name": "0",
                "device_name": "TL-1",
                "channel_type": "Analog Output",
@@ -302,7 +302,7 @@
                "event_based_sampling": null
             },
             {
-               "data_type": "DAQ channel",
+               "object_type": "DAQ channel",
                "channel_name": "6",
                "device_name": "LAS-08307",
                "channel_type": "Analog Output",
@@ -317,7 +317,7 @@
          "hardware_version": null
       },
       {
-         "data_type": "Scanning stage",
+         "object_type": "Scanning stage",
          "name": "stage-x",
          "serial_number": null,
          "manufacturer": {
@@ -338,7 +338,7 @@
          "stage_axis_name": "X"
       },
       {
-         "data_type": "Scanning stage",
+         "object_type": "Scanning stage",
          "name": "stage-y",
          "serial_number": null,
          "manufacturer": {
@@ -359,7 +359,7 @@
          "stage_axis_name": "Y"
       },
       {
-         "data_type": "Scanning stage",
+         "object_type": "Scanning stage",
          "name": "stage-z",
          "serial_number": null,
          "manufacturer": {
@@ -380,7 +380,7 @@
          "stage_axis_name": "Z"
       },
       {
-         "data_type": "Additional imaging device",
+         "object_type": "Additional imaging device",
          "name": "TL-1",
          "serial_number": "01",
          "manufacturer": {
@@ -397,7 +397,7 @@
          "imaging_device_type": "Tunable lens"
       },
       {
-         "data_type": "Additional imaging device",
+         "object_type": "Additional imaging device",
          "name": "RM-1",
          "serial_number": "01",
          "manufacturer": {
@@ -417,7 +417,7 @@
          "imaging_device_type": "Rotation mount"
       },
       {
-         "data_type": "Additional imaging device",
+         "object_type": "Additional imaging device",
          "name": "LC-1",
          "serial_number": "L6CC-00513",
          "manufacturer": {
@@ -434,7 +434,7 @@
          "imaging_device_type": "Laser combiner"
       },
       {
-         "data_type": "Optical table",
+         "object_type": "Optical table",
          "name": "Table",
          "serial_number": null,
          "manufacturer": {

--- a/examples/fip_behavior_instrument.json
+++ b/examples/fip_behavior_instrument.json
@@ -1,12 +1,12 @@
 {
-   "data_type": "Instrument",
+   "object_type": "Instrument",
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/instrument.py",
    "schema_version": "2.0.1",
    "instrument_id": "447_FIP-Behavior_20000101",
    "modification_date": "2000-01-01",
    "calibrations": [
       {
-         "data_type": "Calibration",
+         "object_type": "Calibration",
          "calibration_date": "2023-10-02T03:15:22Z",
          "device_name": "470nm LED",
          "description": "LED calibration",
@@ -23,7 +23,7 @@
          "notes": null
       },
       {
-         "data_type": "Calibration",
+         "object_type": "Calibration",
          "calibration_date": "2023-10-02T03:15:22Z",
          "device_name": "415nm LED",
          "description": "LED calibration",
@@ -40,7 +40,7 @@
          "notes": null
       },
       {
-         "data_type": "Calibration",
+         "object_type": "Calibration",
          "calibration_date": "2023-10-02T03:15:22Z",
          "device_name": "560nm LED",
          "description": "LED calibration",
@@ -78,11 +78,11 @@
    "connections": [],
    "components": [
       {
-         "data_type": "Camera assembly",
+         "object_type": "Camera assembly",
          "name": "BehaviorVideography_FaceSide",
          "camera_target": "Face side left",
          "camera": {
-            "data_type": "Camera",
+            "object_type": "Camera",
             "name": "Side face camera",
             "serial_number": null,
             "manufacturer": {
@@ -121,7 +121,7 @@
             "crop_height": null,
             "crop_unit": "pixel",
             "recording_software": {
-               "data_type": "Software",
+               "object_type": "Software",
                "name": "Bonsai",
                "version": "2.5",
                "url": null,
@@ -131,7 +131,7 @@
             "driver_version": null
          },
          "lens": {
-            "data_type": "Lens",
+            "object_type": "Lens",
             "name": "Xenocam 1",
             "serial_number": null,
             "manufacturer": {
@@ -157,11 +157,11 @@
          "position": null
       },
       {
-         "data_type": "Camera assembly",
+         "object_type": "Camera assembly",
          "name": "BehaviorVideography_FaceBottom",
          "camera_target": "Face bottom",
          "camera": {
-            "data_type": "Camera",
+            "object_type": "Camera",
             "name": "Bottom face Camera",
             "serial_number": null,
             "manufacturer": {
@@ -200,7 +200,7 @@
             "crop_height": null,
             "crop_unit": "pixel",
             "recording_software": {
-               "data_type": "Software",
+               "object_type": "Software",
                "name": "Bonsai",
                "version": "2.5",
                "url": null,
@@ -210,7 +210,7 @@
             "driver_version": null
          },
          "lens": {
-            "data_type": "Lens",
+            "object_type": "Lens",
             "name": "Xenocam 2",
             "serial_number": null,
             "manufacturer": {
@@ -236,7 +236,7 @@
          "position": null
       },
       {
-         "data_type": "Harp device",
+         "object_type": "Harp device",
          "name": "Harp Behavior",
          "serial_number": null,
          "manufacturer": {
@@ -257,7 +257,7 @@
          "computer_name": "behavior_computer",
          "channels": [
             {
-               "data_type": "DAQ channel",
+               "object_type": "DAQ channel",
                "channel_name": "DO0",
                "device_name": "Solenoid Left",
                "channel_type": "Digital Output",
@@ -268,7 +268,7 @@
                "event_based_sampling": null
             },
             {
-               "data_type": "DAQ channel",
+               "object_type": "DAQ channel",
                "channel_name": "DO1",
                "device_name": "Solenoid Right",
                "channel_type": "Digital Output",
@@ -279,7 +279,7 @@
                "event_based_sampling": null
             },
             {
-               "data_type": "DAQ channel",
+               "object_type": "DAQ channel",
                "channel_name": "DI0",
                "device_name": "Janelia_Lick_Detector Left",
                "channel_type": "Digital Input",
@@ -290,7 +290,7 @@
                "event_based_sampling": null
             },
             {
-               "data_type": "DAQ channel",
+               "object_type": "DAQ channel",
                "channel_name": "DI1",
                "device_name": "Janelia_Lick_Detector Right",
                "channel_type": "Digital Input",
@@ -301,7 +301,7 @@
                "event_based_sampling": null
             },
             {
-               "data_type": "DAQ channel",
+               "object_type": "DAQ channel",
                "channel_name": "DI3",
                "device_name": "Photometry Clock",
                "channel_type": "Digital Input",
@@ -323,9 +323,9 @@
          "is_clock_generator": false
       },
       {
-         "data_type": "Reward delivery",
+         "object_type": "Reward delivery",
          "stage_type": {
-            "data_type": "Motorized stage",
+            "object_type": "Motorized stage",
             "name": "NewScaleMotor for LickSpouts",
             "serial_number": null,
             "manufacturer": {
@@ -345,7 +345,7 @@
          },
          "reward_spouts": [
             {
-               "data_type": "Reward spout",
+               "object_type": "Reward spout",
                "name": "Left spout",
                "serial_number": null,
                "manufacturer": null,
@@ -359,7 +359,7 @@
                "spout_diameter_unit": "millimeter",
                "spout_position": null,
                "solenoid_valve": {
-                  "data_type": "Device",
+                  "object_type": "Device",
                   "name": "Solenoid Left",
                   "serial_number": null,
                   "manufacturer": null,
@@ -370,7 +370,7 @@
                   "notes": null
                },
                "lick_sensor": {
-                  "data_type": "Device",
+                  "object_type": "Device",
                   "name": "Janelia_Lick_Detector Left",
                   "serial_number": null,
                   "manufacturer": {
@@ -391,7 +391,7 @@
                "lick_sensor_type": "Capacitive"
             },
             {
-               "data_type": "Reward spout",
+               "object_type": "Reward spout",
                "name": "Right spout",
                "serial_number": null,
                "manufacturer": null,
@@ -405,7 +405,7 @@
                "spout_diameter_unit": "millimeter",
                "spout_position": null,
                "solenoid_valve": {
-                  "data_type": "Device",
+                  "object_type": "Device",
                   "name": "Solenoid Right",
                   "serial_number": null,
                   "manufacturer": null,
@@ -416,7 +416,7 @@
                   "notes": null
                },
                "lick_sensor": {
-                  "data_type": "Device",
+                  "object_type": "Device",
                   "name": "Janelia_Lick_Detector Right",
                   "serial_number": null,
                   "manufacturer": {
@@ -439,7 +439,7 @@
          ]
       },
       {
-         "data_type": "Patch",
+         "object_type": "Patch",
          "name": "Bundle Branching Fiber-optic Patch Cord",
          "serial_number": null,
          "manufacturer": {
@@ -461,7 +461,7 @@
          "photobleaching_date": null
       },
       {
-         "data_type": "Light emitting diode",
+         "object_type": "Light emitting diode",
          "name": "470nm LED",
          "serial_number": null,
          "manufacturer": {
@@ -484,7 +484,7 @@
          "bandwidth_unit": null
       },
       {
-         "data_type": "Light emitting diode",
+         "object_type": "Light emitting diode",
          "name": "415nm LED",
          "serial_number": null,
          "manufacturer": {
@@ -507,7 +507,7 @@
          "bandwidth_unit": null
       },
       {
-         "data_type": "Light emitting diode",
+         "object_type": "Light emitting diode",
          "name": "565nm LED",
          "serial_number": null,
          "manufacturer": {
@@ -530,7 +530,7 @@
          "bandwidth_unit": null
       },
       {
-         "data_type": "Detector",
+         "object_type": "Detector",
          "name": "Green CMOS",
          "serial_number": "21396991",
          "manufacturer": {
@@ -576,7 +576,7 @@
          "driver_version": null
       },
       {
-         "data_type": "Detector",
+         "object_type": "Detector",
          "name": "Red CMOS",
          "serial_number": "21396991",
          "manufacturer": {
@@ -622,7 +622,7 @@
          "driver_version": null
       },
       {
-         "data_type": "Objective",
+         "object_type": "Objective",
          "name": "Objective",
          "serial_number": "128022336",
          "manufacturer": {
@@ -645,7 +645,7 @@
          "objective_type": null
       },
       {
-         "data_type": "Filter",
+         "object_type": "Filter",
          "name": "Green emission filter",
          "serial_number": null,
          "manufacturer": {
@@ -674,7 +674,7 @@
          "description": null
       },
       {
-         "data_type": "Filter",
+         "object_type": "Filter",
          "name": "Red emission filter",
          "serial_number": null,
          "manufacturer": {
@@ -703,7 +703,7 @@
          "description": null
       },
       {
-         "data_type": "Filter",
+         "object_type": "Filter",
          "name": "Emission Dichroic",
          "serial_number": null,
          "manufacturer": {
@@ -732,7 +732,7 @@
          "description": null
       },
       {
-         "data_type": "Filter",
+         "object_type": "Filter",
          "name": "dual-edge standard epi-fluorescence dichroic beamsplitter",
          "serial_number": null,
          "manufacturer": {
@@ -761,7 +761,7 @@
          "description": null
       },
       {
-         "data_type": "Filter",
+         "object_type": "Filter",
          "name": "Excitation filter 410nm",
          "serial_number": null,
          "manufacturer": {
@@ -793,7 +793,7 @@
          "description": null
       },
       {
-         "data_type": "Filter",
+         "object_type": "Filter",
          "name": "Excitation filter 470nm",
          "serial_number": null,
          "manufacturer": {
@@ -825,7 +825,7 @@
          "description": null
       },
       {
-         "data_type": "Filter",
+         "object_type": "Filter",
          "name": "Excitation filter 560nm",
          "serial_number": null,
          "manufacturer": {
@@ -857,7 +857,7 @@
          "description": null
       },
       {
-         "data_type": "Filter",
+         "object_type": "Filter",
          "name": "450 Dichroic Longpass Filter",
          "serial_number": null,
          "manufacturer": {
@@ -889,7 +889,7 @@
          "description": null
       },
       {
-         "data_type": "Filter",
+         "object_type": "Filter",
          "name": "500 Dichroic Longpass Filter",
          "serial_number": null,
          "manufacturer": {
@@ -921,7 +921,7 @@
          "description": null
       },
       {
-         "data_type": "Lens",
+         "object_type": "Lens",
          "name": "Image focusing lens",
          "serial_number": null,
          "manufacturer": {
@@ -947,7 +947,7 @@
          "max_aperture": null
       },
       {
-         "data_type": "Device",
+         "object_type": "Device",
          "name": "Photometry Clock",
          "serial_number": null,
          "manufacturer": null,
@@ -958,7 +958,7 @@
          "notes": null
       },
       {
-         "data_type": "Tube",
+         "object_type": "Tube",
          "name": "mouse_tube_foraging",
          "serial_number": null,
          "manufacturer": null,

--- a/examples/fip_ophys_instrument.json
+++ b/examples/fip_ophys_instrument.json
@@ -1,12 +1,12 @@
 {
-   "data_type": "Instrument",
+   "object_type": "Instrument",
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/instrument.py",
    "schema_version": "2.0.1",
    "instrument_id": "428_FIP1_20231003",
    "modification_date": "2023-10-03",
    "calibrations": [
       {
-         "data_type": "Calibration",
+         "object_type": "Calibration",
          "calibration_date": "2023-10-02T03:15:22Z",
          "device_name": "470nm LED",
          "description": "LED calibration",
@@ -44,11 +44,11 @@
    "connections": [],
    "components": [
       {
-         "data_type": "Camera assembly",
+         "object_type": "Camera assembly",
          "name": "BehaviorVideography_FaceSide",
          "camera_target": "Face side left",
          "camera": {
-            "data_type": "Camera",
+            "object_type": "Camera",
             "name": "Side face camera",
             "serial_number": null,
             "manufacturer": {
@@ -87,7 +87,7 @@
             "crop_height": null,
             "crop_unit": "pixel",
             "recording_software": {
-               "data_type": "Software",
+               "object_type": "Software",
                "name": "Bonsai",
                "version": "2.5",
                "url": null,
@@ -97,7 +97,7 @@
             "driver_version": null
          },
          "lens": {
-            "data_type": "Lens",
+            "object_type": "Lens",
             "name": "Xenocam 1",
             "serial_number": null,
             "manufacturer": {
@@ -123,11 +123,11 @@
          "position": null
       },
       {
-         "data_type": "Camera assembly",
+         "object_type": "Camera assembly",
          "name": "BehaviorVideography_FaceBottom",
          "camera_target": "Face bottom",
          "camera": {
-            "data_type": "Camera",
+            "object_type": "Camera",
             "name": "Bottom face Camera",
             "serial_number": null,
             "manufacturer": {
@@ -166,7 +166,7 @@
             "crop_height": null,
             "crop_unit": "pixel",
             "recording_software": {
-               "data_type": "Software",
+               "object_type": "Software",
                "name": "Bonsai",
                "version": "2.5",
                "url": null,
@@ -176,7 +176,7 @@
             "driver_version": null
          },
          "lens": {
-            "data_type": "Lens",
+            "object_type": "Lens",
             "name": "Xenocam 2",
             "serial_number": null,
             "manufacturer": {
@@ -202,7 +202,7 @@
          "position": null
       },
       {
-         "data_type": "Patch",
+         "object_type": "Patch",
          "name": "Bundle Branching Fiber-optic Patch Cord",
          "serial_number": null,
          "manufacturer": {
@@ -224,7 +224,7 @@
          "photobleaching_date": null
       },
       {
-         "data_type": "Light emitting diode",
+         "object_type": "Light emitting diode",
          "name": "470nm LED",
          "serial_number": null,
          "manufacturer": {
@@ -247,7 +247,7 @@
          "bandwidth_unit": null
       },
       {
-         "data_type": "Light emitting diode",
+         "object_type": "Light emitting diode",
          "name": "415nm LED",
          "serial_number": null,
          "manufacturer": {
@@ -270,7 +270,7 @@
          "bandwidth_unit": null
       },
       {
-         "data_type": "Light emitting diode",
+         "object_type": "Light emitting diode",
          "name": "565nm LED",
          "serial_number": null,
          "manufacturer": {
@@ -293,7 +293,7 @@
          "bandwidth_unit": null
       },
       {
-         "data_type": "Detector",
+         "object_type": "Detector",
          "name": "Green CMOS",
          "serial_number": "21396991",
          "manufacturer": {
@@ -339,7 +339,7 @@
          "driver_version": null
       },
       {
-         "data_type": "Detector",
+         "object_type": "Detector",
          "name": "Red CMOS",
          "serial_number": "21396991",
          "manufacturer": {
@@ -385,7 +385,7 @@
          "driver_version": null
       },
       {
-         "data_type": "Objective",
+         "object_type": "Objective",
          "name": "Objective",
          "serial_number": "128022336",
          "manufacturer": {
@@ -408,7 +408,7 @@
          "objective_type": null
       },
       {
-         "data_type": "Filter",
+         "object_type": "Filter",
          "name": "Green emission filter",
          "serial_number": null,
          "manufacturer": {
@@ -437,7 +437,7 @@
          "description": null
       },
       {
-         "data_type": "Filter",
+         "object_type": "Filter",
          "name": "Red emission filter",
          "serial_number": null,
          "manufacturer": {
@@ -466,7 +466,7 @@
          "description": null
       },
       {
-         "data_type": "Filter",
+         "object_type": "Filter",
          "name": "Emission Dichroic",
          "serial_number": null,
          "manufacturer": {
@@ -495,7 +495,7 @@
          "description": null
       },
       {
-         "data_type": "Filter",
+         "object_type": "Filter",
          "name": "dual-edge standard epi-fluorescence dichroic beamsplitter",
          "serial_number": null,
          "manufacturer": {
@@ -524,7 +524,7 @@
          "description": null
       },
       {
-         "data_type": "Filter",
+         "object_type": "Filter",
          "name": "Excitation filter 410nm",
          "serial_number": null,
          "manufacturer": {
@@ -556,7 +556,7 @@
          "description": null
       },
       {
-         "data_type": "Filter",
+         "object_type": "Filter",
          "name": "Excitation filter 470nm",
          "serial_number": null,
          "manufacturer": {
@@ -588,7 +588,7 @@
          "description": null
       },
       {
-         "data_type": "Filter",
+         "object_type": "Filter",
          "name": "Excitation filter 560nm",
          "serial_number": null,
          "manufacturer": {
@@ -620,7 +620,7 @@
          "description": null
       },
       {
-         "data_type": "Filter",
+         "object_type": "Filter",
          "name": "450 Dichroic Longpass Filter",
          "serial_number": null,
          "manufacturer": {
@@ -652,7 +652,7 @@
          "description": null
       },
       {
-         "data_type": "Filter",
+         "object_type": "Filter",
          "name": "500 Dichroic Longpass Filter",
          "serial_number": null,
          "manufacturer": {
@@ -684,7 +684,7 @@
          "description": null
       },
       {
-         "data_type": "Lens",
+         "object_type": "Lens",
          "name": "Image focusing lens",
          "serial_number": null,
          "manufacturer": {
@@ -710,7 +710,7 @@
          "max_aperture": null
       },
       {
-         "data_type": "Harp device",
+         "object_type": "Harp device",
          "name": "Harp Behavior",
          "serial_number": null,
          "manufacturer": {
@@ -731,7 +731,7 @@
          "computer_name": "behavior_computer",
          "channels": [
             {
-               "data_type": "DAQ channel",
+               "object_type": "DAQ channel",
                "channel_name": "DO0",
                "device_name": "Solenoid Left",
                "channel_type": "Digital Output",
@@ -742,7 +742,7 @@
                "event_based_sampling": null
             },
             {
-               "data_type": "DAQ channel",
+               "object_type": "DAQ channel",
                "channel_name": "DO1",
                "device_name": "Solenoid Right",
                "channel_type": "Digital Output",
@@ -753,7 +753,7 @@
                "event_based_sampling": null
             },
             {
-               "data_type": "DAQ channel",
+               "object_type": "DAQ channel",
                "channel_name": "DI0",
                "device_name": "Lick-o-meter Left",
                "channel_type": "Digital Input",
@@ -764,7 +764,7 @@
                "event_based_sampling": null
             },
             {
-               "data_type": "DAQ channel",
+               "object_type": "DAQ channel",
                "channel_name": "DI1",
                "device_name": "Lick-o-meter Right",
                "channel_type": "Digital Input",
@@ -775,7 +775,7 @@
                "event_based_sampling": null
             },
             {
-               "data_type": "DAQ channel",
+               "object_type": "DAQ channel",
                "channel_name": "DI3",
                "device_name": "Photometry Clock",
                "channel_type": "Digital Input",
@@ -797,11 +797,11 @@
          "is_clock_generator": false
       },
       {
-         "data_type": "Reward delivery",
+         "object_type": "Reward delivery",
          "stage_type": null,
          "reward_spouts": [
             {
-               "data_type": "Reward spout",
+               "object_type": "Reward spout",
                "name": "Left spout",
                "serial_number": null,
                "manufacturer": null,
@@ -815,7 +815,7 @@
                "spout_diameter_unit": "millimeter",
                "spout_position": null,
                "solenoid_valve": {
-                  "data_type": "Device",
+                  "object_type": "Device",
                   "name": "Solenoid Left",
                   "serial_number": null,
                   "manufacturer": null,
@@ -826,7 +826,7 @@
                   "notes": null
                },
                "lick_sensor": {
-                  "data_type": "Device",
+                  "object_type": "Device",
                   "name": "Lick-o-meter Left",
                   "serial_number": null,
                   "manufacturer": null,
@@ -839,7 +839,7 @@
                "lick_sensor_type": null
             },
             {
-               "data_type": "Reward spout",
+               "object_type": "Reward spout",
                "name": "Right spout",
                "serial_number": null,
                "manufacturer": null,
@@ -853,7 +853,7 @@
                "spout_diameter_unit": "millimeter",
                "spout_position": null,
                "solenoid_valve": {
-                  "data_type": "Device",
+                  "object_type": "Device",
                   "name": "Solenoid Right",
                   "serial_number": null,
                   "manufacturer": null,
@@ -864,7 +864,7 @@
                   "notes": null
                },
                "lick_sensor": {
-                  "data_type": "Device",
+                  "object_type": "Device",
                   "name": "Lick-o-meter Right",
                   "serial_number": null,
                   "manufacturer": null,
@@ -879,7 +879,7 @@
          ]
       },
       {
-         "data_type": "Device",
+         "object_type": "Device",
          "name": "Photometry Clock",
          "serial_number": null,
          "manufacturer": null,
@@ -890,7 +890,7 @@
          "notes": null
       },
       {
-         "data_type": "Disc",
+         "object_type": "Disc",
          "name": "mouse_disc",
          "serial_number": null,
          "manufacturer": null,

--- a/examples/mri_session.json
+++ b/examples/mri_session.json
@@ -1,5 +1,5 @@
 {
-   "data_type": "Session",
+   "object_type": "Session",
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/session.py",
    "schema_version": "2.0.1",
    "protocol_id": [
@@ -29,7 +29,7 @@
    "anaesthesia": null,
    "data_streams": [
       {
-         "data_type": "Stream",
+         "object_type": "Stream",
          "stream_start_time": "2024-03-12T16:27:55.584892Z",
          "stream_end_time": "2024-03-12T16:27:55.584892Z",
          "daq_names": [],
@@ -46,12 +46,12 @@
          "stack_parameters": null,
          "mri_scans": [
             {
-               "data_type": "MRI scan",
+               "object_type": "MRI scan",
                "scan_index": 1,
                "scan_type": "Set Up",
                "primary_scan": false,
                "mri_scanner": {
-                  "data_type": "Scanner",
+                  "object_type": "Scanner",
                   "name": "Scanner 72",
                   "serial_number": null,
                   "manufacturer": null,
@@ -75,7 +75,7 @@
                "vc_position": null,
                "subject_position": "Supine",
                "voxel_sizes": {
-                  "data_type": "Scale3d transform",
+                  "object_type": "Scale3d transform",
                   "scale": [
                      "0.5",
                      "0.4375",
@@ -87,12 +87,12 @@
                "notes": "Set up scan for the 3D scan."
             },
             {
-               "data_type": "MRI scan",
+               "object_type": "MRI scan",
                "scan_index": 2,
                "scan_type": "3D Scan",
                "primary_scan": true,
                "mri_scanner": {
-                  "data_type": "Scanner",
+                  "object_type": "Scanner",
                   "name": "Scanner 72",
                   "serial_number": null,
                   "manufacturer": null,
@@ -113,7 +113,7 @@
                "repetition_time": "500.0",
                "repetition_time_unit": "millisecond",
                "vc_orientation": {
-                  "data_type": "Rotation3d transform",
+                  "object_type": "Rotation3d transform",
                   "rotation": [
                      "1.0",
                      "0.0",
@@ -127,7 +127,7 @@
                   ]
                },
                "vc_position": {
-                  "data_type": "Translation3d transform",
+                  "object_type": "Translation3d transform",
                   "translation": [
                      "-6.1",
                      "-7.0",
@@ -136,7 +136,7 @@
                },
                "subject_position": "Supine",
                "voxel_sizes": {
-                  "data_type": "Scale3d transform",
+                  "object_type": "Scale3d transform",
                   "scale": [
                      "0.1",
                      "0.1",

--- a/examples/multiplane_ophys_session.json
+++ b/examples/multiplane_ophys_session.json
@@ -1,5 +1,5 @@
 {
-   "data_type": "Session",
+   "object_type": "Session",
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/session.py",
    "schema_version": "2.0.1",
    "protocol_id": [],
@@ -27,7 +27,7 @@
    "anaesthesia": null,
    "data_streams": [
       {
-         "data_type": "Stream",
+         "object_type": "Stream",
          "stream_start_time": "2022-07-12T07:00:00Z",
          "stream_end_time": "2022-07-12T07:00:00Z",
          "daq_names": [],
@@ -40,7 +40,7 @@
          ],
          "light_sources": [
             {
-               "data_type": "Laser config",
+               "object_type": "Laser config",
                "name": "Laser A",
                "wavelength": 920,
                "wavelength_unit": "nanometer",
@@ -56,7 +56,7 @@
          "fiber_modules": [],
          "ophys_fovs": [
             {
-               "data_type": "Field of view",
+               "object_type": "Field of view",
                "index": 0,
                "imaging_depth": 190,
                "imaging_depth_unit": "micrometer",
@@ -88,7 +88,7 @@
                "notes": null
             },
             {
-               "data_type": "Field of view",
+               "object_type": "Field of view",
                "index": 1,
                "imaging_depth": 232,
                "imaging_depth_unit": "micrometer",
@@ -120,7 +120,7 @@
                "notes": null
             },
             {
-               "data_type": "Field of view",
+               "object_type": "Field of view",
                "index": 2,
                "imaging_depth": 136,
                "imaging_depth_unit": "micrometer",
@@ -152,7 +152,7 @@
                "notes": null
             },
             {
-               "data_type": "Field of view",
+               "object_type": "Field of view",
                "index": 3,
                "imaging_depth": 282,
                "imaging_depth_unit": "micrometer",
@@ -184,7 +184,7 @@
                "notes": null
             },
             {
-               "data_type": "Field of view",
+               "object_type": "Field of view",
                "index": 4,
                "imaging_depth": 72,
                "imaging_depth_unit": "micrometer",
@@ -216,7 +216,7 @@
                "notes": null
             },
             {
-               "data_type": "Field of view",
+               "object_type": "Field of view",
                "index": 5,
                "imaging_depth": 326,
                "imaging_depth_unit": "micrometer",
@@ -248,7 +248,7 @@
                "notes": null
             },
             {
-               "data_type": "Field of view",
+               "object_type": "Field of view",
                "index": 6,
                "imaging_depth": 30,
                "imaging_depth_unit": "micrometer",
@@ -280,7 +280,7 @@
                "notes": null
             },
             {
-               "data_type": "Field of view",
+               "object_type": "Field of view",
                "index": 7,
                "imaging_depth": 364,
                "imaging_depth_unit": "micrometer",

--- a/examples/ophys_procedures.json
+++ b/examples/ophys_procedures.json
@@ -1,11 +1,11 @@
 {
-   "data_type": "Procedures",
+   "object_type": "Procedures",
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/procedures.py",
    "schema_version": "2.0.1",
    "subject_id": "625100",
    "subject_procedures": [
       {
-         "data_type": "Surgery",
+         "object_type": "Surgery",
          "protocol_id": "doi",
          "start_date": "2022-07-12",
          "experimenters": [
@@ -23,7 +23,7 @@
          "animal_weight_post": "22.3",
          "weight_unit": "gram",
          "anaesthesia": {
-            "data_type": "Anaesthetic",
+            "object_type": "Anaesthetic",
             "type": "Isoflurane",
             "duration": "180",
             "duration_unit": "minute",
@@ -32,7 +32,7 @@
          "workstation_id": "SWS 3",
          "procedures": [
             {
-               "data_type": "Headframe",
+               "object_type": "Headframe",
                "protocol_id": "2109",
                "headframe_type": "AI straight",
                "headframe_part_number": "TO ENTER",
@@ -41,10 +41,10 @@
                "well_type": null
             },
             {
-               "data_type": "Nanoject injection",
+               "object_type": "Nanoject injection",
                "injection_materials": [
                   {
-                     "data_type": "Viral material",
+                     "object_type": "Viral material",
                      "material_type": "Virus",
                      "name": "AAV2/1-Syn-Flex-ChrimsonR-tdT",
                      "tars_identifiers": null,
@@ -91,13 +91,13 @@
                "injection_volume_unit": "nanoliter"
             },
             {
-               "data_type": "Fiber implant",
+               "object_type": "Fiber implant",
                "protocol_id": "TO ENTER",
                "probes": [
                   {
-                     "data_type": "Ophys probe",
+                     "object_type": "Ophys probe",
                      "ophys_probe": {
-                        "data_type": "Fiber probe",
+                        "object_type": "Fiber probe",
                         "name": "Probe A",
                         "serial_number": null,
                         "manufacturer": null,
@@ -137,7 +137,7 @@
          "notes": null
       },
       {
-         "data_type": "Water restriction",
+         "object_type": "Water restriction",
          "ethics_review_id": "1234",
          "target_fraction_weight": 25,
          "target_fraction_weight_unit": "percent",
@@ -149,7 +149,7 @@
          "end_date": "2023-05-23"
       },
       {
-         "data_type": "Surgery",
+         "object_type": "Surgery",
          "protocol_id": "doi",
          "start_date": "2023-05-31",
          "experimenters": [
@@ -167,7 +167,7 @@
          "animal_weight_post": null,
          "weight_unit": "gram",
          "anaesthesia": {
-            "data_type": "Anaesthetic",
+            "object_type": "Anaesthetic",
             "type": "Isoflurane",
             "duration": "30",
             "duration_unit": "minute",
@@ -176,7 +176,7 @@
          "workstation_id": "SWS 3",
          "procedures": [
             {
-               "data_type": "Perfusion",
+               "object_type": "Perfusion",
                "protocol_id": "dx.doi.org/10.17504/protocols.io.bg5vjy66",
                "output_specimen_ids": [
                   "672640"
@@ -188,7 +188,7 @@
    ],
    "specimen_procedures": [
       {
-         "data_type": "Specimen procedure",
+         "object_type": "Specimen procedure",
          "procedure_type": "Immunolabeling",
          "procedure_name": null,
          "specimen_id": "672640",
@@ -211,7 +211,7 @@
          "hcr_series": null,
          "antibodies": [
             {
-               "data_type": "Antibody",
+               "object_type": "Antibody",
                "name": "Chicken polyclonal",
                "source": {
                   "name": "Abcam",
@@ -244,7 +244,7 @@
          "notes": "Primary dilution factor 1:1000 ---final concentration is 10ug/ml"
       },
       {
-         "data_type": "Specimen procedure",
+         "object_type": "Specimen procedure",
          "procedure_type": "Immunolabeling",
          "procedure_name": null,
          "specimen_id": "672640",
@@ -267,7 +267,7 @@
          "hcr_series": null,
          "antibodies": [
             {
-               "data_type": "Antibody",
+               "object_type": "Antibody",
                "name": "Alexa Fluor 488 goat anti-chicken IgY (H+L)",
                "source": {
                   "name": "Thermo Fisher Scientific",

--- a/examples/ophys_session.json
+++ b/examples/ophys_session.json
@@ -1,5 +1,5 @@
 {
-   "data_type": "Session",
+   "object_type": "Session",
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/session.py",
    "schema_version": "2.0.1",
    "protocol_id": [],
@@ -27,14 +27,14 @@
    "anaesthesia": null,
    "data_streams": [
       {
-         "data_type": "Stream",
+         "object_type": "Stream",
          "stream_start_time": "2022-07-12T07:00:00Z",
          "stream_end_time": "2022-07-12T07:00:00Z",
          "daq_names": [],
          "camera_names": [],
          "light_sources": [
             {
-               "data_type": "Laser config",
+               "object_type": "Laser config",
                "name": "Laser A",
                "wavelength": 405,
                "wavelength_unit": "nanometer",
@@ -42,7 +42,7 @@
                "excitation_power_unit": "milliwatt"
             },
             {
-               "data_type": "Laser config",
+               "object_type": "Laser config",
                "name": "Laser B",
                "wavelength": 473,
                "wavelength_unit": "nanometer",
@@ -55,7 +55,7 @@
          "manipulator_modules": [],
          "detectors": [
             {
-               "data_type": "Detector config",
+               "object_type": "Detector config",
                "name": "Hamamatsu Camera",
                "exposure_time": "10",
                "exposure_time_unit": "millisecond",
@@ -64,14 +64,14 @@
          ],
          "fiber_connections": [
             {
-               "data_type": "Fiber connection config",
+               "object_type": "Fiber connection config",
                "patch_cord_name": "Patch Cord A",
                "patch_cord_output_power": "40",
                "output_power_unit": "microwatt",
                "fiber_name": "Fiber A"
             },
             {
-               "data_type": "Fiber connection config",
+               "object_type": "Fiber connection config",
                "patch_cord_name": "Patch Cord B",
                "patch_cord_output_power": "43",
                "output_power_unit": "microwatt",

--- a/examples/procedures.json
+++ b/examples/procedures.json
@@ -1,11 +1,11 @@
 {
-   "data_type": "Procedures",
+   "object_type": "Procedures",
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/procedures.py",
    "schema_version": "2.0.1",
    "subject_id": "625100",
    "subject_procedures": [
       {
-         "data_type": "Surgery",
+         "object_type": "Surgery",
          "protocol_id": "doi",
          "start_date": "2022-07-12",
          "experimenters": [
@@ -23,7 +23,7 @@
          "animal_weight_post": "22.3",
          "weight_unit": "gram",
          "anaesthesia": {
-            "data_type": "Anaesthetic",
+            "object_type": "Anaesthetic",
             "type": "Isoflurane",
             "duration": "1",
             "duration_unit": "minute",
@@ -32,7 +32,7 @@
          "workstation_id": "SWS 3",
          "procedures": [
             {
-               "data_type": "Craniotomy",
+               "object_type": "Craniotomy",
                "protocol_id": "1234",
                "craniotomy_type": "Visual Cortex",
                "craniotomy_hemisphere": "Left",
@@ -45,14 +45,14 @@
                "recovery_time_unit": null
             },
             {
-               "data_type": "Nanoject injection",
+               "object_type": "Nanoject injection",
                "injection_materials": [
                   {
-                     "data_type": "Viral material",
+                     "object_type": "Viral material",
                      "material_type": "Virus",
                      "name": "AAV2-Flex-ChrimsonR",
                      "tars_identifiers": {
-                        "data_type": "Tars virus identifiers",
+                        "object_type": "Tars virus identifiers",
                         "virus_tars_id": "AiV222",
                         "plasmid_tars_alias": "AiP222",
                         "prep_lot_number": "VT222",
@@ -98,7 +98,7 @@
          "notes": null
       },
       {
-         "data_type": "Surgery",
+         "object_type": "Surgery",
          "protocol_id": "doi",
          "start_date": "2022-09-23",
          "experimenters": [
@@ -119,7 +119,7 @@
          "workstation_id": null,
          "procedures": [
             {
-               "data_type": "Perfusion",
+               "object_type": "Perfusion",
                "protocol_id": "doi_of_protocol",
                "output_specimen_ids": [
                   "1",

--- a/examples/processing.json
+++ b/examples/processing.json
@@ -1,12 +1,12 @@
 {
-   "data_type": "Processing",
+   "object_type": "Processing",
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/processing.py",
    "schema_version": "2.0.1",
    "processing_pipeline": {
-      "data_type": "Pipeline process",
+      "object_type": "Pipeline process",
       "data_processes": [
          {
-            "data_type": "Data process",
+            "object_type": "Data process",
             "name": "Image tile fusing",
             "software_version": "0.0.1",
             "start_date_time": "2022-11-22T08:43:00Z",
@@ -21,7 +21,7 @@
             "outputs": {},
             "notes": null,
             "resources": {
-               "data_type": "Resource usage",
+               "object_type": "Resource usage",
                "os": "Ubuntu 20.04",
                "architecture": "x86-64",
                "cpu": "Intel Core i7",
@@ -33,36 +33,36 @@
                "ram_unit": "Gigabyte",
                "cpu_usage": [
                   {
-                     "data_type": "Resource timestamped",
+                     "object_type": "Resource timestamped",
                      "timestamp": "2024-09-13T00:00:00Z",
                      "usage": 75.5
                   },
                   {
-                     "data_type": "Resource timestamped",
+                     "object_type": "Resource timestamped",
                      "timestamp": "2024-09-13T00:00:00Z",
                      "usage": 80.0
                   }
                ],
                "gpu_usage": [
                   {
-                     "data_type": "Resource timestamped",
+                     "object_type": "Resource timestamped",
                      "timestamp": "2024-09-13T00:00:00Z",
                      "usage": 60.0
                   },
                   {
-                     "data_type": "Resource timestamped",
+                     "object_type": "Resource timestamped",
                      "timestamp": "2024-09-13T00:00:00Z",
                      "usage": 65.5
                   }
                ],
                "ram_usage": [
                   {
-                     "data_type": "Resource timestamped",
+                     "object_type": "Resource timestamped",
                      "timestamp": "2024-09-13T00:00:00Z",
                      "usage": 70.0
                   },
                   {
-                     "data_type": "Resource timestamped",
+                     "object_type": "Resource timestamped",
                      "timestamp": "2024-09-13T00:00:00Z",
                      "usage": 72.5
                   }
@@ -71,7 +71,7 @@
             }
          },
          {
-            "data_type": "Data process",
+            "object_type": "Data process",
             "name": "File format conversion",
             "software_version": "0.0.1",
             "start_date_time": "2022-11-22T08:43:00Z",
@@ -89,7 +89,7 @@
             "resources": null
          },
          {
-            "data_type": "Data process",
+            "object_type": "Data process",
             "name": "Image destriping",
             "software_version": "0.2.1",
             "start_date_time": "2022-11-22T08:43:00Z",
@@ -123,7 +123,7 @@
    },
    "analyses": [
       {
-         "data_type": "Analysis process",
+         "object_type": "Analysis process",
          "name": "Analysis",
          "software_version": "0.0.1",
          "start_date_time": "2022-11-22T08:43:00Z",
@@ -151,7 +151,7 @@
          "description": "some description"
       },
       {
-         "data_type": "Analysis process",
+         "object_type": "Analysis process",
          "name": "Analysis",
          "software_version": "0.0.1",
          "start_date_time": "2022-11-22T08:43:00Z",

--- a/examples/quality_control.json
+++ b/examples/quality_control.json
@@ -1,10 +1,10 @@
 {
-   "data_type": "Quality control",
+   "object_type": "Quality control",
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/quality_control.py",
    "schema_version": "2.0.1",
    "evaluations": [
       {
-         "data_type": "QC evaluation",
+         "object_type": "QC evaluation",
          "modality": {
             "name": "Extracellular electrophysiology",
             "abbreviation": "ecephys"
@@ -91,7 +91,7 @@
          "created": "2022-11-22T00:00:00Z"
       },
       {
-         "data_type": "QC evaluation",
+         "object_type": "QC evaluation",
          "modality": {
             "name": "Behavior videos",
             "abbreviation": "behavior-videos"
@@ -150,7 +150,7 @@
          "created": "2022-11-22T00:00:00Z"
       },
       {
-         "data_type": "QC evaluation",
+         "object_type": "QC evaluation",
          "modality": {
             "name": "Extracellular electrophysiology",
             "abbreviation": "ecephys"

--- a/examples/subject.json
+++ b/examples/subject.json
@@ -1,5 +1,5 @@
 {
-   "data_type": "Subject",
+   "object_type": "Subject",
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/subject.py",
    "schema_version": "2.0.1",
    "subject_id": "12345",
@@ -17,7 +17,7 @@
    "alleles": [],
    "background_strain": "C57BL/6J",
    "breeding_info": {
-      "data_type": "Breeding info",
+      "object_type": "Breeding info",
       "breeding_group": "Emx1-IRES-Cre(ND)",
       "maternal_id": "546543",
       "maternal_genotype": "Emx1-IRES-Cre/wt; Camk2a-tTa/Camk2a-tTA",
@@ -37,7 +37,7 @@
    "restrictions": null,
    "wellness_reports": [],
    "housing": {
-      "data_type": "Housing",
+      "object_type": "Housing",
       "cage_id": "123",
       "room_id": null,
       "light_cycle": null,

--- a/src/aind_data_schema/base.py
+++ b/src/aind_data_schema/base.py
@@ -101,29 +101,29 @@ class DataModel(BaseModel, Generic[GenericModelType]):
     """
 
     model_config = ConfigDict(extra="forbid", use_enum_values=True)
-    data_type: ClassVar[str]  # This prevents Pydantic from treating it as a normal field
+    object_type: ClassVar[str]  # This prevents Pydantic from treating it as a normal field
 
     def __init_subclass__(cls, **kwargs):
-        """Automatically set the correct `data_type` as a Literal[...]"""
+        """Automatically set the correct `object_type` as a Literal[...]"""
         super().__init_subclass__(**kwargs)
-        data_type_value = cls._data_type_from_name()
-        cls.__annotations__["data_type"] = Literal[data_type_value]  # Set literal type annotation
-        cls.data_type = data_type_value  # Set the value on the class itself
+        object_type_value = cls._object_type_from_name()
+        cls.__annotations__["object_type"] = Literal[object_type_value]  # Set literal type annotation
+        cls.object_type = object_type_value  # Set the value on the class itself
 
     @model_validator(mode="before")
-    def coerce_data_type(cls, values):
-        """Ensure that data_type is set to the correct value
+    def coerce_object_type(cls, values):
+        """Ensure that object_type is set to the correct value
 
         This ensures that subclasses/parent classes can be deserialized correctly
         """
-        cls_data_type = cls._data_type_from_name()
-        if "data_type" in values and values["data_type"] != cls_data_type:
-            values["data_type"] = cls_data_type
+        cls_object_type = cls._object_type_from_name()
+        if "object_type" in values and values["object_type"] != cls_object_type:
+            values["object_type"] = cls_object_type
         return values
 
     @classmethod
-    def _data_type_from_name(cls) -> str:
-        """Convert a class name to a data_type
+    def _object_type_from_name(cls) -> str:
+        """Convert a class name to a object_type
 
         Adds a space anytime a lowercase letter is followed by a capital letter
         or when multiple capitals are followed by a lowercase

--- a/src/aind_data_schema/components/coordinates.py
+++ b/src/aind_data_schema/components/coordinates.py
@@ -162,7 +162,7 @@ class RelativePosition(DataModel):
     """Position and rotation of a device in a rig or instrument"""
 
     device_position_transformations: List[
-        Annotated[Union[Translation3dTransform, Rotation3dTransform], Field(discriminator="data_type")]
+        Annotated[Union[Translation3dTransform, Rotation3dTransform], Field(discriminator="object_type")]
     ] = Field(..., title="Device position transforms")
     device_origin: str = Field(
         ..., title="Device origin", description="Reference point on device for position information"

--- a/src/aind_data_schema/components/devices.py
+++ b/src/aind_data_schema/components/devices.py
@@ -553,7 +553,7 @@ class LightAssembly(DataModel):
 
     # required fields
     name: str = Field(..., title="Light assembly name")
-    light: Annotated[Union[Laser, LightEmittingDiode, Lamp], Field(discriminator="data_type")]
+    light: Annotated[Union[Laser, LightEmittingDiode, Lamp], Field(discriminator="object_type")]
     lens: Lens = Field(..., title="Lens")
 
     # optional fields

--- a/src/aind_data_schema/components/tile.py
+++ b/src/aind_data_schema/components/tile.py
@@ -47,7 +47,7 @@ class Tile(DataModel):
                 Rotation3dTransform,
                 Affine3dTransform,
             ],
-            Field(discriminator="data_type"),
+            Field(discriminator="object_type"),
         ]
     ] = Field(..., title="Tile coordinate transformations")
     file_name: Optional[str] = Field(default=None, title="File name")

--- a/src/aind_data_schema/core/instrument.py
+++ b/src/aind_data_schema/core/instrument.py
@@ -165,7 +165,7 @@ class Instrument(DataCoreModel):
                 DAQDevice,
                 Device,  # note that order matters in the Union, DAQDevice and Device should go last
             ],
-            Field(discriminator="data_type"),
+            Field(discriminator="object_type"),
         ]
     ] = Field(
         ...,

--- a/src/aind_data_schema/core/procedures.py
+++ b/src/aind_data_schema/core/procedures.py
@@ -677,7 +677,7 @@ class Surgery(DataModel):
                 RetroOrbitalInjection,
                 SampleCollection,
             ],
-            Field(discriminator="data_type"),
+            Field(discriminator="object_type"),
         ]
     ] = Field(title="Procedures", min_length=1)
     notes: Optional[str] = Field(default=None, title="Notes")
@@ -698,7 +698,7 @@ class Procedures(DataCoreModel):
     subject_procedures: List[
         Annotated[
             Union[Surgery, TrainingProtocol, WaterRestriction, OtherSubjectProcedure],
-            Field(discriminator="data_type"),
+            Field(discriminator="object_type"),
         ]
     ] = Field(default=[], title="Subject Procedures")
     specimen_procedures: List[SpecimenProcedure] = Field(default=[], title="Specimen Procedures")

--- a/src/aind_data_schema/core/session.py
+++ b/src/aind_data_schema/core/session.py
@@ -255,7 +255,7 @@ class LaserConfig(DataModel):
 
 LIGHT_SOURCE_CONFIGS = Annotated[
     Union[LightEmittingDiodeConfig, LaserConfig],
-    Field(discriminator="data_type"),
+    Field(discriminator="object_type"),
 ]
 
 
@@ -520,7 +520,7 @@ class StimulusEpoch(DataModel):
         List[
             Annotated[
                 Union[AuditoryStimulation, OptoStimulation, OlfactoryStimulation, PhotoStimulation, VisualStimulation],
-                Field(discriminator="data_type"),
+                Field(discriminator="object_type"),
             ]
         ]
     ] = Field(default=None, title="Stimulus parameters")

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -170,28 +170,28 @@ class BaseTests(unittest.TestCase):
         """Test that schema version are bumped successfully
         and that validation errors prevent bumping"""
 
-        class TestModel(DataCoreModel):
+        class TestCoreModel(DataCoreModel):
             """test class"""
 
             describedBy: str = "modelv1"
             schema_version: SkipValidation[Literal["1.0.0"]] = "1.0.0"
 
-        v1_init = TestModel()
+        v1_init = TestCoreModel()
         self.assertEqual("1.0.0", v1_init.schema_version)
 
-        # Re-define TestModel with a bumped schema version
-        class TestModel(DataCoreModel):
+        # Re-define TestCoreModel with a bumped schema version
+        class TestCoreModel(DataCoreModel):
             """test class"""
 
             describedBy: str = "modelv2"
             schema_version: SkipValidation[Literal["1.0.1"]] = "1.0.1"
             extra_field: str = "extra_field"
 
-        v2_from_v1 = TestModel(**v1_init.model_dump())
+        v2_from_v1 = TestCoreModel(**v1_init.model_dump())
         self.assertEqual("1.0.1", v2_from_v1.schema_version)
 
         # Re-re-define to make sure that the extra field is not allowed
-        class TestModel(DataCoreModel):
+        class TestCoreModel(DataCoreModel):
             """test class"""
 
             describedBy: str = "modelv1"
@@ -199,7 +199,7 @@ class BaseTests(unittest.TestCase):
 
         # Check that adding additional fields still fails validation
         # this is to ensure you can't get a bumped schema_version without passing validation
-        self.assertRaises(ValidationError, lambda: TestModel(**v2_from_v1.model_dump()))
+        self.assertRaises(ValidationError, lambda: TestCoreModel(**v2_from_v1.model_dump()))
 
     @patch("builtins.open", new_callable=mock_open)
     @patch("logging.warning")

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -69,19 +69,19 @@ class BaseTests(unittest.TestCase):
     def test_units(self):
         """Test that models with value/value_unit pairs throw errors properly"""
 
-        class TestModel(DataModel):
+        class UnitValueModel(DataModel):
             """temporary test model"""
 
             value: Optional[str] = Field(default=None)
             value_unit: Optional[str] = Field(default=None)
 
-        self.assertRaises(ValidationError, lambda: TestModel(value="value"))
+        self.assertRaises(ValidationError, lambda: UnitValueModel(value="value"))
 
-        test0 = TestModel(value="value", value_unit="unit")
+        test0 = UnitValueModel(value="value", value_unit="unit")
         self.assertIsNotNone(test0)
 
         # it's fine if units are set and the value isn't
-        test1 = TestModel(value_unit="unit")
+        test1 = UnitValueModel(value_unit="unit")
         self.assertIsNotNone(test1)
 
         # Multi-unit condition

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -219,8 +219,8 @@ class BaseTests(unittest.TestCase):
 class DataModelTests(unittest.TestCase):
     """Tests for DataModel"""
 
-    def test_generate_data_type(self):
-        """Test that generate_data_type correctly sets the data_type field"""
+    def test_generate_object_type(self):
+        """Test that generate_object_type correctly sets the object_type field"""
 
         class TestModel(DataModel):
             """Temporary test model"""
@@ -228,7 +228,7 @@ class DataModelTests(unittest.TestCase):
             value: str
 
         model_instance = TestModel(value="test")
-        self.assertEqual(model_instance.data_type, "Test model")
+        self.assertEqual(model_instance.object_type, "Test model")
 
         class AnotherTestModel(DataModel):
             """Another temporary test model"""
@@ -236,7 +236,7 @@ class DataModelTests(unittest.TestCase):
             value: str
 
         another_model_instance = AnotherTestModel(value="test")
-        self.assertEqual(another_model_instance.data_type, "Another test model")
+        self.assertEqual(another_model_instance.object_type, "Another test model")
 
         class QCModel(DataModel):
             """Test model with two capital letters in a row"""
@@ -244,20 +244,20 @@ class DataModelTests(unittest.TestCase):
             value: str
 
         qc_model_instance = QCModel(value="test")
-        self.assertEqual(qc_model_instance.data_type, "QC model")
+        self.assertEqual(qc_model_instance.object_type, "QC model")
 
-    def test_data_type_unique(self):
-        """Test that all subclasses of DataModel have unique data_type values"""
+    def test_object_type_unique(self):
+        """Test that all subclasses of DataModel have unique object_type values"""
 
         # For some reason duplicate subclasses can get generated at runtime
         subclasses = set(DataModel.__subclasses__())
 
-        data_types = {}
+        object_types = {}
         for subclass in subclasses:
-            data_type = subclass._data_type_from_name()
-            self.assertNotIn(data_type, data_types.values())
+            object_type = subclass._object_type_from_name()
+            self.assertNotIn(object_type, object_types.values())
 
-            data_types[subclass.__name__] = data_type
+            object_types[subclass.__name__] = object_type
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Replaces `data_type` with `object_type` and fixes a few tests that were breaking because they shared an identical `object_type` field (not sure why this didn't cause problems before...). 