### PR TITLE
fix: making encoder/pulse_p_r Optional

### DIFF
--- a/src/aind_data_schema/components/devices.py
+++ b/src/aind_data_schema/components/devices.py
@@ -777,8 +777,8 @@ class Treadmill(MousePlatform):
     device_type: Literal["Treadmill"] = "Treadmill"
     treadmill_width: Decimal = Field(..., title="Width of treadmill (mm)")
     width_unit: SizeUnit = Field(default=SizeUnit.CM, title="Width unit")
-    encoder: Device = Field(..., title="Encoder")
-    pulse_per_revolution: int = Field(..., title="Pulse per revolution")
+    encoder: Optional[Device] = Field(default=None, title="Encoder")
+    pulse_per_revolution: Optional[int] = Field(default=None, title="Pulse per revolution")
 
 
 class Arena(MousePlatform):


### PR DESCRIPTION
This PR makes two fields Optional for backward compatibility