### PR TITLE
1262 make tarsvirusidentifiersplasmid tars alias a list

### DIFF
--- a/examples/procedures.py
+++ b/examples/procedures.py
@@ -47,7 +47,7 @@ p = Procedures(
                             name="AAV2-Flex-ChrimsonR",
                             tars_identifiers=TarsVirusIdentifiers(
                                 virus_tars_id="AiV222",
-                                plasmid_tars_alias="AiP222",
+                                plasmid_tars_alias=["AiP222"],
                                 prep_lot_number="VT222",
                             ),
                             titer=2300000000,

--- a/src/aind_data_schema/core/procedures.py
+++ b/src/aind_data_schema/core/procedures.py
@@ -378,9 +378,9 @@ class TarsVirusIdentifiers(DataModel):
     """TARS data for a viral prep"""
 
     virus_tars_id: Optional[str] = Field(default=None, title="Virus ID, usually begins 'AiV'")
-    plasmid_tars_alias: Optional[str] = Field(
+    plasmid_tars_alias: Optional[List[str]] = Field(
         default=None,
-        title="Plasmid alias",
+        title="List of plasmid aliases",
         description="Alias used to reference the plasmid, usually begins 'AiP'",
     )
     prep_lot_number: str = Field(..., title="Preparation lot number")

--- a/tests/test_procedures.py
+++ b/tests/test_procedures.py
@@ -337,7 +337,7 @@ class ProceduresTests(unittest.TestCase):
                     name="AAV2-Flex-ChrimsonR",
                     tars_identifiers=TarsVirusIdentifiers(
                         virus_tars_id="AiV222",
-                        plasmid_tars_alias=["AiP222"],
+                        plasmid_tars_alias=["AiP222", "AiP223"],
                         prep_lot_number="VT222",
                     ),
                     titer=2300000000,

--- a/tests/test_procedures.py
+++ b/tests/test_procedures.py
@@ -156,7 +156,7 @@ class ProceduresTests(unittest.TestCase):
                                     name="AAV2-Flex-ChrimsonR",
                                     tars_identifiers=TarsVirusIdentifiers(
                                         virus_tars_id="AiV222",
-                                        plasmid_tars_alias="AiP222",
+                                        plasmid_tars_alias=["AiP222"],
                                         prep_lot_number="VT222",
                                     ),
                                     titer=2300000000,
@@ -191,7 +191,7 @@ class ProceduresTests(unittest.TestCase):
                                     name="AAV2-Flex-ChrimsonR",
                                     tars_identifiers=TarsVirusIdentifiers(
                                         virus_tars_id="AiV222",
-                                        plasmid_tars_alias="AiP222",
+                                        plasmid_tars_alias=["AiP222"],
                                         prep_lot_number="VT222",
                                     ),
                                     titer=2300000000,
@@ -337,7 +337,7 @@ class ProceduresTests(unittest.TestCase):
                     name="AAV2-Flex-ChrimsonR",
                     tars_identifiers=TarsVirusIdentifiers(
                         virus_tars_id="AiV222",
-                        plasmid_tars_alias="AiP222",
+                        plasmid_tars_alias=["AiP222"],
                         prep_lot_number="VT222",
                     ),
                     titer=2300000000,


### PR DESCRIPTION
PR makes plasmid_tars_alias accept a List[str]

This was on the 2.0 milestone, so I didn't bother making it backward compatible.