### PR TITLE
Fix: correctly handling merging two Optional[List[Any]] fields in __add__ function

### DIFF
--- a/src/aind_data_schema/core/acquisition.py
+++ b/src/aind_data_schema/core/acquisition.py
@@ -40,7 +40,7 @@ from aind_data_schema.components.coordinates import Affine3dTransform
 from aind_data_schema.utils.validators import subject_specimen_id_compatibility
 
 from aind_data_schema_models.modalities import Modality
-from aind_data_schema.utils.merge import merge_notes
+from aind_data_schema.utils.merge import merge_notes, merge_optional_list
 
 # Define the requirements for each modality
 # Define the mapping of modalities to their required device types
@@ -313,7 +313,7 @@ class Acquisition(DataCoreModel):
         protocol_id = self.protocol_id + other.protocol_id
         calibrations = self.calibrations + other.calibrations
         maintenance = self.maintenance + other.maintenance
-        software = self.software + other.software
+        software = merge_optional_list(self.software, other.software)
         data_streams = self.data_streams + other.data_streams
         stimulus_epochs = self.stimulus_epochs + other.stimulus_epochs
 

--- a/src/aind_data_schema/utils/merge.py
+++ b/src/aind_data_schema/utils/merge.py
@@ -4,7 +4,7 @@ from typing import Any, List, Optional
 
 
 def merge_optional_list(a: Optional[List[Any]], b: Optional[List[Any]]) -> Optional[List[Any]]:
-    """Merge two optional values"""
+    """Merge two Optional[List[Any]] values"""
 
     merged = (a or []) + (b or [])
     return merged or None

--- a/src/aind_data_schema/utils/merge.py
+++ b/src/aind_data_schema/utils/merge.py
@@ -1,6 +1,13 @@
 """ Helper functions for composability """
 
-from typing import Optional
+from typing import Any, List, Optional
+
+
+def merge_optional_list(a: Optional[List[Any]], b: Optional[List[Any]]) -> Optional[List[Any]]:
+    """Merge two optional values"""
+
+    merged = (a or []) + (b or [])
+    return merged or None
 
 
 def merge_notes(notes1: Optional[str], notes2: Optional[str]) -> Optional[str]:

--- a/tests/test_utils_merge.py
+++ b/tests/test_utils_merge.py
@@ -1,7 +1,7 @@
 """ Tests for merge utilities """
 
 import unittest
-from aind_data_schema.utils.merge import merge_notes
+from aind_data_schema.utils.merge import merge_notes, merge_optional_list
 
 
 class TestMergeNotes(unittest.TestCase):
@@ -34,6 +34,38 @@ class TestMergeNotes(unittest.TestCase):
         notes2 = None
         result = merge_notes(notes1, notes2)
         self.assertIsNone(result)
+
+
+class MergeOptionalListTests(unittest.TestCase):
+    """Tests for merge_optional_list"""
+
+    def test_both_none(self):
+        """Test when both inputs are None"""
+        self.assertIsNone(merge_optional_list(None, None))
+
+    def test_first_none(self):
+        """Test when first input is None"""
+        self.assertEqual(merge_optional_list(None, [1, 2, 3]), [1, 2, 3])
+
+    def test_second_none(self):
+        """Test when second input is None"""
+        self.assertEqual(merge_optional_list([1, 2, 3], None), [1, 2, 3])
+
+    def test_both_empty(self):
+        """Test when both inputs are empty lists"""
+        self.assertIsNone(merge_optional_list([], []))
+
+    def test_first_empty(self):
+        """Test when first input is an empty list"""
+        self.assertEqual(merge_optional_list([], [1, 2, 3]), [1, 2, 3])
+
+    def test_second_empty(self):
+        """Test when second input is an empty list"""
+        self.assertEqual(merge_optional_list([1, 2, 3], []), [1, 2, 3])
+
+    def test_both_non_empty(self):
+        """Test when both inputs are non-empty lists"""
+        self.assertEqual(merge_optional_list([1, 2], [3, 4]), [1, 2, 3, 4])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR fixes a bug introduced in the composability PR where the optional `acquisition.software` field could throw errors if either field was `None` and you attempted to merge two acquisition files.