### PR TITLE
Feat: Arena default CoordinateSystem

### DIFF
--- a/src/aind_data_schema/components/coordinates.py
+++ b/src/aind_data_schema/components/coordinates.py
@@ -366,7 +366,7 @@ class CoordinateSystemLibrary:
         axes=[
             Axis(name=AxisName.X, direction=Direction.LR),
             Axis(name=AxisName.Y, direction=Direction.FB),
-            Axis(name=AxisName.Z, direction=Direction.TB),
+            Axis(name=AxisName.Z, direction=Direction.BT),
         ],
     )
 

--- a/src/aind_data_schema/components/coordinates.py
+++ b/src/aind_data_schema/components/coordinates.py
@@ -33,7 +33,11 @@ class Origin(str, Enum):
     C7 = "C7"
     TIP = "Tip"  # of a probe
     FRONT_CENTER = "Front_center"  # front center of a device, e.g. camera
-    BOTTOM_CENTER = "Center"  # center of a space on the ground, e.g. arena
+    ARENA_CENTER = "Arena_center"  # center of an arena on the ground surface
+    ARENA_FRONT_LEFT = "Arena_front_left"
+    ARENA_FRONT_RIGHT = "Arena_front_right"
+    ARENA_BACK_LEFT = "Arena_back_left" 
+    ARENA_BACK_RIGHT = "Arena_back_right"
 
 
 class AxisName(str, Enum):
@@ -361,7 +365,7 @@ class CoordinateSystemLibrary:
     # Arena
     ARENA_RBT = CoordinateSystem(
         name="ARENA_RBT",
-        origin=Origin.BOTTOM_CENTER,
+        origin=Origin.ARENA_CENTER,
         axis_unit=SizeUnit.CM,
         axes=[
             Axis(name=AxisName.X, direction=Direction.LR),

--- a/src/aind_data_schema/components/coordinates.py
+++ b/src/aind_data_schema/components/coordinates.py
@@ -36,7 +36,7 @@ class Origin(str, Enum):
     ARENA_CENTER = "Arena_center"  # center of an arena on the ground surface
     ARENA_FRONT_LEFT = "Arena_front_left"
     ARENA_FRONT_RIGHT = "Arena_front_right"
-    ARENA_BACK_LEFT = "Arena_back_left" 
+    ARENA_BACK_LEFT = "Arena_back_left"
     ARENA_BACK_RIGHT = "Arena_back_right"
 
 

--- a/src/aind_data_schema/components/coordinates.py
+++ b/src/aind_data_schema/components/coordinates.py
@@ -33,6 +33,7 @@ class Origin(str, Enum):
     C7 = "C7"
     TIP = "Tip"  # of a probe
     FRONT_CENTER = "Front_center"  # front center of a device, e.g. camera
+    CENTER = "Center"  # center of a space, e.g. arena
 
 
 class AxisName(str, Enum):
@@ -354,6 +355,18 @@ class CoordinateSystemLibrary:
             Axis(name=AxisName.ML, direction=Direction.LR),
             Axis(name=AxisName.SI, direction=Direction.SI),
             Axis(name=AxisName.DEPTH, direction=Direction.TB),
+        ],
+    )
+
+    # Arena
+    ARENA_RBT = CoordinateSystem(
+        name="ARENA_RBT",
+        origin=Origin.CENTER,
+        axis_unit=SizeUnit.CM,
+        axes=[
+            Axis(name=AxisName.X, direction=Direction.LR),
+            Axis(name=AxisName.Y, direction=Direction.FB),
+            Axis(name=AxisName.Z, direction=Direction.TB),
         ],
     )
 

--- a/src/aind_data_schema/components/coordinates.py
+++ b/src/aind_data_schema/components/coordinates.py
@@ -33,7 +33,7 @@ class Origin(str, Enum):
     C7 = "C7"
     TIP = "Tip"  # of a probe
     FRONT_CENTER = "Front_center"  # front center of a device, e.g. camera
-    CENTER = "Center"  # center of a space, e.g. arena
+    BOTTOM_CENTER = "Center"  # center of a space on the ground, e.g. arena
 
 
 class AxisName(str, Enum):
@@ -361,7 +361,7 @@ class CoordinateSystemLibrary:
     # Arena
     ARENA_RBT = CoordinateSystem(
         name="ARENA_RBT",
-        origin=Origin.CENTER,
+        origin=Origin.BOTTOM_CENTER,
         axis_unit=SizeUnit.CM,
         axes=[
             Axis(name=AxisName.X, direction=Direction.LR),

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -161,7 +161,7 @@ class DataDescriptionTest(unittest.TestCase):
         self.assertIn("DataLevel", str(context.exception))
 
     def test_derived_valid(self):
-        """ Test that you can construct a valid derived DataDescription """
+        """Test that you can construct a valid derived DataDescription"""
 
         dt = datetime.datetime.now()
         f = Funding(funder=Organization.NINDS, grant_number="grant001")


### PR DESCRIPTION
This PR adds ARENA_RBT a coordinate system for arena spaces and home cages. It also adds several new Origin points (four corners and center, at "ground" level) that are intended to provide flexible coordinate system definitions for arenas.