### PR TITLE
BREAKING CHANGE: Support more standard craniotomy types

### DIFF
--- a/examples/procedures.py
+++ b/examples/procedures.py
@@ -27,7 +27,6 @@ from aind_data_schema.components.coordinates import (
     Axis,
     Direction,
     CoordinateSystemLibrary,
-    AnatomicalRelative,
 )
 
 # If a timezone isn't specified, the timezone of the computer running this

--- a/examples/procedures.py
+++ b/examples/procedures.py
@@ -61,9 +61,9 @@ surgery1 = Surgery(
             position=Coordinate(
                 system_name="SurgerySystem",
                 position=[-2, 2, 0, 0],
-                size=1,
-                size_unit=SizeUnit.MM,
             ),
+            size=1,
+            size_unit=SizeUnit.MM,
         ),
         BrainInjection(
             protocol_id="5678",

--- a/examples/procedures.py
+++ b/examples/procedures.py
@@ -26,6 +26,7 @@ from aind_data_schema.components.coordinates import (
     Axis,
     Direction,
     CoordinateSystemLibrary,
+    AnatomicalRelative,
 )
 
 # If a timezone isn't specified, the timezone of the computer running this
@@ -57,7 +58,7 @@ surgery1 = Surgery(
         Craniotomy(
             craniotomy_type="Visual Cortex",
             protocol_id="1234",
-            craniotomy_hemisphere="Left",
+            position=[AnatomicalRelative.LEFT],
         ),
         BrainInjection(
             protocol_id="5678",

--- a/examples/procedures.py
+++ b/examples/procedures.py
@@ -61,6 +61,8 @@ surgery1 = Surgery(
             position=Coordinate(
                 system_name="SurgerySystem",
                 position=[-2, 2, 0, 0],
+                size=1,
+                size_unit=SizeUnit.MM,
             ),
         ),
         BrainInjection(

--- a/examples/procedures.py
+++ b/examples/procedures.py
@@ -6,6 +6,7 @@ from aind_data_schema.components.identifiers import Person
 from aind_data_schema.core.procedures import (
     Anaesthetic,
     Craniotomy,
+    CraniotomyType,
     BrainInjection,
     Perfusion,
     Procedures,
@@ -56,9 +57,12 @@ surgery1 = Surgery(
     workstation_id="SWS 3",
     procedures=[
         Craniotomy(
-            craniotomy_type="Visual Cortex",
+            craniotomy_type=CraniotomyType.CIRCLE,
             protocol_id="1234",
-            position=[AnatomicalRelative.LEFT],
+            position=Coordinate(
+                system_name="SurgerySystem",
+                position=[-2, 2, 0, 0],
+            ),
         ),
         BrainInjection(
             protocol_id="5678",

--- a/src/aind_data_schema/core/procedures.py
+++ b/src/aind_data_schema/core/procedures.py
@@ -102,8 +102,8 @@ class CraniotomyType(str, Enum):
     """Name of craniotomy Type"""
 
     DHC = "Dual hemisphere craniotomy"
-    THREE_MM = "3 mm"
-    FIVE_MM = "5 mm"
+    CIRCLE = "Circle"
+    SQUARE = "Square"
     VISCTX = "Visual Cortex"
     WHC = "Whole hemisphere craniotomy"
     OTHER = "Other"
@@ -339,12 +339,14 @@ class Craniotomy(DataModel):
 
     protocol_id: str = Field(..., title="Protocol ID", description="DOI for protocols.io")
     craniotomy_type: CraniotomyType = Field(..., title="Craniotomy type")
-    craniotomy_hemisphere: Optional[Side] = Field(default=None, title="Craniotomy hemisphere")
+    position: Union[Coordinate, List[AnatomicalRelative]] = Field(..., title="Craniotomy position")
+    protective_material: Optional[ProtectiveMaterial] = Field(default=None, title="Protective material")
+
+    size: Optional[float] = Field(default=None, title="Craniotomy size, radius or width/height")
+    size_unit: Optional[SizeUnit] = Field(default=None, title="Craniotomy size unit")
+
     implant_part_number: Optional[str] = Field(default=None, title="Implant part number")
     dura_removed: Optional[bool] = Field(default=None, title="Dura removed")
-    protective_material: Optional[ProtectiveMaterial] = Field(default=None, title="Protective material")
-    recovery_time: Optional[Decimal] = Field(default=None, title="Recovery time")
-    recovery_time_unit: Optional[TimeUnit] = Field(default=None, title="Recovery time unit")
 
 
 class Headframe(DataModel):

--- a/src/aind_data_schema/core/procedures.py
+++ b/src/aind_data_schema/core/procedures.py
@@ -339,10 +339,7 @@ class Craniotomy(DataModel):
     protocol_id: str = Field(..., title="Protocol ID", description="DOI for protocols.io")
     craniotomy_type: CraniotomyType = Field(..., title="Craniotomy type")
 
-    position: Optional[Union[Coordinate, List[AnatomicalRelative]]] = Field(
-        default=None,
-        title="Craniotomy position"
-    )
+    position: Optional[Union[Coordinate, List[AnatomicalRelative]]] = Field(default=None, title="Craniotomy position")
 
     size: Optional[float] = Field(default=None, title="Craniotomy size", description="Diameter or side length")
     size_unit: Optional[SizeUnit] = Field(default=None, title="Craniotomy size unit")
@@ -353,7 +350,7 @@ class Craniotomy(DataModel):
 
     @model_validator(mode="after")
     def check_position(cls, values):
-        """ Ensure a position is provided for certain craniotomy types """
+        """Ensure a position is provided for certain craniotomy types"""
         POS_REQUIRED = [CraniotomyType.CIRCLE, CraniotomyType.SQUARE, CraniotomyType.WHC]
 
         if values.craniotomy_type in POS_REQUIRED and not values.position:

--- a/src/aind_data_schema/core/procedures.py
+++ b/src/aind_data_schema/core/procedures.py
@@ -342,7 +342,7 @@ class Craniotomy(DataModel):
     position: Union[Coordinate, List[AnatomicalRelative]] = Field(..., title="Craniotomy position")
     protective_material: Optional[ProtectiveMaterial] = Field(default=None, title="Protective material")
 
-    size: Optional[float] = Field(default=None, title="Craniotomy size, radius or width/height")
+    size: Optional[float] = Field(default=None, title="Craniotomy size", description="Diameter or side length")
     size_unit: Optional[SizeUnit] = Field(default=None, title="Craniotomy size unit")
 
     implant_part_number: Optional[str] = Field(default=None, title="Implant part number")

--- a/src/aind_data_schema/core/procedures.py
+++ b/src/aind_data_schema/core/procedures.py
@@ -351,10 +351,21 @@ class Craniotomy(DataModel):
     @model_validator(mode="after")
     def check_position(cls, values):
         """Ensure a position is provided for certain craniotomy types"""
+
         POS_REQUIRED = [CraniotomyType.CIRCLE, CraniotomyType.SQUARE, CraniotomyType.WHC]
 
         if values.craniotomy_type in POS_REQUIRED and not values.position:
             raise ValueError(f"Craniotomy.position must be provided for craniotomy type {values.craniotomy_type}")
+        return values
+
+    @model_validator(mode="after")
+    def validate_size(cls, values):
+        """Ensure that size is provided for certain craniotomy types"""
+
+        SIZE_REQUIRED = [CraniotomyType.CIRCLE, CraniotomyType.SQUARE]
+
+        if values.craniotomy_type in SIZE_REQUIRED and not values.size:
+            raise ValueError(f"Craniotomy.size must be provided for craniotomy type {values.craniotomy_type}")
         return values
 
 

--- a/src/aind_data_schema/core/procedures.py
+++ b/src/aind_data_schema/core/procedures.py
@@ -102,10 +102,9 @@ class CraniotomyType(str, Enum):
     """Name of craniotomy Type"""
 
     DHC = "Dual hemisphere craniotomy"
+    WHC = "Whole hemisphere craniotomy"
     CIRCLE = "Circle"
     SQUARE = "Square"
-    VISCTX = "Visual Cortex"
-    WHC = "Whole hemisphere craniotomy"
     OTHER = "Other"
 
 
@@ -339,14 +338,27 @@ class Craniotomy(DataModel):
 
     protocol_id: str = Field(..., title="Protocol ID", description="DOI for protocols.io")
     craniotomy_type: CraniotomyType = Field(..., title="Craniotomy type")
-    position: Union[Coordinate, List[AnatomicalRelative]] = Field(..., title="Craniotomy position")
-    protective_material: Optional[ProtectiveMaterial] = Field(default=None, title="Protective material")
+
+    position: Optional[Union[Coordinate, List[AnatomicalRelative]]] = Field(
+        default=None,
+        title="Craniotomy position"
+    )
 
     size: Optional[float] = Field(default=None, title="Craniotomy size", description="Diameter or side length")
     size_unit: Optional[SizeUnit] = Field(default=None, title="Craniotomy size unit")
 
+    protective_material: Optional[ProtectiveMaterial] = Field(default=None, title="Protective material")
     implant_part_number: Optional[str] = Field(default=None, title="Implant part number")
     dura_removed: Optional[bool] = Field(default=None, title="Dura removed")
+
+    @model_validator(mode="after")
+    def check_position(cls, values):
+        """ Ensure a position is provided for certain craniotomy types """
+        POS_REQUIRED = [CraniotomyType.CIRCLE, CraniotomyType.SQUARE, CraniotomyType.WHC]
+
+        if values.craniotomy_type in POS_REQUIRED and not values.position:
+            raise ValueError(f"Craniotomy.position must be provided for craniotomy type {values.craniotomy_type}")
+        return values
 
 
 class Headframe(DataModel):

--- a/tests/test_composability_merge.py
+++ b/tests/test_composability_merge.py
@@ -17,6 +17,7 @@ from aind_data_schema.components.coordinates import (
     Coordinate,
     CoordinateTransform,
     CoordinateSystemLibrary,
+    AnatomicalRelative,
 )
 from aind_data_schema.components.devices import Calibration, Maintenance
 
@@ -330,7 +331,7 @@ class TestComposability(unittest.TestCase):
                         Craniotomy(
                             craniotomy_type="Visual Cortex",
                             protocol_id="1234",
-                            craniotomy_hemisphere="Left",
+                            position=[AnatomicalRelative.LEFT],
                         )
                     ],
                     measured_coordinates={

--- a/tests/test_composability_merge.py
+++ b/tests/test_composability_merge.py
@@ -31,7 +31,7 @@ from aind_data_schema.components.devices import Calibration, Maintenance
 from aind_data_schema_models.organizations import Organization
 from aind_data_schema_models.pid_names import PIDName
 from aind_data_schema_models.registries import Registry
-from aind_data_schema_models.units import PowerUnit
+from aind_data_schema_models.units import PowerUnit, SizeUnit
 from aind_data_schema_models.modalities import Modality
 
 from aind_data_schema.components import tile
@@ -342,6 +342,8 @@ class TestComposability(unittest.TestCase):
                                 system_name="BREGMA_ARI",
                                 position=[-2, -4, 0, 0],
                             ),
+                            size=1,
+                            size_unit=SizeUnit.MM,
                         ),
                     ],
                     measured_coordinates={

--- a/tests/test_composability_merge.py
+++ b/tests/test_composability_merge.py
@@ -6,7 +6,15 @@ from datetime import datetime, timezone, date
 from aind_data_schema.core.quality_control import QualityControl, QCEvaluation, QCMetric, QCStatus, Status, Stage
 
 from aind_data_schema.core.acquisition import Acquisition, DataStream, SubjectDetails
-from aind_data_schema.core.procedures import Procedures, Reagent, Surgery, Anaesthetic, Craniotomy, Perfusion
+from aind_data_schema.core.procedures import (
+    Procedures,
+    Reagent,
+    Surgery,
+    Anaesthetic,
+    Craniotomy,
+    Perfusion,
+    CraniotomyType,
+)
 from aind_data_schema.core.processing import Processing, DataProcess, ProcessName, ProcessStage
 from aind_data_schema.components.identifiers import Person, Code
 from aind_data_schema.components.configs import InVitroImagingConfig, Immersion
@@ -17,7 +25,6 @@ from aind_data_schema.components.coordinates import (
     Coordinate,
     CoordinateTransform,
     CoordinateSystemLibrary,
-    AnatomicalRelative,
 )
 from aind_data_schema.components.devices import Calibration, Maintenance
 
@@ -329,10 +336,13 @@ class TestComposability(unittest.TestCase):
                     workstation_id="SWS 3",
                     procedures=[
                         Craniotomy(
-                            craniotomy_type="Visual Cortex",
+                            craniotomy_type=CraniotomyType.CIRCLE,
                             protocol_id="1234",
-                            position=[AnatomicalRelative.LEFT],
-                        )
+                            position=Coordinate(
+                                system_name="BREGMA_ARI",
+                                position=[-2, -4, 0, 0],
+                            ),
+                        ),
                     ],
                     measured_coordinates={
                         Origin.BREGMA: Coordinate(

--- a/tests/test_procedures.py
+++ b/tests/test_procedures.py
@@ -539,5 +539,6 @@ class ProceduresTests(unittest.TestCase):
         )
         self.assertIsNotNone(craniotomy)
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_procedures.py
+++ b/tests/test_procedures.py
@@ -530,7 +530,9 @@ class ProceduresTests(unittest.TestCase):
                 protocol_id="123",
                 craniotomy_type=CraniotomyType.WHC,
             )
-        self.assertIn("Craniotomy.position must be provided for craniotomy type Whole hemisphere craniotomy", str(e.exception))
+        self.assertIn(
+            "Craniotomy.position must be provided for craniotomy type Whole hemisphere craniotomy", str(e.exception)
+        )
 
         # Should be okay for craniotomy types that do not require position
         craniotomy = Craniotomy(

--- a/tests/test_procedures.py
+++ b/tests/test_procedures.py
@@ -25,6 +25,8 @@ from aind_data_schema.core.procedures import (
     InjectionDynamics,
     InjectionProfile,
     Injection,
+    Craniotomy,
+    CraniotomyType,
 )
 from aind_data_schema_models.brain_atlas import CCFStructure
 from aind_data_schema.components.coordinates import (
@@ -497,6 +499,45 @@ class ProceduresTests(unittest.TestCase):
         expected_exception = "specimen_id must be an extension of the subject_id."
         self.assertIn(expected_exception, str(e.exception))
 
+    def test_craniotomy_position_validation(self):
+        """Test validation for craniotomy position"""
+
+        # Should be okay
+        craniotomy = Craniotomy(
+            protocol_id="123",
+            craniotomy_type=CraniotomyType.CIRCLE,
+            position=Coordinate(system_name="BREGMA_ARID", position=[0.5, 1, 0, 0]),
+        )
+        self.assertIsNotNone(craniotomy)
+
+        # Missing position for required craniotomy types should raise an error
+        with self.assertRaises(ValueError) as e:
+            Craniotomy(
+                protocol_id="123",
+                craniotomy_type=CraniotomyType.CIRCLE,
+            )
+        self.assertIn("Craniotomy.position must be provided for craniotomy type Circle", str(e.exception))
+
+        with self.assertRaises(ValueError) as e:
+            Craniotomy(
+                protocol_id="123",
+                craniotomy_type=CraniotomyType.SQUARE,
+            )
+        self.assertIn("Craniotomy.position must be provided for craniotomy type Square", str(e.exception))
+
+        with self.assertRaises(ValueError) as e:
+            Craniotomy(
+                protocol_id="123",
+                craniotomy_type=CraniotomyType.WHC,
+            )
+        self.assertIn("Craniotomy.position must be provided for craniotomy type Whole hemisphere craniotomy", str(e.exception))
+
+        # Should be okay for craniotomy types that do not require position
+        craniotomy = Craniotomy(
+            protocol_id="123",
+            craniotomy_type=CraniotomyType.DHC,
+        )
+        self.assertIsNotNone(craniotomy)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_procedures.py
+++ b/tests/test_procedures.py
@@ -36,6 +36,7 @@ from aind_data_schema.components.coordinates import (
     Rotation,
 )
 from aind_data_schema_models.mouse_anatomy import InjectionTargets
+from aind_data_schema_models.units import SizeUnit
 
 PYD_VERSION = re.match(r"(\d+.\d+).\d+", pyd_version).group(1)
 
@@ -535,6 +536,43 @@ class ProceduresTests(unittest.TestCase):
         )
 
         # Should be okay for craniotomy types that do not require position
+        craniotomy = Craniotomy(
+            protocol_id="123",
+            craniotomy_type=CraniotomyType.DHC,
+        )
+        self.assertIsNotNone(craniotomy)
+
+    def test_craniotomy_size_validation(self):
+        """Test validation for craniotomy size"""
+
+        # Should be okay
+        craniotomy = Craniotomy(
+            protocol_id="123",
+            craniotomy_type=CraniotomyType.CIRCLE,
+            position=Coordinate(system_name="BREGMA_ARID", position=[0.5, 1, 0, 0]),
+            size=2.0,
+            size_unit=SizeUnit.MM,
+        )
+        self.assertIsNotNone(craniotomy)
+
+        # Missing size for required craniotomy types should raise an error
+        with self.assertRaises(ValueError) as e:
+            Craniotomy(
+                protocol_id="123",
+                craniotomy_type=CraniotomyType.CIRCLE,
+                position=Coordinate(system_name="BREGMA_ARID", position=[0.5, 1, 0, 0]),
+            )
+        self.assertIn("Craniotomy.size must be provided for craniotomy type Circle", str(e.exception))
+
+        with self.assertRaises(ValueError) as e:
+            Craniotomy(
+                protocol_id="123",
+                craniotomy_type=CraniotomyType.SQUARE,
+                position=Coordinate(system_name="BREGMA_ARID", position=[0.5, 1, 0, 0]),
+            )
+        self.assertIn("Craniotomy.size must be provided for craniotomy type Square", str(e.exception))
+
+        # Should be okay for craniotomy types that do not require size
         craniotomy = Craniotomy(
             protocol_id="123",
             craniotomy_type=CraniotomyType.DHC,

--- a/tests/test_procedures.py
+++ b/tests/test_procedures.py
@@ -508,6 +508,8 @@ class ProceduresTests(unittest.TestCase):
             protocol_id="123",
             craniotomy_type=CraniotomyType.CIRCLE,
             position=Coordinate(system_name="BREGMA_ARID", position=[0.5, 1, 0, 0]),
+            size=2.0,
+            size_unit=SizeUnit.MM,
         )
         self.assertIsNotNone(craniotomy)
 
@@ -516,6 +518,8 @@ class ProceduresTests(unittest.TestCase):
             Craniotomy(
                 protocol_id="123",
                 craniotomy_type=CraniotomyType.CIRCLE,
+                size=2.0,
+                size_unit=SizeUnit.MM,
             )
         self.assertIn("Craniotomy.position must be provided for craniotomy type Circle", str(e.exception))
 
@@ -523,6 +527,8 @@ class ProceduresTests(unittest.TestCase):
             Craniotomy(
                 protocol_id="123",
                 craniotomy_type=CraniotomyType.SQUARE,
+                size=2.0,
+                size_unit=SizeUnit.MM,
             )
         self.assertIn("Craniotomy.position must be provided for craniotomy type Square", str(e.exception))
 


### PR DESCRIPTION
This PR refactors `Craniotomy` to better match the new coordinate system approach to and to allow for circular/square craniotomies that have a position on the brain. It still supports the existing SHIELD implants.