### PR TITLE
fix: RTD requires path to conf.py file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,3 +12,7 @@ python:
       extra_requirements:
         - dev
         - docs
+
+sphinx:
+  # Path to your Sphinx configuration file.
+  configuration: docs/source/conf.py


### PR DESCRIPTION
This is a change in how Sphinx works