### PR TITLE
1135 add exposure and compression string to camera detector

### DIFF
--- a/src/aind_data_schema/components/devices.py
+++ b/src/aind_data_schema/components/devices.py
@@ -331,7 +331,11 @@ class Detector(Device):
 class Camera(Detector):
     """Camera Detector"""
 
-    compression: Optional[Code] = Field(default=None, title="Compression")
+    compression: Optional[Code] = Field(
+        default=None,
+        title="Compression",
+        description="Compression algorithm used immediately after acquisition",
+    )
 
 
 class Filter(Device):

--- a/src/aind_data_schema/components/devices.py
+++ b/src/aind_data_schema/components/devices.py
@@ -28,7 +28,7 @@ from aind_data_schema.components.coordinates import (
     CoordinateSystem,
 )
 from aind_data_schema.components.reagent import Reagent
-from aind_data_schema.components.identifiers import Software
+from aind_data_schema.components.identifiers import Software, Code
 
 
 class ImagingDeviceType(str, Enum):
@@ -330,6 +330,8 @@ class Detector(Device):
 
 class Camera(Detector):
     """Camera Detector"""
+
+    compression: Optional[Code] = Field(default=None, title="Compression")
 
 
 class Filter(Device):


### PR DESCRIPTION
This PR adds an optional compression field that takes a `Code` object as input. Users can specify their specific compression parameters in the generic parameters field.