### PR TITLE
refactor: LickSpoutConfig, AirPuffDevice, and AirPuffConfig

### DIFF
--- a/examples/fip_behavior_instrument.py
+++ b/examples/fip_behavior_instrument.py
@@ -178,7 +178,7 @@ connections = [
 ]
 
 reward_delivery = LickSpoutAssembly(
-    reward_spouts=[
+    lick_spouts=[
         LickSpout(
             name="Left spout",
             spout_diameter=1.2,

--- a/examples/fip_behavior_instrument.py
+++ b/examples/fip_behavior_instrument.py
@@ -177,7 +177,7 @@ connections = [
     ),
 ]
 
-reward_delivery = LickSpoutAssembly(
+lick_spout_assembly = LickSpoutAssembly(
     lick_spouts=[
         LickSpout(
             name="Left spout",
@@ -417,7 +417,7 @@ inst = Instrument(
         camera1,
         camera2,
         harp_behavior,
-        reward_delivery,
+        lick_spout_assembly,
         patch_cord,
         *light_sources,
         *detectors,

--- a/examples/fip_behavior_instrument.py
+++ b/examples/fip_behavior_instrument.py
@@ -17,8 +17,8 @@ from aind_data_schema.components.devices import (
     HarpDeviceType,
     DAQChannel,
     DaqChannelType,
-    RewardDelivery,
-    RewardSpout,
+    LickSpoutAssembly,
+    LickSpout,
     Device,
     LickSensorType,
     MotorizedStage,
@@ -177,9 +177,9 @@ connections = [
     ),
 ]
 
-reward_delivery = RewardDelivery(
+reward_delivery = LickSpoutAssembly(
     reward_spouts=[
-        RewardSpout(
+        LickSpout(
             name="Left spout",
             spout_diameter=1.2,
             solenoid_valve=Device(name="Solenoid Left"),
@@ -189,7 +189,7 @@ reward_delivery = RewardDelivery(
             ),
             lick_sensor_type=LickSensorType("Capacitive"),
         ),
-        RewardSpout(
+        LickSpout(
             name="Right spout",
             spout_diameter=1.2,
             solenoid_valve=Device(name="Solenoid Right"),
@@ -200,7 +200,7 @@ reward_delivery = RewardDelivery(
             lick_sensor_type=LickSensorType("Capacitive"),
         ),
     ],
-    stage_type=MotorizedStage(
+    motorized_stage=MotorizedStage(
         name="NewScaleMotor for LickSpouts",
         manufacturer=Organization.NEW_SCALE_TECHNOLOGIES,
         travel=15.0,

--- a/examples/fip_ophys_instrument.py
+++ b/examples/fip_ophys_instrument.py
@@ -327,9 +327,9 @@ connections = [
 
 mouse_platform = d.Disc(name="mouse_disc", radius=8.5)
 
-stimulus_device = d.RewardDelivery(
+stimulus_device = d.LickSpoutAssembly(
     reward_spouts=[
-        d.RewardSpout(
+        d.LickSpout(
             name="Left spout",
             spout_diameter=1.2,
             solenoid_valve=d.Device(name="Solenoid Left"),
@@ -337,7 +337,7 @@ stimulus_device = d.RewardDelivery(
                 name="Lick-o-meter Left",
             ),
         ),
-        d.RewardSpout(
+        d.LickSpout(
             name="Right spout",
             spout_diameter=1.2,
             solenoid_valve=d.Device(name="Solenoid Right"),

--- a/examples/fip_ophys_instrument.py
+++ b/examples/fip_ophys_instrument.py
@@ -328,7 +328,7 @@ connections = [
 mouse_platform = d.Disc(name="mouse_disc", radius=8.5)
 
 stimulus_device = d.LickSpoutAssembly(
-    reward_spouts=[
+    lick_spouts=[
         d.LickSpout(
             name="Left spout",
             spout_diameter=1.2,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 dynamic = ["version"]
 
 dependencies = [
-    'aind-data-schema-models>=2.4.4',
+    'aind-data-schema-models>=2.5.0',
     'dictdiffer',
     'pydantic>=2.7',
     'inflection',

--- a/src/aind_data_schema/components/configs.py
+++ b/src/aind_data_schema/components/configs.py
@@ -50,6 +50,15 @@ class StimulusModality(str, Enum):
     WHEEL_FRICTION = "Wheel friction"
 
 
+class Valence(str, Enum):
+    """Valence of a stimulus"""
+
+    POSITIVE = "Positive"
+    NEGATIVE = "Negative"
+    NEUTRAL = "Neutral"
+    UNKNOWN = "Unknown"
+
+
 class DeviceConfig(DataModel):
     """Parent class for all configurations"""
 
@@ -272,15 +281,18 @@ class LaserConfig(DeviceConfig):
 
 
 # Behavior components
-class RewardSolution(str, Enum):
-    """Reward solution name"""
+class Liquid(str, Enum):
+    """Solution names"""
 
     WATER = "Water"
     OTHER = "Other"
 
 
-class RewardSpoutConfig(DataModel):
-    """Reward spout acquisition information"""
+class LickSpoutConfig(DataModel):
+    """Lick spout acquisition information"""
+
+    solution: Liquid = Field(..., title="Solution")
+    solution_valence:  Valence = Field(..., title="Valence")
 
     relative_position: List[AnatomicalRelative] = Field(..., title="Initial relative position")
     position: Optional[Transform] = Field(default=None, title="Initial position")
@@ -290,23 +302,25 @@ class RewardSpoutConfig(DataModel):
         description="True if spout position changes during acquisition as tracked in data",
     )
 
-
-class RewardDeliveryConfig(DataModel):
-    """Description of reward delivery configuration"""
-
-    reward_solution: RewardSolution = Field(..., title="Reward solution", description="If Other use notes")
-    reward_spouts: List[RewardSpoutConfig] = Field(..., title="Reward spouts")
     notes: Optional[str] = Field(default=None, title="Notes", validate_default=True)
 
     @field_validator("notes", mode="after")
     def validate_other(cls, value: Optional[str], info: ValidationInfo) -> Optional[str]:
         """Validator for other/notes"""
 
-        if info.data.get("reward_solution") == RewardSolution.OTHER and not value:
+        if info.data.get("reward_solution") == Liquid.OTHER and not value:
             raise ValueError(
                 "Notes cannot be empty if reward_solution is Other. Describe the reward_solution in the notes field."
             )
         return value
+
+
+class AirPuffConfig(DataModel):
+    """ Air puff device configuration """
+
+    valence: Valence = Field(default=Valence.NEGATIVE, title="Valence")
+    relative_position: List[AnatomicalRelative] = Field(..., title="Initial relative position")
+    position: Optional[Transform] = Field(default=None, title="Initial position")
 
 
 class SpeakerConfig(DeviceConfig):

--- a/src/aind_data_schema/components/configs.py
+++ b/src/aind_data_schema/components/configs.py
@@ -13,6 +13,7 @@ from aind_data_schema_models.units import (
     SizeUnit,
     SoundIntensityUnit,
     TimeUnit,
+    PressureUnit,
 )
 
 from aind_data_schema.components.devices import ImmersionMedium
@@ -321,7 +322,7 @@ class AirPuffConfig(DataModel):
     position: Optional[Transform] = Field(default=None, title="Initial position")
 
     pressure: Optional[float] = Field(default=None, title="Pressure")
-    # pressure_unit: Optional[PressureUnit] = Field(default=None, title="Pressure unit")
+    pressure_unit: Optional[PressureUnit] = Field(default=None, title="Pressure unit")
 
     duration: Optional[float] = Field(default=None, title="Duration")
 

--- a/src/aind_data_schema/components/configs.py
+++ b/src/aind_data_schema/components/configs.py
@@ -308,8 +308,8 @@ class LickSpoutConfig(DataModel):
 
         if values.solution == Liquid.OTHER and not values.notes:
             raise ValueError(
-                "Notes cannot be empty if LickSpoutConfig.reward_solution is Other."
-                "Describe the reward_solution in the notes field."
+                "Notes cannot be empty if LickSpoutConfig.solution is Other."
+                "Describe the solution in the notes field."
             )
         return values
 

--- a/src/aind_data_schema/components/configs.py
+++ b/src/aind_data_schema/components/configs.py
@@ -280,11 +280,13 @@ class LaserConfig(DeviceConfig):
     excitation_power_unit: Optional[PowerUnit] = Field(default=None, title="Excitation power unit")
 
 
-# Behavior components
 class Liquid(str, Enum):
     """Solution names"""
 
     WATER = "Water"
+    SUCROSE = "Sucrose"
+    QUININE = "Quinine"
+    CITRIC_ACID = "Citric acid"
     OTHER = "Other"
 
 

--- a/src/aind_data_schema/components/configs.py
+++ b/src/aind_data_schema/components/configs.py
@@ -298,11 +298,6 @@ class LickSpoutConfig(DataModel):
 
     relative_position: List[AnatomicalRelative] = Field(..., title="Initial relative position")
     position: Optional[Transform] = Field(default=None, title="Initial position")
-    variable_position: bool = Field(
-        ...,
-        title="Variable position",
-        description="True if spout position changes during acquisition as tracked in data",
-    )
 
     notes: Optional[str] = Field(default=None, title="Notes", validate_default=True)
 
@@ -324,6 +319,11 @@ class AirPuffConfig(DataModel):
     valence: Valence = Field(default=Valence.NEGATIVE, title="Valence")
     relative_position: List[AnatomicalRelative] = Field(..., title="Initial relative position")
     position: Optional[Transform] = Field(default=None, title="Initial position")
+
+    pressure: Optional[float] = Field(default=None, title="Pressure")
+    # pressure_unit: Optional[PressureUnit] = Field(default=None, title="Pressure unit")
+
+    duration: Optional[float] = Field(default=None, title="Duration")
 
 
 class SpeakerConfig(DeviceConfig):

--- a/src/aind_data_schema/components/configs.py
+++ b/src/aind_data_schema/components/configs.py
@@ -292,7 +292,7 @@ class LickSpoutConfig(DataModel):
     """Lick spout acquisition information"""
 
     solution: Liquid = Field(..., title="Solution")
-    solution_valence:  Valence = Field(..., title="Valence")
+    solution_valence: Valence = Field(..., title="Valence")
 
     relative_position: List[AnatomicalRelative] = Field(..., title="Initial relative position")
     position: Optional[Transform] = Field(default=None, title="Initial position")
@@ -304,19 +304,20 @@ class LickSpoutConfig(DataModel):
 
     notes: Optional[str] = Field(default=None, title="Notes", validate_default=True)
 
-    @field_validator("notes", mode="after")
-    def validate_other(cls, value: Optional[str], info: ValidationInfo) -> Optional[str]:
+    @model_validator(mode="after")
+    def validate_other(cls, values):
         """Validator for other/notes"""
 
-        if info.data.get("reward_solution") == Liquid.OTHER and not value:
+        if values.solution == Liquid.OTHER and not values.notes:
             raise ValueError(
-                "Notes cannot be empty if reward_solution is Other. Describe the reward_solution in the notes field."
+                "Notes cannot be empty if LickSpoutConfig.reward_solution is Other."
+                "Describe the reward_solution in the notes field."
             )
-        return value
+        return values
 
 
 class AirPuffConfig(DataModel):
-    """ Air puff device configuration """
+    """Air puff device configuration"""
 
     valence: Valence = Field(default=Valence.NEGATIVE, title="Valence")
     relative_position: List[AnatomicalRelative] = Field(..., title="Initial relative position")

--- a/src/aind_data_schema/components/devices.py
+++ b/src/aind_data_schema/components/devices.py
@@ -797,8 +797,8 @@ class LickSpoutAssembly(DataModel):
 class AirPuffDevice(Device):
     """Description of an air puff device"""
 
-    size: float = Field(..., title="Spout diameter")
-    size_unit: SizeUnit = Field(..., title="Size unit")
+    diameter: float = Field(..., title="Spout diameter")
+    diameter_unit: SizeUnit = Field(..., title="Size unit")
 
 
 class Speaker(Device):

--- a/src/aind_data_schema/components/devices.py
+++ b/src/aind_data_schema/components/devices.py
@@ -797,6 +797,9 @@ class LickSpoutAssembly(DataModel):
 class AirPuffDevice(Device):
     """Description of an air puff device"""
 
+    size: float = Field(..., title="Spout diameter")
+    size_unit: SizeUnit = Field(..., title="Size unit")
+
 
 class Speaker(Device):
     """Description of a speaker for auditory stimuli"""

--- a/src/aind_data_schema/components/devices.py
+++ b/src/aind_data_schema/components/devices.py
@@ -790,7 +790,7 @@ class LickSpout(Device):
 class LickSpoutAssembly(DataModel):
     """Description of multiple lick spouts, possibly mounted on a stage"""
 
-    reward_spouts: List[LickSpout] = Field(..., title="Water spouts")
+    lick_spouts: List[LickSpout] = Field(..., title="Water spouts")
     motorized_stage: Optional[MotorizedStage] = Field(default=None, title="Motorized stage")
 
 

--- a/src/aind_data_schema/components/devices.py
+++ b/src/aind_data_schema/components/devices.py
@@ -795,7 +795,7 @@ class LickSpoutAssembly(DataModel):
 
 
 class AirPuffDevice(Device):
-    """ Description of an air puff device"""
+    """Description of an air puff device"""
 
 
 class Speaker(Device):

--- a/src/aind_data_schema/components/devices.py
+++ b/src/aind_data_schema/components/devices.py
@@ -776,8 +776,8 @@ class Monitor(Device):
     )
 
 
-class RewardSpout(Device):
-    """Description of a reward spout"""
+class LickSpout(Device):
+    """Description of a lick spout"""
 
     spout_diameter: Decimal = Field(..., title="Spout diameter (mm)")
     spout_diameter_unit: SizeUnit = Field(default=SizeUnit.MM, title="Spout diameter unit")
@@ -787,11 +787,15 @@ class RewardSpout(Device):
     lick_sensor_type: Optional[LickSensorType] = Field(default=None, title="Lick sensor type")
 
 
-class RewardDelivery(DataModel):
-    """Description of reward delivery system"""
+class LickSpoutAssembly(DataModel):
+    """Description of multiple lick spouts, possibly mounted on a stage"""
 
-    stage_type: Optional[MotorizedStage] = Field(default=None, title="Motorized stage")
-    reward_spouts: List[RewardSpout] = Field(..., title="Water spouts")
+    reward_spouts: List[LickSpout] = Field(..., title="Water spouts")
+    motorized_stage: Optional[MotorizedStage] = Field(default=None, title="Motorized stage")
+
+
+class AirPuffDevice(Device):
+    """ Description of an air puff device"""
 
 
 class Speaker(Device):

--- a/src/aind_data_schema/core/acquisition.py
+++ b/src/aind_data_schema/core/acquisition.py
@@ -34,6 +34,8 @@ from aind_data_schema.components.configs import (
     MRIScan,
     StimulusModality,
     InVitroImagingConfig,
+    LickSpoutConfig,
+    AirPuffConfig,
 )
 from aind_data_schema.utils.validators import subject_specimen_id_compatibility
 
@@ -126,6 +128,8 @@ class DataStream(DataModel):
                 Stack,
                 MRIScan,
                 InVitroImagingConfig,
+                LickSpoutConfig,
+                AirPuffConfig,
             ],
             Field(discriminator="object_type"),
         ]

--- a/src/aind_data_schema/core/acquisition.py
+++ b/src/aind_data_schema/core/acquisition.py
@@ -32,7 +32,6 @@ from aind_data_schema.components.configs import (
     MousePlatformConfig,
     Stack,
     MRIScan,
-    RewardDeliveryConfig,
     StimulusModality,
     InVitroImagingConfig,
 )
@@ -82,7 +81,6 @@ class SubjectDetails(DataModel):
     weight_unit: MassUnit = Field(default=MassUnit.G, title="Weight unit")
     anaesthesia: Optional[Anaesthetic] = Field(default=None, title="Anaesthesia")
     mouse_platform_name: str = Field(..., title="Mouse platform")
-    reward_delivery: Optional[RewardDeliveryConfig] = Field(default=None, title="Reward delivery")
     reward_consumed_total: Optional[Decimal] = Field(default=None, title="Total reward consumed (mL)")
     reward_consumed_unit: Optional[VolumeUnit] = Field(default=None, title="Reward consumed unit")
 

--- a/src/aind_data_schema/core/instrument.py
+++ b/src/aind_data_schema/core/instrument.py
@@ -44,7 +44,9 @@ from aind_data_schema.components.devices import (
     PatchCord,
     PockelsCell,
     PolygonalScanner,
+    LickSpout,
     LickSpoutAssembly,
+    AirPuffDevice,
     ScanningStage,
     Speaker,
     Treadmill,
@@ -137,7 +139,9 @@ class Instrument(DataCoreModel):
             Union[
                 Monitor,
                 Olfactometer,
+                LickSpout,
                 LickSpoutAssembly,
+                AirPuffDevice,
                 Speaker,
                 CameraAssembly,
                 Enclosure,
@@ -170,7 +174,7 @@ class Instrument(DataCoreModel):
                 Arena,
                 MousePlatform,
                 DAQDevice,
-                Device,  # note that order matters in the Union, DAQDevice and Device should go last
+                Device,
             ],
             Field(discriminator="object_type"),
         ]

--- a/src/aind_data_schema/core/instrument.py
+++ b/src/aind_data_schema/core/instrument.py
@@ -44,7 +44,7 @@ from aind_data_schema.components.devices import (
     PatchCord,
     PockelsCell,
     PolygonalScanner,
-    RewardDelivery,
+    LickSpoutAssembly,
     ScanningStage,
     Speaker,
     Treadmill,
@@ -62,7 +62,7 @@ DEVICES_REQUIRED = {
     Modality.POPHYS.abbreviation: [[Laser], [Detector], [Objective]],
     Modality.SLAP.abbreviation: [[Laser], [Detector], [Objective], [DigitalMicromirrorDevice]],
     Modality.BEHAVIOR_VIDEOS.abbreviation: [CameraAssembly],
-    Modality.BEHAVIOR.abbreviation: [[RewardDelivery]],
+    Modality.BEHAVIOR.abbreviation: [[LickSpoutAssembly]],
     Modality.SPIM.abbreviation: [[Laser], [Objective], [ScanningStage]],
 }
 
@@ -137,7 +137,7 @@ class Instrument(DataCoreModel):
             Union[
                 Monitor,
                 Olfactometer,
-                RewardDelivery,
+                LickSpoutAssembly,
                 Speaker,
                 CameraAssembly,
                 Enclosure,

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -22,7 +22,6 @@ from aind_data_schema.components.configs import (
     DomeModule,
     ManipulatorConfig,
     MRIScan,
-    RewardDeliveryConfig,
 )
 from aind_data_schema.core.acquisition import (
     Acquisition,
@@ -95,12 +94,6 @@ class AcquisitionTest(unittest.TestCase):
         )
 
         self.assertIsNotNone(acquisition)
-
-        with self.assertRaises(pydantic.ValidationError):
-            RewardDeliveryConfig()
-
-        with self.assertRaises(pydantic.ValidationError):
-            RewardDeliveryConfig(reward_solution="Other")
 
         with self.assertRaises(ValidationError):
             MRIScan(

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -145,7 +145,6 @@ class TestLickSpoutConfig(unittest.TestCase):
             solution=Liquid.WATER,
             solution_valence=Valence.POSITIVE,
             relative_position=[],
-            variable_position=True,
         )
         self.assertIsNotNone(lick_spout)
 
@@ -156,7 +155,6 @@ class TestLickSpoutConfig(unittest.TestCase):
                 solution=Liquid.OTHER,
                 solution_valence=Valence.POSITIVE,
                 relative_position=[],
-                variable_position=True,
             )
         self.assertIn(
             "Notes cannot be empty if LickSpoutConfig.reward_solution is Other."

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -157,8 +157,7 @@ class TestLickSpoutConfig(unittest.TestCase):
                 relative_position=[],
             )
         self.assertIn(
-            "Notes cannot be empty if LickSpoutConfig.solution is Other."
-            "Describe the solution in the notes field.",
+            "Notes cannot be empty if LickSpoutConfig.solution is Other." "Describe the solution in the notes field.",
             str(context.exception),
         )
 

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -3,7 +3,7 @@
 import unittest
 from decimal import Decimal
 from pydantic import ValidationError
-from aind_data_schema.components.configs import MRIScan, Scale, ManipulatorConfig
+from aind_data_schema.components.configs import MRIScan, Scale, ManipulatorConfig, LickSpoutConfig, Liquid, Valence
 from aind_data_schema.components.coordinates import Coordinate, CoordinateSystemLibrary, Transform, Affine, Translation
 from aind_data_schema_models.brain_atlas import CCFStructure
 from aind_data_schema_models.units import AngleUnit
@@ -132,6 +132,35 @@ class TestManipulatorConfig(unittest.TestCase):
 
         self.assertIn(
             "Length of atlas_coordinates, manipulator_coordinates, and manipulator_axis_positions must be the same",
+            str(context.exception),
+        )
+
+
+class TestLickSpoutConfig(unittest.TestCase):
+    """Tests for the LickSpoutConfig class"""
+
+    def test_validate_other_success(self):
+        """Test validate_other method with valid data"""
+        lick_spout = LickSpoutConfig(
+            solution=Liquid.WATER,
+            solution_valence=Valence.POSITIVE,
+            relative_position=[],
+            variable_position=True,
+        )
+        self.assertIsNotNone(lick_spout)
+
+    def test_validate_other_failure(self):
+        """Test validate_other method with invalid data"""
+        with self.assertRaises(ValueError) as context:
+            LickSpoutConfig(
+                solution=Liquid.OTHER,
+                solution_valence=Valence.POSITIVE,
+                relative_position=[],
+                variable_position=True,
+            )
+        self.assertIn(
+            "Notes cannot be empty if LickSpoutConfig.reward_solution is Other."
+            "Describe the reward_solution in the notes field.",
             str(context.exception),
         )
 

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -157,8 +157,8 @@ class TestLickSpoutConfig(unittest.TestCase):
                 relative_position=[],
             )
         self.assertIn(
-            "Notes cannot be empty if LickSpoutConfig.reward_solution is Other."
-            "Describe the reward_solution in the notes field.",
+            "Notes cannot be empty if LickSpoutConfig.solution is Other."
+            "Describe the solution in the notes field.",
             str(context.exception),
         )
 

--- a/tests/test_inst_acq_compatibility.py
+++ b/tests/test_inst_acq_compatibility.py
@@ -912,7 +912,7 @@ class TestInstrumentAcquisitionCompatibility(unittest.TestCase):
         ]
         stimulus_devices = [
             d.LickSpoutAssembly(
-                reward_spouts=[
+                lick_spouts=[
                     d.LickSpout(
                         name="Left spout",
                         spout_diameter=1.2,

--- a/tests/test_inst_acq_compatibility.py
+++ b/tests/test_inst_acq_compatibility.py
@@ -911,9 +911,9 @@ class TestInstrumentAcquisitionCompatibility(unittest.TestCase):
             ),
         ]
         stimulus_devices = [
-            d.RewardDelivery(
+            d.LickSpoutAssembly(
                 reward_spouts=[
-                    d.RewardSpout(
+                    d.LickSpout(
                         name="Left spout",
                         spout_diameter=1.2,
                         solenoid_valve=d.Device(name="Solenoid Left"),
@@ -923,7 +923,7 @@ class TestInstrumentAcquisitionCompatibility(unittest.TestCase):
                         ),
                         lick_sensor_type=d.LickSensorType("Capacitive"),
                     ),
-                    d.RewardSpout(
+                    d.LickSpout(
                         name="Right spout",
                         spout_diameter=1.2,
                         solenoid_valve=d.Device(name="Solenoid Right"),

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -315,7 +315,7 @@ stimulus_devices = [
         ],
     ),
     LickSpoutAssembly(
-        reward_spouts=[
+        lick_spouts=[
             LickSpout(
                 name="Left spout",
                 spout_diameter=1.2,

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -32,8 +32,8 @@ from aind_data_schema.components.devices import (
     Olfactometer,
     OlfactometerChannel,
     PatchCord,
-    RewardDelivery,
-    RewardSpout,
+    LickSpoutAssembly,
+    LickSpout,
     ScanningStage,
     DigitalMicromirrorDevice,
 )
@@ -314,9 +314,9 @@ stimulus_devices = [
             ),
         ],
     ),
-    RewardDelivery(
+    LickSpoutAssembly(
         reward_spouts=[
-            RewardSpout(
+            LickSpout(
                 name="Left spout",
                 spout_diameter=1.2,
                 solenoid_valve=Device(name="Solenoid Left"),
@@ -324,7 +324,7 @@ stimulus_devices = [
                     name="Lick-o-meter Left",
                 ),
             ),
-            RewardSpout(
+            LickSpout(
                 name="Right spout",
                 spout_diameter=1.2,
                 solenoid_valve=Device(name="Solenoid Right"),


### PR DESCRIPTION
This PR removes the class `RewardSpout` and `RewardSpoutconfig` and replaces them with device-specific configurations for recording the valence and qualities of rewards. New classes:

- LickSpout
- LickSpoutConfig
- AirPuffDevice
- AirPuffConfig