### PR TITLE
tests: remove all references to pyd version from tests

### DIFF
--- a/src/aind_data_schema/base.py
+++ b/src/aind_data_schema/base.py
@@ -1,8 +1,8 @@
 """ generic base class with supporting validators and fields for basic AIND schema """
 
 import json
-import re
 import logging
+import re
 from pathlib import Path
 from typing import Any, ClassVar, Generic, Literal, Optional, TypeVar, get_args
 
@@ -16,13 +16,13 @@ from pydantic import (
     ValidationError,
     ValidatorFunctionWrapHandler,
     create_model,
-    model_validator,
     field_validator,
+    model_validator,
 )
 from pydantic.functional_validators import WrapValidator
 from typing_extensions import Annotated
-from aind_data_schema.utils.validators import recursive_coord_system_check
 
+from aind_data_schema.utils.validators import recursive_coord_system_check
 
 MAX_FILE_SIZE = 500 * 1024  # 500KB
 

--- a/src/aind_data_schema/components/configs.py
+++ b/src/aind_data_schema/components/configs.py
@@ -5,37 +5,24 @@ from decimal import Decimal
 from enum import Enum
 from typing import List, Literal, Optional
 
+from aind_data_schema_models.brain_atlas import CCFStructure
 from aind_data_schema_models.process_names import ProcessName
 from aind_data_schema_models.units import (
     AngleUnit,
     FrequencyUnit,
     PowerUnit,
+    PressureUnit,
     SizeUnit,
     SoundIntensityUnit,
     TimeUnit,
-    PressureUnit,
 )
-
-from aind_data_schema.components.devices import ImmersionMedium
-from aind_data_schema.components.tile import AcquisitionTile
-from aind_data_schema.components.coordinates import (
-    Coordinate,
-    Transform,
-    CoordinateSystem,
-)
-from aind_data_schema_models.brain_atlas import CCFStructure
 from pydantic import Field, field_validator, model_validator
 from pydantic_core.core_schema import ValidationInfo
 
-from aind_data_schema.base import (
-    GenericModelType,
-    DataModel,
-)
-from aind_data_schema.components.coordinates import (
-    Scale,
-    AnatomicalRelative,
-)
-from aind_data_schema.components.tile import Channel
+from aind_data_schema.base import DataModel, GenericModelType
+from aind_data_schema.components.coordinates import AnatomicalRelative, Coordinate, CoordinateSystem, Scale, Transform
+from aind_data_schema.components.devices import ImmersionMedium
+from aind_data_schema.components.tile import AcquisitionTile, Channel
 
 
 class StimulusModality(str, Enum):

--- a/src/aind_data_schema/components/coordinates.py
+++ b/src/aind_data_schema/components/coordinates.py
@@ -1,15 +1,15 @@
 """Classes to define device positions, orientations, and coordinates"""
 
+import math
 from enum import Enum
 from typing import List, Optional, Union
-import math
 
+from aind_data_schema_models.atlas import AtlasName
 from aind_data_schema_models.units import AngleUnit, SizeUnit
 from pydantic import Field
 from typing_extensions import Annotated
 
 from aind_data_schema.base import DataModel
-from aind_data_schema_models.atlas import AtlasName
 
 
 class Origin(str, Enum):

--- a/src/aind_data_schema/components/devices.py
+++ b/src/aind_data_schema/components/devices.py
@@ -19,15 +19,9 @@ from aind_data_schema_models.units import (
 from pydantic import Field, ValidationInfo, field_validator, model_validator
 from typing_extensions import Annotated
 
-from aind_data_schema.base import GenericModelType, DataModel
-from aind_data_schema.components.coordinates import (
-    AxisName,
-    Transform,
-    AnatomicalRelative,
-    Scale,
-    CoordinateSystem,
-)
-from aind_data_schema.components.identifiers import Software, Code
+from aind_data_schema.base import DataModel, GenericModelType
+from aind_data_schema.components.coordinates import AnatomicalRelative, AxisName, CoordinateSystem, Scale, Transform
+from aind_data_schema.components.identifiers import Code, Software
 
 
 class ImagingDeviceType(str, Enum):

--- a/src/aind_data_schema/components/identifiers.py
+++ b/src/aind_data_schema/components/identifiers.py
@@ -1,9 +1,11 @@
 """ Schema for identifiers """
 
 from typing import Optional
-from pydantic import Field
-from aind_data_schema.base import DataModel, GenericModelType
+
 from aind_data_schema_models.registries import Registry, _Orcid
+from pydantic import Field
+
+from aind_data_schema.base import DataModel, GenericModelType
 
 
 class Person(DataModel):

--- a/src/aind_data_schema/components/measurements.py
+++ b/src/aind_data_schema/components/measurements.py
@@ -1,29 +1,28 @@
 """Calibration data models"""
 
-from typing import List, Optional, Annotated, Union, Literal
-
-from aind_data_schema.base import Field, AwareDatetimeWithDefault
-from aind_data_schema.components.reagent import Reagent
+from typing import Annotated, List, Literal, Optional, Union
 
 from aind_data_schema_models.units import (
-    SizeUnit,
-    MassUnit,
-    FrequencyUnit,
-    SpeedUnit,
-    VolumeUnit,
     AngleUnit,
-    TimeUnit,
-    PowerUnit,
-    CurrentUnit,
     ConcentrationUnit,
-    TemperatureUnit,
-    SoundIntensityUnit,
-    VoltageUnit,
+    CurrentUnit,
+    FrequencyUnit,
+    MassUnit,
     MemoryUnit,
+    PowerUnit,
+    SizeUnit,
+    SoundIntensityUnit,
+    SpeedUnit,
+    TemperatureUnit,
+    TimeUnit,
     UnitlessUnit,
+    VoltageUnit,
+    VolumeUnit,
 )
-from aind_data_schema.components.configs import DeviceConfig
 
+from aind_data_schema.base import AwareDatetimeWithDefault, Field
+from aind_data_schema.components.configs import DeviceConfig
+from aind_data_schema.components.reagent import Reagent
 
 UNITS = Union[
     SizeUnit,

--- a/src/aind_data_schema/components/stimulus.py
+++ b/src/aind_data_schema/components/stimulus.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 from aind_data_schema_models.units import ConcentrationUnit, FrequencyUnit, PowerUnit, TimeUnit
 from pydantic import Field, model_validator
 
-from aind_data_schema.base import GenericModel, GenericModelType, DataModel
+from aind_data_schema.base import DataModel, GenericModel, GenericModelType
 
 
 class PulseShape(str, Enum):

--- a/src/aind_data_schema/components/subjects.py
+++ b/src/aind_data_schema/components/subjects.py
@@ -1,18 +1,17 @@
 """Subject species models"""
 
-from enum import Enum
-from typing import List, Optional
 from datetime import date as date_type
 from datetime import time
-
-from aind_data_schema.base import DataModel
-
-from pydantic import Field, field_validator, model_validator
+from enum import Enum
+from typing import List, Optional
 
 from aind_data_schema_models.organizations import Organization
 from aind_data_schema_models.pid_names import PIDName
 from aind_data_schema_models.species import Species, Strain
+from pydantic import Field, field_validator, model_validator
 from pydantic_core.core_schema import ValidationInfo
+
+from aind_data_schema.base import DataModel
 
 
 class Sex(str, Enum):

--- a/src/aind_data_schema/components/tile.py
+++ b/src/aind_data_schema/components/tile.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 from aind_data_schema_models.units import AngleUnit, PowerUnit, SizeUnit
 from pydantic import Field
 
-from aind_data_schema.base import DataModel, AwareDatetimeWithDefault
+from aind_data_schema.base import AwareDatetimeWithDefault, DataModel
 from aind_data_schema.components.coordinates import CoordinateTransform
 
 

--- a/src/aind_data_schema/core/acquisition.py
+++ b/src/aind_data_schema/core/acquisition.py
@@ -1,44 +1,7 @@
 """ schema describing imaging acquisition """
 
 from decimal import Decimal
-from typing import List, Literal, Optional, Union, Annotated
-
-from pydantic import Field, SkipValidation, model_validator
-
-from aind_data_schema.base import DataCoreModel, DataModel, AwareDatetimeWithDefault, GenericModel, GenericModelType
-from aind_data_schema_models.units import VolumeUnit, MassUnit
-from aind_data_schema.components.devices import (
-    Camera,
-    CameraAssembly,
-    EphysAssembly,
-    FiberAssembly,
-)
-from aind_data_schema.components.measurements import CALIBRATIONS, Maintenance
-
-from aind_data_schema.core.procedures import Anaesthetic
-from aind_data_schema.components.identifiers import Person, Software, Code
-from aind_data_schema.components.coordinates import CoordinateSystem
-
-from aind_data_schema.components.configs import (
-    DomeModule,
-    PatchCordConfig,
-    FiberAssemblyConfig,
-    ManipulatorConfig,
-    DetectorConfig,
-    FieldOfView,
-    SlapFieldOfView,
-    SpeakerConfig,
-    LightEmittingDiodeConfig,
-    LaserConfig,
-    MousePlatformConfig,
-    Stack,
-    MRIScan,
-    StimulusModality,
-    InVitroImagingConfig,
-    LickSpoutConfig,
-    AirPuffConfig,
-)
-from aind_data_schema.utils.validators import subject_specimen_id_compatibility
+from typing import Annotated, List, Literal, Optional, Union
 
 from aind_data_schema_models.modalities import Modality
 from aind_data_schema_models.units import MassUnit, VolumeUnit
@@ -64,6 +27,7 @@ from aind_data_schema.components.configs import (
     Stack,
     StimulusModality,
 )
+from aind_data_schema.components.coordinates import CoordinateSystem
 from aind_data_schema.components.devices import Camera, CameraAssembly, EphysAssembly, FiberAssembly
 from aind_data_schema.components.identifiers import Code, Person, Software
 from aind_data_schema.components.measurements import CALIBRATIONS, Maintenance

--- a/src/aind_data_schema/core/acquisition.py
+++ b/src/aind_data_schema/core/acquisition.py
@@ -1,46 +1,38 @@
 """ schema describing imaging acquisition """
 
 from decimal import Decimal
-from typing import List, Literal, Optional, Union, Annotated
-
-from pydantic import Field, SkipValidation, model_validator
-
-from aind_data_schema.base import DataCoreModel, DataModel, AwareDatetimeWithDefault, GenericModel, GenericModelType
-from aind_data_schema_models.units import VolumeUnit, MassUnit
-from aind_data_schema.components.devices import (
-    Camera,
-    CameraAssembly,
-    EphysAssembly,
-    FiberAssembly,
-)
-from aind_data_schema.components.measurements import CALIBRATIONS, Maintenance
-
-from aind_data_schema.core.procedures import Anaesthetic
-from aind_data_schema.components.identifiers import Person, Software, Code
-
-from aind_data_schema.components.configs import (
-    DomeModule,
-    PatchCordConfig,
-    FiberAssemblyConfig,
-    ManipulatorConfig,
-    DetectorConfig,
-    FieldOfView,
-    SlapFieldOfView,
-    SpeakerConfig,
-    LightEmittingDiodeConfig,
-    LaserConfig,
-    MousePlatformConfig,
-    Stack,
-    MRIScan,
-    StimulusModality,
-    InVitroImagingConfig,
-    LickSpoutConfig,
-    AirPuffConfig,
-)
-from aind_data_schema.utils.validators import subject_specimen_id_compatibility
+from typing import Annotated, List, Literal, Optional, Union
 
 from aind_data_schema_models.modalities import Modality
+from aind_data_schema_models.units import MassUnit, VolumeUnit
+from pydantic import Field, SkipValidation, model_validator
+
+from aind_data_schema.base import AwareDatetimeWithDefault, DataCoreModel, DataModel, GenericModel, GenericModelType
+from aind_data_schema.components.configs import (
+    AirPuffConfig,
+    DetectorConfig,
+    DomeModule,
+    FiberAssemblyConfig,
+    FieldOfView,
+    InVitroImagingConfig,
+    LaserConfig,
+    LickSpoutConfig,
+    LightEmittingDiodeConfig,
+    ManipulatorConfig,
+    MousePlatformConfig,
+    MRIScan,
+    PatchCordConfig,
+    SlapFieldOfView,
+    SpeakerConfig,
+    Stack,
+    StimulusModality,
+)
+from aind_data_schema.components.devices import Camera, CameraAssembly, EphysAssembly, FiberAssembly
+from aind_data_schema.components.identifiers import Code, Person, Software
+from aind_data_schema.components.measurements import CALIBRATIONS, Maintenance
+from aind_data_schema.core.procedures import Anaesthetic
 from aind_data_schema.utils.merge import merge_notes, merge_optional_list
+from aind_data_schema.utils.validators import subject_specimen_id_compatibility
 
 # Define the requirements for each modality
 # Define the mapping of modalities to their required device types

--- a/src/aind_data_schema/core/data_description.py
+++ b/src/aind_data_schema/core/data_description.py
@@ -16,7 +16,7 @@ from aind_data_schema_models.modalities import Modality
 from aind_data_schema_models.organizations import Organization
 from pydantic import Field, SkipValidation, model_validator
 
-from aind_data_schema.base import DataCoreModel, DataModel, AwareDatetimeWithDefault
+from aind_data_schema.base import AwareDatetimeWithDefault, DataCoreModel, DataModel
 from aind_data_schema.components.identifiers import Person
 
 

--- a/src/aind_data_schema/core/instrument.py
+++ b/src/aind_data_schema/core/instrument.py
@@ -1,19 +1,19 @@
 """Core Instrument model"""
 
 from datetime import date
-from typing import List, Literal, Optional, Set, Union, Dict
 from enum import Enum
+from typing import Dict, List, Literal, Optional, Set, Union
 
 from aind_data_schema_models.modalities import Modality
+from aind_data_schema_models.organizations import Organization
 from pydantic import Field, SkipValidation, ValidationInfo, field_serializer, field_validator, model_validator
 from typing_extensions import Annotated
 
-from aind_data_schema_models.organizations import Organization
 from aind_data_schema.base import DataCoreModel, DataModel
 from aind_data_schema.components.coordinates import CoordinateSystem
-from aind_data_schema.utils.validators import recursive_get_all_names
 from aind_data_schema.components.devices import (
     AdditionalImagingDevice,
+    AirPuffDevice,
     Arena,
     CameraAssembly,
     CameraTarget,
@@ -31,6 +31,8 @@ from aind_data_schema.components.devices import (
     Laser,
     LaserAssembly,
     Lens,
+    LickSpout,
+    LickSpoutAssembly,
     LightEmittingDiode,
     Monitor,
     MotorizedStage,
@@ -43,17 +45,15 @@ from aind_data_schema.components.devices import (
     PatchCord,
     PockelsCell,
     PolygonalScanner,
-    LickSpout,
-    LickSpoutAssembly,
-    AirPuffDevice,
+    Scanner,
     ScanningStage,
     Speaker,
     Treadmill,
     Tube,
     Wheel,
-    Scanner,
 )
 from aind_data_schema.components.measurements import CALIBRATIONS
+from aind_data_schema.utils.validators import recursive_get_all_names
 
 # Define the mapping of modalities to their required device types
 # The list of list pattern is used to allow for multiple options within a group, so e.g.

--- a/src/aind_data_schema/core/metadata.py
+++ b/src/aind_data_schema/core/metadata.py
@@ -3,9 +3,9 @@
 import inspect
 import json
 import logging
+import warnings
 from datetime import datetime, timezone
 from enum import Enum
-import warnings
 from typing import Dict, List, Literal, Optional, get_args
 from uuid import UUID, uuid4
 
@@ -21,13 +21,13 @@ from pydantic import (
     model_validator,
 )
 
-from aind_data_schema.base import DataCoreModel, is_dict_corrupt, AwareDatetimeWithDefault
-from aind_data_schema.core.acquisition import Acquisition, MODALITY_DEVICE_REQUIREMENTS, CONFIG_DEVICE_REQUIREMENTS
+from aind_data_schema.base import AwareDatetimeWithDefault, DataCoreModel, is_dict_corrupt
+from aind_data_schema.core.acquisition import CONFIG_DEVICE_REQUIREMENTS, MODALITY_DEVICE_REQUIREMENTS, Acquisition
 from aind_data_schema.core.data_description import DataDescription
+from aind_data_schema.core.instrument import Instrument
 from aind_data_schema.core.procedures import Injection, Procedures, Surgery
 from aind_data_schema.core.processing import Processing
 from aind_data_schema.core.quality_control import QualityControl
-from aind_data_schema.core.instrument import Instrument
 from aind_data_schema.core.subject import Subject
 from aind_data_schema.utils.compatibility_check import InstrumentAcquisitionCompatibility
 

--- a/src/aind_data_schema/core/model.py
+++ b/src/aind_data_schema/core/model.py
@@ -7,8 +7,8 @@ from aind_data_schema_models.organizations import Organization
 from aind_data_schema_models.system_architecture import ModelBackbone
 from pydantic import Field
 
-from aind_data_schema.base import DataModel, DataCoreModel, GenericModel, GenericModelType
-from aind_data_schema.components.identifiers import Person, Software, Code
+from aind_data_schema.base import DataCoreModel, DataModel, GenericModel, GenericModelType
+from aind_data_schema.components.identifiers import Code, Person, Software
 from aind_data_schema.core.processing import DataProcess, ProcessName
 
 

--- a/src/aind_data_schema/core/procedures.py
+++ b/src/aind_data_schema/core/procedures.py
@@ -3,8 +3,9 @@
 from datetime import date
 from decimal import Decimal
 from enum import Enum
-from typing import List, Literal, Optional, Set, Union, Dict
+from typing import Dict, List, Literal, Optional, Set, Union
 
+from aind_data_schema_models.brain_atlas import CCFStructure
 from aind_data_schema_models.mouse_anatomy import MouseAnatomyModel
 from aind_data_schema_models.organizations import Organization
 from aind_data_schema_models.pid_names import PIDName
@@ -19,18 +20,17 @@ from aind_data_schema_models.units import (
     UnitlessUnit,
     VolumeUnit,
 )
-from aind_data_schema_models.brain_atlas import CCFStructure
 from pydantic import Field, SkipValidation, field_serializer, field_validator, model_validator
 from pydantic_core.core_schema import ValidationInfo
 from typing_extensions import Annotated
 
-from aind_data_schema.base import DataCoreModel, DataModel, AwareDatetimeWithDefault
+from aind_data_schema.base import AwareDatetimeWithDefault, DataCoreModel, DataModel
+from aind_data_schema.components.coordinates import AnatomicalRelative, Coordinate, CoordinateSystem, Origin
 from aind_data_schema.components.devices import FiberProbe, MyomatrixArray
 from aind_data_schema.components.identifiers import Person
 from aind_data_schema.components.reagent import Reagent
-from aind_data_schema.components.coordinates import CoordinateSystem, Coordinate, Origin, AnatomicalRelative
 from aind_data_schema.utils.merge import merge_notes
-from aind_data_schema.utils.validators import subject_specimen_id_compatibility, recursive_coord_system_check
+from aind_data_schema.utils.validators import recursive_coord_system_check, subject_specimen_id_compatibility
 
 
 class ImmunolabelClass(str, Enum):

--- a/src/aind_data_schema/core/processing.py
+++ b/src/aind_data_schema/core/processing.py
@@ -7,14 +7,8 @@ from aind_data_schema_models.process_names import ProcessName
 from aind_data_schema_models.units import MemoryUnit, UnitlessUnit
 from pydantic import Field, SkipValidation, ValidationInfo, field_validator, model_validator
 
-from aind_data_schema.base import (
-    DataCoreModel,
-    GenericModel,
-    GenericModelType,
-    DataModel,
-    AwareDatetimeWithDefault,
-)
-from aind_data_schema.components.identifiers import Person, Code
+from aind_data_schema.base import AwareDatetimeWithDefault, DataCoreModel, DataModel, GenericModel, GenericModelType
+from aind_data_schema.components.identifiers import Code, Person
 from aind_data_schema.utils.merge import merge_notes
 
 

--- a/src/aind_data_schema/core/quality_control.py
+++ b/src/aind_data_schema/core/quality_control.py
@@ -7,7 +7,7 @@ from typing import Any, List, Literal, Optional, Union
 from aind_data_schema_models.modalities import Modality
 from pydantic import BaseModel, Field, SkipValidation, field_validator, model_validator
 
-from aind_data_schema.base import DataCoreModel, DataModel, AwareDatetimeWithDefault
+from aind_data_schema.base import AwareDatetimeWithDefault, DataCoreModel, DataModel
 from aind_data_schema.utils.merge import merge_notes
 
 

--- a/src/aind_data_schema/core/subject.py
+++ b/src/aind_data_schema/core/subject.py
@@ -1,10 +1,11 @@
 """ schema for mostly mouse metadata """
 
-from typing import Literal, Optional, Annotated, Union
+from typing import Annotated, Literal, Optional, Union
+
 from pydantic import Field, SkipValidation
 
 from aind_data_schema.base import DataCoreModel
-from aind_data_schema.components.subjects import MouseSubject, HumanSubject
+from aind_data_schema.components.subjects import HumanSubject, MouseSubject
 
 
 class Subject(DataCoreModel):

--- a/src/aind_data_schema/utils/compatibility_check.py
+++ b/src/aind_data_schema/utils/compatibility_check.py
@@ -2,8 +2,8 @@
 
 from typing import Optional
 
-from aind_data_schema.core.instrument import Instrument
 from aind_data_schema.core.acquisition import Acquisition
+from aind_data_schema.core.instrument import Instrument
 
 
 class InstrumentAcquisitionCompatibility:

--- a/src/aind_data_schema/utils/validators.py
+++ b/src/aind_data_schema/utils/validators.py
@@ -1,7 +1,7 @@
 """ Validator utility functions """
 
-from typing import Any, List
 from enum import Enum
+from typing import Any, List
 
 
 def subject_specimen_id_compatibility(subject_id: str, specimen_id: str) -> bool:

--- a/src/aind_data_schema/utils/validators.py
+++ b/src/aind_data_schema/utils/validators.py
@@ -3,7 +3,6 @@
 from enum import Enum
 from typing import Any, List
 
-
 # Fields that should have the same length as the coordinate system axes
 AXIS_FIELD_NAMES = ["scale", "translation", "angles", "position"]
 
@@ -12,7 +11,7 @@ class CoordinateSystemException(Exception):
     """Raised when a coordinate system is missing."""
 
     def __init__(self):
-        """ Initialize the exception. """
+        """Initialize the exception."""
         super().__init__("CoordinateSystem is required when a Transform or Coordinate is present")
 
 
@@ -20,7 +19,7 @@ class SystemNameException(Exception):
     """Raised when there is a system name mismatch."""
 
     def __init__(self, expected, found):
-        """ Initialize the exception with the expected and found axis counts. """
+        """Initialize the exception with the expected and found axis counts."""
         self.expected = expected
         self.found = found
         super().__init__(f"System name mismatch, expected {expected}, found {found}")
@@ -30,7 +29,7 @@ class AxisCountException(Exception):
     """Raised when the axis count does not match."""
 
     def __init__(self, expected, found):
-        """ Initialize the exception with the expected and found axis counts. """
+        """Initialize the exception with the expected and found axis counts."""
         self.expected = expected
         self.found = found
         super().__init__(f"Axis count mismatch, expected {expected} axes, but found {found}")

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -1,13 +1,11 @@
 """ Test for the acquisition.json """
 
-import re
 import unittest
 from datetime import datetime, timezone
 
 import pydantic
 from aind_data_schema_models.modalities import Modality
 from pydantic import ValidationError
-from pydantic import __version__ as pyd_version
 
 from aind_data_schema.components.coordinates import (
     Affine,
@@ -29,8 +27,6 @@ from aind_data_schema.core.acquisition import (
     SubjectDetails,
 )
 from aind_data_schema_models.brain_atlas import CCFStructure
-
-PYD_VERSION = re.match(r"(\d+.\d+).\d+", pyd_version).group(1)
 
 
 class AcquisitionTest(unittest.TestCase):

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -3,7 +3,6 @@
 import datetime
 import json
 import os
-import re
 import unittest
 from pathlib import Path
 from typing import List
@@ -13,18 +12,15 @@ from aind_data_schema_models.data_name_patterns import DataLevel
 from aind_data_schema_models.modalities import Modality
 from aind_data_schema_models.organizations import Organization
 from pydantic import ValidationError
-from pydantic import __version__ as pyd_version
 
 from aind_data_schema.components.identifiers import Person
 from aind_data_schema.core.data_description import (
     DataDescription,
-    DataRegex,
     Funding,
     build_data_name,
 )
 
 DATA_DESCRIPTION_FILES_PATH = Path(__file__).parent / "resources" / "ephys_data_description"
-PYD_VERSION = re.match(r"(\d+.\d+).\d+", pyd_version).group(1)
 
 
 class DataDescriptionTest(unittest.TestCase):
@@ -235,14 +231,7 @@ class DataDescriptionTest(unittest.TestCase):
                 funding_source=[Funding(funder=Organization.NINDS, grant_number="grant001")],
                 investigators=[Person(name="Jane Smith")],
             )
-        expected_exception = (
-            "1 validation error for DataDescription\n"
-            "project_name\n"
-            f"  String should match pattern '{DataRegex.NO_SPECIAL_CHARS_EXCEPT_SPACE.value}'"
-            " [type=string_pattern_mismatch, input_value='a_32r&!#R$&#', input_type=str]\n"
-            f"    For further information visit https://errors.pydantic.dev/{PYD_VERSION}/v/string_pattern_mismatch"
-        )
-        self.assertEqual(expected_exception, repr(e.exception))
+        self.assertIn("String should match pattern", str(e.exception))
 
     def test_model_constructors(self):
         """test static methods for constructing models"""

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,6 +1,6 @@
 """ test Device models"""
 
-import unittest
+import unittest 
 
 from aind_data_schema_models.harp_types import HarpDeviceType
 from aind_data_schema_models.organizations import Organization

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -45,7 +45,7 @@ class DeviceTests(unittest.TestCase):
             )
 
         self.assertIn("Value error, Notes cannot be empty", str(e3.exception))
-        self.assertIn("'data_interface'", str(e3.exception))
+        self.assertIn("data_interface", str(e3.exception))
 
         HarpDevice(
             name="test_harp",

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,11 +1,9 @@
 """ test Device models"""
 
-import re
 import unittest
 
 from aind_data_schema_models.harp_types import HarpDeviceType
 from aind_data_schema_models.organizations import Organization
-from pydantic import __version__ as pyd_version
 
 from aind_data_schema.components.devices import (
     AdditionalImagingDevice,
@@ -17,8 +15,6 @@ from aind_data_schema.components.devices import (
     ImmersionMedium,
     Objective,
 )
-
-PYD_VERSION = re.match(r"(\d+.\d+).\d+", pyd_version).group(1)
 
 
 class DeviceTests(unittest.TestCase):
@@ -36,15 +32,8 @@ class DeviceTests(unittest.TestCase):
                 data_interface=DataInterface.OTHER,
             )
 
-        expected_e2 = (
-            "1 validation error for Detector\n"
-            "  Value error, Notes cannot be empty while any of the following fields"
-            " are set to 'other': ['immersion', 'detector_type', 'data_interface']"
-            " [type=value_error, input_value={'name': 'test_detector',...terface.OTHER: 'Other'>}, input_type=dict]\n"
-            f"    For further information visit https://errors.pydantic.dev/{PYD_VERSION}/v/value_error"
-        )
-
-        self.assertEqual(repr(e2.exception), expected_e2)
+        self.assertIn("Value error, Notes cannot be empty", str(e2.exception))
+        self.assertIn("'immersion', 'detector_type', 'data_interface'", str(e2.exception))
 
         with self.assertRaises(ValueError) as e3:
             HarpDevice(
@@ -55,16 +44,8 @@ class DeviceTests(unittest.TestCase):
                 is_clock_generator=False,
             )
 
-        expected_e3 = (
-            "1 validation error for HarpDevice\n"
-            "data_interface\n"
-            "  Value error, Notes cannot be empty if data_interface is Other."
-            " Describe the data interface in the notes field."
-            " [type=value_error, input_value=<DataInterface.OTHER: 'Other'>, input_type=DataInterface]\n"
-            f"    For further information visit https://errors.pydantic.dev/{PYD_VERSION}/v/value_error"
-        )
-
-        self.assertEqual(repr(e3.exception), expected_e3)
+        self.assertIn("Value error, Notes cannot be empty", str(e3.exception))
+        self.assertIn("'data_interface'", str(e3.exception))
 
         HarpDevice(
             name="test_harp",
@@ -77,29 +58,12 @@ class DeviceTests(unittest.TestCase):
         with self.assertRaises(ValueError) as e4:
             Objective(name="test_objective", numerical_aperture=0.5, magnification=10, immersion=ImmersionMedium.OTHER)
 
-        expected_e4 = (
-            "1 validation error for Objective\n"
-            "immersion\n"
-            "  Value error, Notes cannot be empty if immersion is Other. Describe the immersion in the notes field."
-            " [type=value_error, input_value=<ImmersionMedium.OTHER: 'other'>, input_type=ImmersionMedium]\n"
-            f"    For further information visit https://errors.pydantic.dev/{PYD_VERSION}/v/value_error"
-        )
-
-        self.assertEqual(repr(e4.exception), expected_e4)
+        self.assertIn("Value error, Notes cannot be empty if immersion is Other", str(e4.exception))
 
         with self.assertRaises(ValueError) as e5:
             AdditionalImagingDevice(name="test_additional_imaging", imaging_device_type=ImagingDeviceType.OTHER)
 
-        expected_e5 = (
-            "1 validation error for AdditionalImagingDevice\n"
-            "imaging_device_type\n"
-            "  Value error, Notes cannot be empty if imaging_device_type is Other. "
-            "Describe the imaging device type in the notes field."
-            " [type=value_error, input_value=<ImagingDeviceType.OTHER: 'Other'>, input_type=ImagingDeviceType]\n"
-            f"    For further information visit https://errors.pydantic.dev/{PYD_VERSION}/v/value_error"
-        )
-
-        self.assertEqual(repr(e5.exception), expected_e5)
+        self.assertIn("Value error, Notes cannot be empty if imaging_device_type", str(e5.exception))
 
 
 if __name__ == "__main__":

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,6 +1,6 @@
 """ test Device models"""
 
-import unittest 
+import unittest
 
 from aind_data_schema_models.harp_types import HarpDeviceType
 from aind_data_schema_models.organizations import Organization

--- a/tests/test_imaging.py
+++ b/tests/test_imaging.py
@@ -1,13 +1,11 @@
 """ test Imaging """
 
-import re
 import unittest
 from datetime import datetime, timezone
 
 from aind_data_schema_models.organizations import Organization
 from aind_data_schema_models.units import PowerUnit
 from pydantic import ValidationError
-from pydantic import __version__ as pyd_version
 
 from aind_data_schema.components import tile
 from aind_data_schema.components.coordinates import (
@@ -26,8 +24,6 @@ from aind_data_schema.core.instrument import Instrument
 from aind_data_schema_models.modalities import Modality
 from aind_data_schema.components.identifiers import Person, Code
 from aind_data_schema.components.measurements import Calibration
-
-PYD_VERSION = re.match(r"(\d+.\d+).\d+", pyd_version).group(1)
 
 
 class ImagingTests(unittest.TestCase):

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,7 +1,6 @@
 """Tests metadata module"""
 
 import json
-import re
 import unittest
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, call, patch
@@ -10,7 +9,6 @@ import uuid
 from aind_data_schema_models.modalities import Modality
 from aind_data_schema_models.organizations import Organization
 from pydantic import ValidationError
-from pydantic import __version__ as pyd_version
 
 from aind_data_schema.components.devices import (
     EphysAssembly,
@@ -40,7 +38,6 @@ from tests.resources.ephys_instrument import inst as ephys_inst
 
 from aind_data_schema_models.species import Strain
 
-PYD_VERSION = re.match(r"(\d+.\d+).\d+", pyd_version).group(1)
 
 EXAMPLES_DIR = Path(__file__).parents[1] / "examples"
 EPHYS_INST_JSON = EXAMPLES_DIR / "ephys_instrument.json"
@@ -161,16 +158,10 @@ class TestMetadata(unittest.TestCase):
         # Assert at least a name and location are required
         with self.assertRaises(ValidationError) as e:
             Metadata()
-        expected_exception_message = (
-            "2 validation errors for Metadata\n"
-            "name\n"
-            "  Field required [type=missing, input_value={}, input_type=dict]\n"
-            f"    For further information visit https://errors.pydantic.dev/{PYD_VERSION}/v/missing\n"
-            "location\n"
-            "  Field required [type=missing, input_value={}, input_type=dict]\n"
-            f"    For further information visit https://errors.pydantic.dev/{PYD_VERSION}/v/missing"
-        )
-        self.assertEqual(expected_exception_message, str(e.exception))
+
+        self.assertIn("Field required", str(e.exception))
+        self.assertIn("name", str(e.exception))
+        self.assertIn("location", str(e.exception))
 
     def test_invalid_core_models(self):
         """Test that invalid models don't raise an error, but marks the

--- a/tests/test_procedures.py
+++ b/tests/test_procedures.py
@@ -1,13 +1,11 @@
 """ test Procedures """
 
-import re
 import unittest
 from datetime import date
 
 from aind_data_schema_models.organizations import Organization
 from aind_data_schema_models.units import TimeUnit, ConcentrationUnit, VolumeUnit
 from pydantic import ValidationError
-from pydantic import __version__ as pyd_version
 
 from aind_data_schema.components.devices import FiberProbe
 from aind_data_schema.components.identifiers import Person
@@ -38,8 +36,6 @@ from aind_data_schema.components.coordinates import (
 )
 from aind_data_schema_models.mouse_anatomy import InjectionTargets
 from aind_data_schema_models.units import SizeUnit
-
-PYD_VERSION = re.match(r"(\d+.\d+).\d+", pyd_version).group(1)
 
 
 class ProceduresTests(unittest.TestCase):

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1,6 +1,5 @@
 """ test processing """
 
-import re
 import unittest
 from datetime import datetime
 
@@ -18,7 +17,6 @@ from aind_data_schema.core.processing import (
     ProcessStage,
 )
 
-PYD_VERSION = re.match(r"(\d+.\d+).\d+", pydantic.__version__).group(1)
 t = datetime.fromisoformat("2024-09-13T14:00:00")
 
 


### PR DESCRIPTION
This PR removes pydantic version dependencies (using pyd_version) from all tests. This simplifies tests and makes them less brittle.