### PR TITLE
refactor: remove id, created, last_modified

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 dynamic = ["version"]
 
 dependencies = [
-    'aind-data-schema-models>=2.5.1',
+    'aind-data-schema-models>=2.5.1,<2.6',
     'dictdiffer',
     'pydantic>=2.7',
     'inflection',

--- a/src/aind_data_schema/core/metadata.py
+++ b/src/aind_data_schema/core/metadata.py
@@ -4,7 +4,6 @@ import inspect
 import json
 import logging
 import warnings
-from datetime import datetime
 from enum import Enum
 from typing import Dict, List, Literal, Optional, get_args
 

--- a/src/aind_data_schema/core/metadata.py
+++ b/src/aind_data_schema/core/metadata.py
@@ -304,7 +304,6 @@ def create_metadata_json(
     name: str,
     location: str,
     core_jsons: Dict[str, Optional[dict]],
-    optional_created: Optional[datetime] = None,
     optional_external_links: Optional[dict] = None,
 ) -> dict:
     """Creates a Metadata dict from dictionary of core schema fields."""
@@ -314,8 +313,6 @@ def create_metadata_json(
         "name": name,
         "location": location,
     }
-    if optional_created is not None:
-        params["created"] = optional_created
     if optional_external_links is not None:
         params["external_links"] = optional_external_links
     core_fields = dict()

--- a/src/aind_data_schema/core/metadata.py
+++ b/src/aind_data_schema/core/metadata.py
@@ -4,10 +4,9 @@ import inspect
 import json
 import logging
 import warnings
-from datetime import datetime, timezone
+from datetime import datetime
 from enum import Enum
 from typing import Dict, List, Literal, Optional, get_args
-from uuid import UUID, uuid4
 
 from aind_data_schema_models.modalities import Modality
 from pydantic import (
@@ -16,12 +15,11 @@ from pydantic import (
     SkipValidation,
     ValidationError,
     ValidationInfo,
-    field_serializer,
     field_validator,
     model_validator,
 )
 
-from aind_data_schema.base import AwareDatetimeWithDefault, DataCoreModel, is_dict_corrupt
+from aind_data_schema.base import DataCoreModel, is_dict_corrupt
 from aind_data_schema.core.acquisition import CONFIG_DEVICE_REQUIREMENTS, MODALITY_DEVICE_REQUIREMENTS, Acquisition
 from aind_data_schema.core.data_description import DataDescription
 from aind_data_schema.core.instrument import Instrument
@@ -77,26 +75,10 @@ class Metadata(DataCoreModel):
     _DESCRIBED_BY_URL = DataCoreModel._DESCRIBED_BY_BASE_URL.default + "aind_data_schema/core/metadata.py"
     describedBy: str = Field(default=_DESCRIBED_BY_URL, json_schema_extra={"const": _DESCRIBED_BY_URL})
     schema_version: SkipValidation[Literal["2.0.41"]] = Field(default="2.0.41")
-    id: UUID = Field(
-        default_factory=uuid4,
-        alias="_id",
-        title="Data Asset ID",
-        description="The unique id of the data asset.",
-    )
     name: str = Field(
         ...,
         description="Name of the data asset.",
         title="Data Asset Name",
-    )
-    created: AwareDatetimeWithDefault = Field(
-        default_factory=lambda: datetime.now(tz=timezone.utc),
-        title="Created",
-        description="The utc date and time the data asset created.",
-    )
-    last_modified: AwareDatetimeWithDefault = Field(
-        default_factory=lambda: datetime.now(tz=timezone.utc),
-        title="Last Modified",
-        description="The utc date and time that the data asset was last modified.",
     )
     location: str = Field(
         ...,
@@ -160,16 +142,6 @@ class Metadata(DataCoreModel):
         else:
             core_model = value
         return core_model
-
-    @field_validator("last_modified", mode="after")
-    def validate_last_modified(cls, value, info: ValidationInfo):
-        """Convert last_modified field to UTC from other timezones"""
-        return value.astimezone(timezone.utc)
-
-    @field_serializer("last_modified")
-    def serialize_last_modified(value) -> str:
-        """Serialize last_modified field"""
-        return value.isoformat().replace("+00:00", "Z")
 
     @model_validator(mode="after")
     def validate_metadata(self):

--- a/src/aind_data_schema/core/metadata.py
+++ b/src/aind_data_schema/core/metadata.py
@@ -16,6 +16,7 @@ from pydantic import (
     ValidationInfo,
     field_validator,
     model_validator,
+    ConfigDict,
 )
 
 from aind_data_schema.base import DataCoreModel, is_dict_corrupt
@@ -65,6 +66,8 @@ class ExternalPlatforms(str, Enum):
 class Metadata(DataCoreModel):
     """The records in the Data Asset Collection needs to contain certain fields
     to easily query and index the data."""
+
+    model_config = ConfigDict(extra="ignore")
 
     # Special file name extension to distinguish this json file from others
     # The models base on this schema will be saved to metadata.nd.json as

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -4,7 +4,6 @@ import json
 import unittest
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, call, patch
-import uuid
 
 from aind_data_schema_models.modalities import Modality
 from aind_data_schema_models.organizations import Organization


### PR DESCRIPTION
This PR removes the fields:

- Metadata.id
- Metadata.created
- Metadata.last_modified

These will be used internally on DocDB but we'll no longer use them externally to identify assets. The API will continue to return at least the created/last_modified so downstream tools can use them. 

If we want to keep using `id` in downstream tools (like the QC portal) we would need to keep that in the metadata. I think we're safe to go to using `name`, which is better for users anyways, and we should deal with name conflicts.