### PR TITLE
refactor: separating manipulator and ephys configs 

### DIFF
--- a/examples/ephys_acquisition.py
+++ b/examples/ephys_acquisition.py
@@ -12,16 +12,46 @@ from aind_data_schema.core.acquisition import (
     SubjectDetails,
 )
 from aind_data_schema.components.configs import (
-    DomeModule,
+    EphysAssemblyConfig,
     ManipulatorConfig,
+    ProbeConfig,
     StimulusModality,
+    AtlasCoordinate,
 )
-from aind_data_schema.components.coordinates import Coordinate, CoordinateSystemLibrary
+from aind_data_schema.components.coordinates import Coordinate, CoordinateSystemLibrary, AtlasLibrary,
 from aind_data_schema.components.stimulus import VisualStimulation
 from aind_data_schema_models.brain_atlas import CCFStructure
 
 bonsai_software = Software(name="Bonsai", version="2.7")
 
+ephys_config_a = EphysAssemblyConfig(
+    device_name="Ephys_assemblyA",
+    manipulator_config=ManipulatorConfig(
+        device_name="ManipulatorA",
+        coordinate_system=CoordinateSystemLibrary.PROBE_XYZ,
+        local_axis_positions=Coordinate(
+            system_name="PROBE_XYZ",
+            position=[8422, 4205, 11087.5],
+        ),
+    ),
+    probe_configs=[
+        ProbeConfig(
+            device_name="ProbeA",
+            primary_targeted_structure=CCFStructure.LGD,
+            coordinate=Coordinate(
+                system_name="BREGMA_ARID",
+                position=[5000, 5000, 0, 1],
+            ),
+            atlas_coordinate=AtlasCoordinate(
+                atlas=AtlasLibrary.CCFv3,
+                coordinate=Coordinate(
+                    system_name="CCFv3",
+                    position=[8422, 4205, 11087.5],
+                ),
+            ),
+        ),
+    ]
+)
 
 ephys_config_a = ManipulatorConfig(
     rotation_angle=0,
@@ -49,10 +79,6 @@ ephys_config_a = ManipulatorConfig(
         ),
     ],
     calibration_date=datetime(year=2023, month=4, day=25, tzinfo=timezone.utc),
-    notes=(
-        "Moved Y to avoid blood vessel, X to avoid edge. Mouse made some noise during the recording"
-        " with a sudden shift in signals. Lots of motion. Maybe some implant motion."
-    ),
 )
 
 ephys_config_b = ManipulatorConfig(
@@ -208,6 +234,10 @@ acquisition = Acquisition(
             ],
         ),
     ],
+    notes=(
+        "Moved Y to avoid blood vessel, X to avoid edge. Mouse made some noise during the recording"
+        " with a sudden shift in signals. Lots of motion. Maybe some implant motion."
+    ),
 )
 
 serialized = acquisition.model_dump_json()

--- a/examples/ophys_acquisition.py
+++ b/examples/ophys_acquisition.py
@@ -68,7 +68,7 @@ a = Acquisition(
                         excitation_wavelength=410,
                         excitation_power=10,
                         emission_wavelength=600,
-                    )
+                    ),
                 ),
                 PatchCordConfig(
                     device_name="Patch Cord B",
@@ -84,7 +84,7 @@ a = Acquisition(
                         excitation_wavelength=560,
                         excitation_power=7,
                         emission_wavelength=700,
-                    )
+                    ),
                 ),
             ],
             notes="Internal trigger.",

--- a/src/aind_data_schema/components/configs.py
+++ b/src/aind_data_schema/components/configs.py
@@ -227,16 +227,23 @@ class ProbeConfig(DeviceConfig):
         default=None, title="Other targeted structure"
     )
 
-    atlas_coordinate: Optional[AtlasCoordinate] = Field(
-        default=None,
-        title="Targeted coordinates in an Atlas",
-    )
     coordinate: Coordinate = Field(
         ...,
         title="Targeted coordinates in the Instrument CoordinateSystem",
     )
+    atlas_coordinate: Optional[AtlasCoordinate] = Field(
+        default=None,
+        title="Targeted coordinates in an Atlas",
+    )
 
     dye: Optional[str] = Field(default=None, title="Dye")
+
+
+class EphysAssemblyConfig(DeviceConfig):
+    """Group of configurations for an ephys assembly"""
+
+    manipulator_config: ManipulatorConfig = Field(..., title="Manipulator configuration")
+    probe_configs: List[ProbeConfig] = Field(..., title="Probe configurations")
 
 
 class NewScaleMISConfig(DeviceConfig):
@@ -254,9 +261,11 @@ class NewScaleMISConfig(DeviceConfig):
     )
 
 
-class FiberAssemblyConfig(ManipulatorConfig):
-    """Inserted fiber photometry probe recorded in a stream"""
+class FiberAssemblyConfig(DeviceConfig):
+    """Group of configurations for a fiber assembly"""
 
+    manipulator_config: ManipulatorConfig = Field(..., title="Manipulator configuration")
+    probe_configs: List[ProbeConfig] = Field(..., title="Probe configurations")
     patch_cord_connections: List[PatchCordConfig] = Field(default=[], title="Fiber photometry devices")
 
 

--- a/src/aind_data_schema/components/configs.py
+++ b/src/aind_data_schema/components/configs.py
@@ -250,21 +250,6 @@ class EphysAssemblyConfig(DeviceConfig):
     probe_configs: List[ProbeConfig] = Field(..., title="Probe configurations")
 
 
-class NewScaleMISConfig(DeviceConfig):
-    """Configuration for the New Scale MIS"""
-
-    arc_angles: List[float] = Field(..., title="Arc angles")
-    module_angles: List[List[float]] = Field(..., title="Module angles")
-    angle_unit: AngleUnit = Field(default=AngleUnit.DEG, title="Angle unit")
-
-    probe_configs: List[List[ProbeConfig]] = Field(..., title="Probe configurations")
-    module_configs: List[List[ManipulatorConfig]] = Field(..., title="Manipulator configurations")
-
-    calibration_date: Optional[datetime] = Field(
-        default=None, title="Date on which coordinate transform was last calibrated"
-    )
-
-
 class FiberAssemblyConfig(DeviceConfig):
     """Group of configurations for a fiber assembly"""
 

--- a/src/aind_data_schema/components/coordinates.py
+++ b/src/aind_data_schema/components/coordinates.py
@@ -332,10 +332,10 @@ class CoordinateSystemLibrary:
         ],
     )
 
-    PROBE_MIS = CoordinateSystem(
-        name="PROBE_MIS",
+    PROBE_XYZ = CoordinateSystem(
+        name="PROBE_XYZ",
         origin=Origin.TIP,
-        axis_unit=SizeUnit.CM,
+        axis_unit=SizeUnit.UM,
         axes=[
             Axis(name=AxisName.X, direction=Direction.FB),
             Axis(name=AxisName.Y, direction=Direction.RL),
@@ -346,7 +346,7 @@ class CoordinateSystemLibrary:
     PROBE_ARID = CoordinateSystem(
         name="PROBE_ARID",
         origin=Origin.TIP,
-        axis_unit=SizeUnit.CM,
+        axis_unit=SizeUnit.UM,
         axes=[
             Axis(name=AxisName.X, direction=Direction.LR),
             Axis(name=AxisName.Y, direction=Direction.IS),
@@ -398,6 +398,10 @@ class CoordinateSystemLibrary:
             Axis(name=AxisName.Z, direction=Direction.IS),
         ],
     )
+
+
+class AtlasLibrary:
+    """Library of common atlases"""
 
     CCFv3 = Atlas(
         name=AtlasName.CCF,

--- a/src/aind_data_schema/components/devices.py
+++ b/src/aind_data_schema/components/devices.py
@@ -578,7 +578,7 @@ class EphysProbe(Device):
     # required fields
     probe_model: ProbeModel = Field(..., title="Probe model")
 
-    # optional fields
+    # details
     lasers: List[Laser] = Field(default=[], title="Lasers connected to this probe")
     headstage: Optional[Headstage] = Field(default=None, title="Headstage for this probe")
 

--- a/src/aind_data_schema/components/devices.py
+++ b/src/aind_data_schema/components/devices.py
@@ -356,9 +356,6 @@ class EphysProbe(Device):
 
     # required fields
     probe_model: ProbeModel = Field(..., title="Probe model")
-
-    # details
-    lasers: List[Laser] = Field(default=[], title="Lasers connected to this probe")
     headstage: Optional[Device] = Field(default=None, title="Headstage for this probe")
 
 
@@ -393,7 +390,7 @@ class FiberProbe(Device):
 
 
 class FiberAssembly(DataModel):
-    """Named module for inserted fiber photometry recording"""
+    """Assembly for optogenetic or fiber photometry recording"""
 
     name: str = Field(..., title="Fiber assembly name")
     manipulator: Manipulator = Field(..., title="Manipulator")

--- a/src/aind_data_schema/components/devices.py
+++ b/src/aind_data_schema/components/devices.py
@@ -548,7 +548,6 @@ class Manipulator(Device):
     """Manipulator used on a dome module"""
 
     manufacturer: Organization.MANIPULATOR_MANUFACTURERS
-    coordinate_system: Optional[CoordinateSystem] = Field(default=None, title="Manipulator coordinate system")
 
 
 class PatchCord(Device):

--- a/src/aind_data_schema/components/devices.py
+++ b/src/aind_data_schema/components/devices.py
@@ -372,8 +372,7 @@ class NewScaleMISRig(DataModel):
 
     name: str = Field(..., title="MIS rig name")
     arcs: List[List[EphysAssembly]] = Field(
-        ..., title="Modules",
-        description="Outer list is for each ARC, inner list is for MODULES on an arc"
+        ..., title="Modules", description="Outer list is for each ARC, inner list is for MODULES on an arc"
     )
 
 

--- a/src/aind_data_schema/components/devices.py
+++ b/src/aind_data_schema/components/devices.py
@@ -367,15 +367,6 @@ class EphysAssembly(DataModel):
     probes: List[EphysProbe] = Field(..., title="Probes that are held by this module")
 
 
-class NewScaleMISRig(DataModel):
-    """Assembly representing a NewScale Modular Insertion System rig"""
-
-    name: str = Field(..., title="MIS rig name")
-    arcs: List[List[EphysAssembly]] = Field(
-        ..., title="Modules", description="Outer list is for each ARC, inner list is for MODULES on an arc"
-    )
-
-
 class FiberProbe(Device):
     """Description of a fiber optic probe"""
 

--- a/src/aind_data_schema/components/devices.py
+++ b/src/aind_data_schema/components/devices.py
@@ -506,13 +506,6 @@ class LightAssembly(DataModel):
     filter: Optional[Filter] = Field(default=None, title="Filter")
 
 
-class ProbePort(DataModel):
-    """Port for a probe connection"""
-
-    index: int = Field(..., title="One-based port index")
-    probes: List[str] = Field(..., title="Names of probes connected to this port")
-
-
 class NeuropixelsBasestation(DAQDevice):
     """PXI-based Neuropixels DAQ"""
 
@@ -520,7 +513,6 @@ class NeuropixelsBasestation(DAQDevice):
     basestation_firmware_version: str = Field(..., title="Basestation firmware version")
     bsc_firmware_version: str = Field(..., title="Basestation connect board firmware")
     slot: int = Field(..., title="Slot number for this basestation")
-    ports: List[ProbePort] = Field(..., title="Basestation ports")
 
     # fixed values
     data_interface: Literal[DataInterface.PXI] = DataInterface.PXI
@@ -529,9 +521,6 @@ class NeuropixelsBasestation(DAQDevice):
 
 class OpenEphysAcquisitionBoard(DAQDevice):
     """Multichannel electrophysiology DAQ"""
-
-    # required fields
-    ports: List[ProbePort] = Field(..., title="Acquisition board ports")
 
     # fixed values
     data_interface: Literal[DataInterface.USB] = DataInterface.USB
@@ -553,7 +542,7 @@ class PatchCord(Device):
 
 
 class LaserAssembly(DataModel):
-    """Assembly for optogenetic stimulation"""
+    """Named assembly combining a manipulator, lasers, collimator, and fibers"""
 
     name: str = Field(..., title="Laser assembly name")
     manipulator: Manipulator = Field(..., title="Manipulator")
@@ -567,7 +556,7 @@ class Headstage(Device):
 
 
 class EphysProbe(Device):
-    """Named probe used in an ephys experiment"""
+    """Probe used in an ephys experiment"""
 
     # required fields
     probe_model: ProbeModel = Field(..., title="Probe model")
@@ -578,11 +567,21 @@ class EphysProbe(Device):
 
 
 class EphysAssembly(DataModel):
-    """Module for electrophysiological recording"""
+    """Assembly for electrophysiological recording"""
 
     name: str = Field(..., title="Ephys assembly name")
     manipulator: Manipulator = Field(..., title="Manipulator")
     probes: List[EphysProbe] = Field(..., title="Probes that are held by this module")
+
+
+class NewScaleMISRig(DataModel):
+    """Assembly representing a NewScale Modular Insertion System rig"""
+
+    name: str = Field(..., title="MIS rig name")
+    arcs: List[List[EphysAssembly]] = Field(
+        ..., title="Modules",
+        description="Outer list is for each ARC, inner list is for MODULES on an arc"
+    )
 
 
 class FiberProbe(Device):
@@ -598,7 +597,7 @@ class FiberProbe(Device):
 
 
 class FiberAssembly(DataModel):
-    """Module for inserted fiber photometry recording"""
+    """Named module for inserted fiber photometry recording"""
 
     name: str = Field(..., title="Fiber assembly name")
     manipulator: Manipulator = Field(..., title="Manipulator")


### PR DESCRIPTION
This draft PR refactors the DomeModule and ManipulatorModule classes to better reflect how they link to devices.

On the device side, I've separated `EphysProbe` and `FiberProbe` from the assembly versions (which include a manipulator). Assemblies can be used on rigs where the manipulators and probes are attached, while the separate probe classes can be used for chronic recordings.

To match this, there are now separate `ManipulatorConfig` and `ProbeConfig` classes, as well as corresponding `EphysAssemblyConfig` and `FiberAssemblyConfig` classes. The manipulator configuration stores information about the manipulator local axis positions, independent of the acquisition coordinate system. The probe config class stores information about the target coordinate in both the acquisition coordinate system and optionally in an atlas. `ProbeConfig` is now generic enough to be re-used by all kinds of devices that get stuck into brains.

**Up for debate**: how should we handle the MIS system? If we want to keep things simple we simply force users to report the position of each manipulator according to the acquisition coordinate system. Alternatively, and what I've done in this draft, is let them define the arc and module angles explicitly and then also report the actual angles in the ManipulatorConfig objects. 

Notes:
- Previously there were lasers attached to ephys probes, presumably for NeuropixelsOpto, users should now report those as a `Connection`