### PR TITLE
refactor: remove metadata_status

### DIFF
--- a/src/aind_data_schema/core/metadata.py
+++ b/src/aind_data_schema/core/metadata.py
@@ -48,15 +48,6 @@ REQUIRED_FILES = [
 ]
 
 
-class MetadataStatus(str, Enum):
-    """Status of Metadata"""
-
-    VALID = "Valid"
-    INVALID = "Invalid"
-    MISSING = "Missing"
-    UNKNOWN = "Unknown"
-
-
 class ExternalPlatforms(str, Enum):
     """External Platforms of Data Assets."""
 
@@ -86,9 +77,6 @@ class Metadata(DataCoreModel):
         ...,
         title="Location",
         description="Current location of the data asset.",
-    )
-    metadata_status: MetadataStatus = Field(
-        default=MetadataStatus.UNKNOWN, title=" Metadata Status", description="The status of the metadata."
     )
     external_links: Dict[ExternalPlatforms, List[str]] = Field(
         default=dict(), title="External Links", description="Links to the data asset on different platforms."
@@ -144,53 +132,6 @@ class Metadata(DataCoreModel):
         else:
             core_model = value
         return core_model
-
-    @model_validator(mode="after")
-    def validate_metadata(self):
-        """Validator for metadata"""
-
-        all_model_fields = dict()
-        for field_name in self.model_fields:
-            # The fields we're interested in are optional. We need to extract out the
-            # class using the get_args method
-            annotation_args = get_args(self.model_fields[field_name].annotation)
-            optional_classes = (
-                None
-                if not annotation_args
-                else (
-                    [
-                        f
-                        for f in get_args(self.model_fields[field_name].annotation)
-                        if inspect.isclass(f) and issubclass(f, DataCoreModel)
-                    ]
-                )
-            )
-            if (
-                optional_classes
-                and inspect.isclass(optional_classes[0])
-                and issubclass(optional_classes[0], DataCoreModel)
-            ):
-                all_model_fields[field_name] = optional_classes[0]
-
-        # For each model field, check that is present and check if the model
-        # is valid. If it isn't valid, still add it, but mark MetadataStatus
-        # as INVALID
-        metadata_status = MetadataStatus.VALID
-        for field_name, model_class in all_model_fields.items():
-            if getattr(self, field_name) is not None:
-                model = getattr(self, field_name)
-                model_contents = model.model_dump()
-                try:
-                    model_class(**model_contents)
-                except ValidationError:
-                    metadata_status = MetadataStatus.INVALID
-        # For certain required fields, like subject, if they are not present,
-        # mark the metadata record as missing
-        if self.subject is None:
-            metadata_status = MetadataStatus.MISSING
-        self.metadata_status = metadata_status
-        # return values
-        return self
 
     @model_validator(mode="after")
     def validate_expected_files_by_modality(self):
@@ -326,7 +267,6 @@ def create_metadata_json(
                 core_fields[key] = value
     # Create Metadata object and convert to JSON
     # If there are any validation errors, still create it
-    # but set MetadataStatus as Invalid
     try:
         metadata = Metadata.model_validate(params | core_fields)
         metadata_json = json.loads(metadata.model_dump_json(by_alias=True))
@@ -336,5 +276,4 @@ def create_metadata_json(
         metadata_json = json.loads(metadata.model_dump_json(by_alias=True))
         for key, value in core_fields.items():
             metadata_json[key] = value
-        metadata_json["metadata_status"] = MetadataStatus.INVALID.value
     return metadata_json

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -19,7 +19,7 @@ from aind_data_schema.components.coordinates import CoordinateSystemLibrary
 from aind_data_schema.components.identifiers import Person, Code
 from aind_data_schema.core.acquisition import Acquisition, SubjectDetails
 from aind_data_schema.core.data_description import DataDescription, Funding
-from aind_data_schema.core.metadata import ExternalPlatforms, Metadata, MetadataStatus, create_metadata_json
+from aind_data_schema.core.metadata import ExternalPlatforms, Metadata, create_metadata_json
 from aind_data_schema.core.procedures import (
     BrainInjection,
     Procedures,
@@ -131,79 +131,6 @@ class TestMetadata(unittest.TestCase):
         cls.dd_json = json.loads(dd.model_dump_json())
         cls.procedures_json = json.loads(procedures.model_dump_json())
         cls.processing_json = json.loads(processing.model_dump_json())
-
-    def test_valid_subject_info(self):
-        """Tests that the record is marked as VALID if a valid subject model
-        is present."""
-        subject = self.subject
-        d1 = Metadata(name="655019_2023-04-03T181709", location="bucket", subject=subject)
-        self.assertEqual("655019_2023-04-03T181709", d1.name)
-        self.assertEqual("bucket", d1.location)
-        self.assertEqual(MetadataStatus.VALID, d1.metadata_status)
-        self.assertEqual(subject, d1.subject)
-
-    def test_missing_subject_info(self):
-        """Marks the metadata status as MISSING if a Subject model is not
-        present"""
-
-        d1 = Metadata(
-            name="655019_2023-04-03T181709",
-            location="bucket",
-        )
-        self.assertEqual(MetadataStatus.MISSING, d1.metadata_status)
-        self.assertEqual("655019_2023-04-03T181709", d1.name)
-        self.assertEqual("bucket", d1.location)
-
-        # Assert at least a name and location are required
-        with self.assertRaises(ValidationError) as e:
-            Metadata()
-
-        self.assertIn("Field required", str(e.exception))
-        self.assertIn("name", str(e.exception))
-        self.assertIn("location", str(e.exception))
-
-    def test_invalid_core_models(self):
-        """Test that invalid models don't raise an error, but marks the
-        metadata_status as INVALID"""
-
-        # Invalid subject model
-        d1 = Metadata(name="655019_2023-04-03T181709", location="bucket", subject=Subject.model_construct())
-        self.assertEqual(MetadataStatus.INVALID, d1.metadata_status)
-
-        # Valid subject model, but invalid procedures model
-        s2 = Subject(
-            subject_id="123345",
-            subject_details=MouseSubject(
-                species=Species.MUS_MUSCULUS,
-                strain=Strain.C57BL_6J,
-                sex=Sex.MALE,
-                date_of_birth="2020-10-10",
-                source=Organization.AI,
-                breeding_info=BreedingInfo(
-                    breeding_group="Emx1-IRES-Cre(ND)",
-                    maternal_id="546543",
-                    maternal_genotype="Emx1-IRES-Cre/wt; Camk2a-tTa/Camk2a-tTA",
-                    paternal_id="232323",
-                    paternal_genotype="Ai93(TITL-GCaMP6f)/wt",
-                ),
-                genotype="Emx1-IRES-Cre;Camk2a-tTA;Ai93(TITL-GCaMP6f)/wt",
-            ),
-        )
-        d2 = Metadata(
-            name="655019_2023-04-03T181709",
-            location="bucket",
-            subject=s2,
-            procedures=Procedures.model_construct(injection_materials=["some materials"]),
-        )
-        self.assertEqual(MetadataStatus.INVALID, d2.metadata_status)
-
-        # Tests constructed via dictionary
-        d3 = Metadata(
-            name="655019_2023-04-03T181709",
-            location="bucket",
-            subject=json.loads(Subject.model_construct().model_dump_json()),
-        )
-        self.assertEqual(MetadataStatus.INVALID, d3.metadata_status)
 
     def test_default_file_extension(self):
         """Tests that the default file extension used is as expected."""
@@ -344,7 +271,6 @@ class TestMetadata(unittest.TestCase):
         self.assertEqual(self.procedures_json, result["procedures"])
         self.assertEqual(self.processing_json, result["processing"])
         self.assertIsNone(result["acquisition"])
-        self.assertEqual(MetadataStatus.VALID.value, result["metadata_status"])
         # also check the other fields
         self.assertDictEqual(expected_result, result)
 
@@ -365,7 +291,7 @@ class TestMetadata(unittest.TestCase):
             location=self.sample_location,
             core_jsons=core_jsons,
         )
-        self.assertEqual(MetadataStatus.INVALID.value, metadata["metadata_status"])
+        self.assertIsNotNone(metadata)
 
     def test_create_from_core_jsons_optional_overwrite(self):
         """Tests metadata json creation with created and external links"""
@@ -413,7 +339,6 @@ class TestMetadata(unittest.TestCase):
         self.assertEqual(self.sample_location, result["location"])
         self.assertEqual(self.subject_json, result["subject"])
         self.assertIsNone(result["acquisition"])
-        self.assertEqual(MetadataStatus.VALID.value, result["metadata_status"])
         # check that corrupt core jsons were ignored
         self.assertIsNone(result["procedures"])
         self.assertIsNone(result["processing"])

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -2,7 +2,6 @@
 
 import json
 import unittest
-from unittest.mock import MagicMock, patch, call
 from datetime import datetime, timezone
 
 from aind_data_schema_models.modalities import Modality
@@ -306,44 +305,6 @@ class TestMetadata(unittest.TestCase):
         self.assertEqual(self.sample_name, result["name"])
         self.assertEqual(self.sample_location, result["location"])
         self.assertEqual(external_links, result["external_links"])
-
-    @patch("logging.warning")
-    @patch("aind_data_schema.core.metadata.is_dict_corrupt")
-    def test_create_from_core_jsons_corrupt(self, mock_is_dict_corrupt: MagicMock, mock_warning: MagicMock):
-        """Tests metadata json creation ignores corrupt core jsons"""
-        # mock corrupt procedures and processing
-        mock_is_dict_corrupt.side_effect = lambda x: (x == self.procedures_json or x == self.processing_json)
-        core_jsons = {
-            "subject": self.subject_json,
-            "data_description": None,
-            "procedures": self.procedures_json,
-            "instrument": None,
-            "processing": self.processing_json,
-            "acquisition": None,
-            "quality_control": None,
-        }
-        # there are some userwarnings when creating Subject from json
-        with self.assertWarns(UserWarning):
-            result = create_metadata_json(
-                name=self.sample_name,
-                location=self.sample_location,
-                core_jsons=core_jsons,
-            )
-        # check that metadata was still created
-        self.assertEqual(self.sample_name, result["name"])
-        self.assertEqual(self.sample_location, result["location"])
-        self.assertEqual(self.subject_json, result["subject"])
-        self.assertIsNone(result["acquisition"])
-        # check that corrupt core jsons were ignored
-        self.assertIsNone(result["procedures"])
-        self.assertIsNone(result["processing"])
-        mock_warning.assert_has_calls(
-            [
-                call("Provided processing is corrupt! It will be ignored."),
-                call("Provided procedures is corrupt! It will be ignored."),
-            ],
-            any_order=True,
-        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
PR removes the `Metadata.metadata_status` field and associated validators.