### PR TITLE
1384 20 replace modalities set with list fix order validator

### DIFF
--- a/src/aind_data_schema/base.py
+++ b/src/aind_data_schema/base.py
@@ -104,7 +104,7 @@ class DataModel(BaseModel, Generic[GenericModelType]):
     model_config = ConfigDict(extra="forbid", use_enum_values=True)
     object_type: ClassVar[str]  # This prevents Pydantic from treating it as a normal field
 
-    def __init_subclass__(cls, **kwargs): 
+    def __init_subclass__(cls, **kwargs):
         """Automatically set the correct `object_type` as a Literal[...]"""
         super().__init_subclass__(**kwargs)
         object_type_value = cls._object_type_from_name()

--- a/src/aind_data_schema/base.py
+++ b/src/aind_data_schema/base.py
@@ -104,7 +104,7 @@ class DataModel(BaseModel, Generic[GenericModelType]):
     model_config = ConfigDict(extra="forbid", use_enum_values=True)
     object_type: ClassVar[str]  # This prevents Pydantic from treating it as a normal field
 
-    def __init_subclass__(cls, **kwargs):
+    def __init_subclass__(cls, **kwargs): 
         """Automatically set the correct `object_type` as a Literal[...]"""
         super().__init_subclass__(**kwargs)
         object_type_value = cls._object_type_from_name()

--- a/src/aind_data_schema/core/instrument.py
+++ b/src/aind_data_schema/core/instrument.py
@@ -2,7 +2,7 @@
 
 from datetime import date
 from enum import Enum
-from typing import Dict, List, Literal, Optional, Set, Union
+from typing import Dict, List, Literal, Optional, Union
 
 from aind_data_schema_models.modalities import Modality
 from aind_data_schema_models.organizations import Organization
@@ -191,7 +191,7 @@ class Instrument(DataCoreModel):
         return names
 
     @field_serializer("modalities", when_used="json")
-    def serialize_modalities(self, modalities: Set[Modality.ONE_OF]):
+    def serialize_modalities(self, modalities: List[Modality.ONE_OF]):
         """Dynamically serialize modalities based on their type."""
         return sorted(modalities, key=lambda x: x.get("name") if isinstance(x, dict) else x.name)
 

--- a/src/aind_data_schema/core/instrument.py
+++ b/src/aind_data_schema/core/instrument.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Literal, Optional, Union
 
 from aind_data_schema_models.modalities import Modality
 from aind_data_schema_models.organizations import Organization
-from pydantic import Field, SkipValidation, ValidationInfo, field_serializer, field_validator, model_validator
+from pydantic import Field, SkipValidation, ValidationInfo, field_validator, model_validator
 from typing_extensions import Annotated
 
 from aind_data_schema.base import DataCoreModel, DataModel
@@ -190,10 +190,10 @@ class Instrument(DataCoreModel):
 
         return names
 
-    @field_serializer("modalities", when_used="json")
-    def serialize_modalities(self, modalities: List[Modality.ONE_OF]):
-        """Dynamically serialize modalities based on their type."""
-        return sorted(modalities, key=lambda x: x.get("name") if isinstance(x, dict) else x.name)
+    @field_validator("modalities", mode="before")
+    def validate_modalities(cls, value: List[Modality.ONE_OF]) -> List[Modality.ONE_OF]:
+        """Sort modalities"""
+        return sorted(value, key=lambda x: x["abbreviation"] if isinstance(x, dict) else x.abbreviation)
 
     @model_validator(mode="after")
     def validate_cameras_other(self):
@@ -233,7 +233,7 @@ class Instrument(DataCoreModel):
         return value
 
     @model_validator(mode="after")
-    def validate_modalities(cls, value):
+    def validate_modality_device_dependencies(cls, value):
         """
         Validate that devices exist for the modalities specified.
 

--- a/src/aind_data_schema/core/procedures.py
+++ b/src/aind_data_schema/core/procedures.py
@@ -21,7 +21,7 @@ from aind_data_schema_models.units import (
     UnitlessUnit,
     VolumeUnit,
 )
-from pydantic import Field, SkipValidation, field_serializer, field_validator, model_validator
+from pydantic import Field, SkipValidation, field_validator, model_validator
 from pydantic_core.core_schema import ValidationInfo
 from typing_extensions import Annotated
 

--- a/src/aind_data_schema/core/procedures.py
+++ b/src/aind_data_schema/core/procedures.py
@@ -611,8 +611,8 @@ class Perfusion(DataModel):
         description="IDs of specimens resulting from this procedure.",
     )
 
-    @field_serializer("output_specimen_ids", when_used="json")
-    def serialize_output_specimen_ids(values: List[str]):
+    @field_validator("output_specimen_ids", mode="before")
+    def serialize_output_specimen_ids(cls, values: List[str]):
         """sort specimen ids for JSON serialization"""
         return sorted(values)
 

--- a/src/aind_data_schema/core/procedures.py
+++ b/src/aind_data_schema/core/procedures.py
@@ -3,7 +3,7 @@
 from datetime import date
 from decimal import Decimal
 from enum import Enum
-from typing import Dict, List, Literal, Optional, Set, Union
+from typing import Dict, List, Literal, Optional, Union
 
 from aind_data_schema_models.brain_atlas import CCFStructure
 from aind_data_schema_models.coordinates import AnatomicalRelative
@@ -605,14 +605,14 @@ class Perfusion(DataModel):
     """Description of a perfusion procedure that creates a specimen"""
 
     protocol_id: str = Field(..., title="Protocol ID", description="DOI for protocols.io")
-    output_specimen_ids: Set[str] = Field(
+    output_specimen_ids: List[str] = Field(
         ...,
         title="Specimen ID",
         description="IDs of specimens resulting from this procedure.",
     )
 
     @field_serializer("output_specimen_ids", when_used="json")
-    def serialize_output_specimen_ids(values: Set[str]):
+    def serialize_output_specimen_ids(values: List[str]):
         """sort specimen ids for JSON serialization"""
         return sorted(values)
 

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -659,13 +659,6 @@ class InstrumentTests(unittest.TestCase):
         instrument_dict_data = json.loads(instrument_dict_json)
         self.assertEqual(instrument_dict_data["modalities"], expected_modalities)
 
-        # Case 3: Modality is an unknown type
-        with self.assertRaises(PydanticSerializationError) as context:
-            instrument_unknown_modality = Instrument.model_construct(modalities={"UnknownModality"})
-
-            instrument_unknown_modality.model_dump_json()
-        self.assertIn("Error calling function `serialize_modalities`", str(context.exception))
-
     def test_coordinate_validator(self):
         """Test the coordinate_validator function"""
 
@@ -765,6 +758,54 @@ class ConnectionTest(unittest.TestCase):
             )
 
         self.assertIn("Connection data key 'Laser A' does not exist", str(context.exception))
+
+    def test_validate_modalities_sorting(self):
+        """Test that validate_modalities sorts modalities by their name"""
+
+        # Create unsorted modalities
+        unsorted_modalities = [
+            Modality.FIB,
+            Modality.ECEPHYS,
+            Modality.BEHAVIOR_VIDEOS,
+        ]
+
+        # Expected sorted modalities
+        expected_sorted_modalities = [
+            Modality.BEHAVIOR_VIDEOS.abbreviation,
+            Modality.ECEPHYS.abbreviation,
+            Modality.FIB.abbreviation,
+        ]
+
+        # Create an instrument with unsorted modalities
+        inst = Instrument(
+            instrument_id="123_EPHYS1-OPTO_20220101",
+            modification_date=date(2020, 10, 10),
+            modalities=unsorted_modalities,
+            coordinate_system=CoordinateSystemLibrary.BREGMA_ARI,
+            components=[
+                *daqs,
+                *cameras,
+                *stick_microscopes,
+                *light_sources,
+                *lms,
+                laser,
+                *ems,
+                *detectors,
+                *patch_cords,
+                *stimulus_devices,
+                scan_stage,
+                Disc(name="Disc A", radius=1),
+                computer_ASDF,
+                computer_foo,
+                computer_W10XXX000,
+            ],
+            connections=connections,
+            calibrations=[],
+        )
+
+        inst_modality_abbr = [modality.abbreviation for modality in inst.modalities]
+        # Validate that the modalities are sorted
+        self.assertEqual(inst_modality_abbr, expected_sorted_modalities)
 
 
 if __name__ == "__main__":

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -4,53 +4,48 @@ import json
 import unittest
 from datetime import date
 
+from aind_data_schema_models.coordinates import AnatomicalRelative
 from aind_data_schema_models.modalities import Modality
 from aind_data_schema_models.organizations import Organization
-from aind_data_schema_models.units import FrequencyUnit, PowerUnit
+from aind_data_schema_models.units import FrequencyUnit, PowerUnit, SizeUnit
 from pydantic import ValidationError
-from pydantic_core import PydanticSerializationError
 
+from aind_data_schema.components.coordinates import CoordinateSystemLibrary
 from aind_data_schema.components.devices import (
     Camera,
     CameraAssembly,
     CameraTarget,
-    OlfactometerChannelType,
+    Computer,
     DAQChannel,
     Detector,
     DetectorType,
     Device,
+    DigitalMicromirrorDevice,
     Disc,
     EphysAssembly,
     EphysProbe,
+    FiberPatchCord,
     Laser,
     LaserAssembly,
     Lens,
+    LickSpout,
+    LickSpoutAssembly,
     Manipulator,
     NeuropixelsBasestation,
     Objective,
     Olfactometer,
     OlfactometerChannel,
-    FiberPatchCord,
-    LickSpoutAssembly,
-    LickSpout,
+    OlfactometerChannelType,
     ScanningStage,
-    DigitalMicromirrorDevice,
-    Computer,
 )
 from aind_data_schema.components.measurements import Calibration
-
 from aind_data_schema.core.instrument import (
-    Connection,
-    Instrument,
     DEVICES_REQUIRED,
+    Connection,
     ConnectionData,
     ConnectionDirection,
+    Instrument,
 )
-from aind_data_schema_models.units import SizeUnit
-from aind_data_schema.components.coordinates import (
-    CoordinateSystemLibrary,
-)
-from aind_data_schema_models.coordinates import AnatomicalRelative
 
 computer_foo = Computer(name="foo")
 computer_ASDF = Computer(name="ASDF")


### PR DESCRIPTION
This PR removes the use of `Set` on ordered lists. Not sure where that came from, but it also causes serialization to fail when you use `model_dump()`. 