### PR TITLE
refactor: split PerformanceMetrics and RewardMetrics

### DIFF
--- a/examples/ophys_acquisition.py
+++ b/examples/ophys_acquisition.py
@@ -68,7 +68,7 @@ a = Acquisition(
                         excitation_wavelength=410,
                         excitation_power=10,
                         emission_wavelength=600,
-                    )
+                    ),
                 ),
                 PatchCordConfig(
                     device_name="Patch Cord B",
@@ -84,7 +84,7 @@ a = Acquisition(
                         excitation_wavelength=560,
                         excitation_power=7,
                         emission_wavelength=700,
-                    )
+                    ),
                 ),
             ],
             notes="Internal trigger.",


### PR DESCRIPTION
This PR solves the issue of having a lot of empty fields in `PerformanceMetrics` if users didn't provide a reward to the subject or vice versa if they didn't have trials during an acquisition.