### PR TITLE
refactor: replace DataProcess.pipeline_steps with Processing.pipelines and DataProcess.pipeline_name

### DIFF
--- a/examples/processing.py
+++ b/examples/processing.py
@@ -46,24 +46,14 @@ example_code = Code(
 )
 
 p = Processing.create_with_sequential_process_graph(
-    data_processes=[
-        DataProcess(
-            experimenters=[Person(name="Dr. Dan")],
-            process_type=ProcessName.PIPELINE,
-            pipeline_steps=[
-                ProcessName.IMAGE_TILE_FUSING,
-                ProcessName.FILE_FORMAT_CONVERSION,
-                ProcessName.IMAGE_DESTRIPING,
-            ],
-            stage=ProcessStage.PROCESSING,
-            output_path="/path/to/outputs",
-            start_date_time=t,
-            end_date_time=t,
-            code=Code(
-                url="https://url/for/pipeline",
-                version="0.1.1",
-            ),
+    pipelines=[
+        Code(
+            name="Imaging processing pipeline",
+            url="https://url/for/pipeline",
+            version="0.1.1",
         ),
+    ],
+    data_processes=[
         DataProcess(
             process_type=ProcessName.IMAGE_TILE_FUSING,
             experimenters=[Person(name="Dr. Dan")],
@@ -71,6 +61,7 @@ p = Processing.create_with_sequential_process_graph(
             start_date_time=t,
             end_date_time=t,
             output_path="/path/to/outputs",
+            pipeline_name="Imaging processing pipeline",
             code=example_code.model_copy(
                 update=dict(
                     parameters={"size": 7},
@@ -93,6 +84,7 @@ p = Processing.create_with_sequential_process_graph(
         ),
         DataProcess(
             process_type=ProcessName.FILE_FORMAT_CONVERSION,
+            pipeline_name="Imaging processing pipeline",
             experimenters=[Person(name="Dr. Dan")],
             stage=ProcessStage.PROCESSING,
             start_date_time=t,
@@ -106,6 +98,7 @@ p = Processing.create_with_sequential_process_graph(
         ),
         DataProcess(
             process_type=ProcessName.IMAGE_DESTRIPING,
+            pipeline_name="Imaging processing pipeline",
             experimenters=[Person(name="Dr. Dan")],
             stage=ProcessStage.PROCESSING,
             start_date_time=t,

--- a/examples/processing.py
+++ b/examples/processing.py
@@ -137,7 +137,7 @@ p = Processing.create_with_sequential_process_graph(
                 )
             ),
         ),
-    ]
+    ],
 )
 serialized = p.model_dump_json()
 deserialized = Processing.model_validate_json(serialized)

--- a/src/aind_data_schema/core/processing.py
+++ b/src/aind_data_schema/core/processing.py
@@ -60,7 +60,9 @@ class DataProcess(DataModel):
     stage: ProcessStage = Field(..., title="Processing stage")
     code: Code = Field(..., title="Code", description="Code used for processing")
     experimenters: List[Person] = Field(..., title="Experimenters", description="People responsible for processing")
-    pipeline_name: Optional[str] = Field(default=None, title="Pipeline name", description="Pipeline names must exist in Processing.pipelines")
+    pipeline_name: Optional[str] = Field(
+        default=None, title="Pipeline name", description="Pipeline names must exist in Processing.pipelines"
+    )
     start_date_time: AwareDatetimeWithDefault = Field(..., title="Start date time")
     end_date_time: AwareDatetimeWithDefault = Field(..., title="End date time")
     output_path: Optional[AssetPath] = Field(
@@ -99,7 +101,9 @@ class Processing(DataCoreModel):
     schema_version: SkipValidation[Literal["2.0.50"]] = Field(default="2.0.50")
 
     data_processes: List[DataProcess] = Field(..., title="Data processing")
-    pipelines: Optional[List[Code]] = Field(default=None, title="Pipelines", description="Repositories containing pipeline code")
+    pipelines: Optional[List[Code]] = Field(
+        default=None, title="Pipelines", description="Repositories containing pipeline code"
+    )
     notes: Optional[str] = Field(default=None, title="Notes")
 
     dependency_graph: Dict[str, List[str]] = Field(
@@ -182,9 +186,7 @@ class Processing(DataCoreModel):
 
         for process in values.data_processes:
             if process.pipeline_name and process.pipeline_name not in pipeline_names:
-                raise ValueError(
-                    f"Pipeline name '{process.pipeline_name}' not found in pipelines list."
-                )
+                raise ValueError(f"Pipeline name '{process.pipeline_name}' not found in pipelines list.")
 
         return values
 

--- a/src/aind_data_schema/core/processing.py
+++ b/src/aind_data_schema/core/processing.py
@@ -102,7 +102,12 @@ class Processing(DataCoreModel):
 
     data_processes: List[DataProcess] = Field(..., title="Data processing")
     pipelines: Optional[List[Code]] = Field(
-        default=None, title="Pipelines", description="Repositories containing pipeline code"
+        default=None,
+        title="Pipelines",
+        description=(
+            "For processing done with pipelines, list the repositories here. Pipelines must use the name field "
+            ",and be referenced in the pipeline_name field of a DataProcess."
+        ),
     )
     notes: Optional[str] = Field(default=None, title="Notes")
 
@@ -110,8 +115,8 @@ class Processing(DataCoreModel):
         ...,
         title="Dependency graph",
         description=(
-            "Directed graph of processing step dependencies. Each key is a process name, and the value is a list of ",
-            "process names that are inputs to that process.",
+            "Directed graph of processing step dependencies. Each key is a process name, and the value is a list of "
+            "process names that are inputs to that process."
         ),
     )
 


### PR DESCRIPTION
This PR removes the field `DataProcess.pipeline_steps` in favor of having each `DataProcess` point to its pipeline using a name. Pipelines are now listed in `Processing.pipelines`.