### PR TITLE
refactor: Add DataStream.connections and Procedures.implanted_devices

### DIFF
--- a/examples/fip_behavior_instrument.py
+++ b/examples/fip_behavior_instrument.py
@@ -217,6 +217,7 @@ connections = [
 ]
 
 lick_spout_assembly = LickSpoutAssembly(
+    name="Lick spout assembly",
     lick_spouts=[
         LickSpout(
             name="Left spout",

--- a/examples/fip_ophys_instrument.py
+++ b/examples/fip_ophys_instrument.py
@@ -353,6 +353,7 @@ connections = [
 mouse_platform = d.Disc(name="mouse_disc", radius=8.5)
 
 stimulus_device = d.LickSpoutAssembly(
+    name="Lick spout assembly",
     lick_spouts=[
         d.LickSpout(
             name="Left spout",

--- a/examples/ophys_procedures.py
+++ b/examples/ophys_procedures.py
@@ -10,11 +10,9 @@ from aind_data_schema.components.identifiers import Person
 from aind_data_schema.core.procedures import (
     Anaesthetic,
     Antibody,
-    FiberImplant,
-    FiberProbe,
     Headframe,
     BrainInjection,
-    OphysProbe,
+    ProbeImplant,
     Perfusion,
     Procedures,
     SpecimenProcedure,
@@ -24,6 +22,7 @@ from aind_data_schema.core.procedures import (
     InjectionDynamics,
     InjectionProfile,
 )
+from aind_data_schema.components.devices import FiberProbe
 from aind_data_schema_models.units import VolumeUnit
 from aind_data_schema_models.brain_atlas import CCFStructure
 from aind_data_schema.components.coordinates import CoordinateSystemLibrary, Coordinate
@@ -31,8 +30,19 @@ from aind_data_schema.components.coordinates import CoordinateSystemLibrary, Coo
 t = datetime.datetime(2022, 7, 12, 7, 00, 00)
 t2 = datetime.datetime(2022, 9, 23, 10, 22, 00)
 
+implanted_devices = [
+    FiberProbe(
+        name="Probe A",
+        core_diameter=200,
+        numerical_aperture=0.37,
+        ferrule_material="Ceramic",
+        total_length=0.5,
+    )
+]
+
 p = Procedures(
     subject_id="625100",
+    implanted_devices=implanted_devices,
     subject_procedures=[
         Surgery(
             start_date=t.date(),
@@ -80,24 +90,14 @@ p = Procedures(
                     ],
                     targeted_structure=CCFStructure.VTA,
                 ),
-                FiberImplant(
+                ProbeImplant(
                     protocol_id="TO ENTER",
-                    probes=[
-                        OphysProbe(
-                            ophys_probe=FiberProbe(
-                                name="Probe A",
-                                core_diameter=200,
-                                numerical_aperture=0.37,
-                                ferrule_material="Ceramic",
-                                total_length=0.5,
-                            ),
-                            targeted_structure=CCFStructure.VTA,
-                            coordinate=Coordinate(
-                                system_name="BREGMA_ARID",
-                                position=[-600, -3050, 0, 4200],
-                            ),
-                        )
-                    ],
+                    implanted_device_names=["Probe A"],
+                    targeted_structure=CCFStructure.VTA,
+                    coordinate=Coordinate(
+                        system_name="BREGMA_ARID",
+                        position=[-600, -3050, 0, 4200],
+                    ),
                 ),
             ],
         ),

--- a/src/aind_data_schema/components/devices.py
+++ b/src/aind_data_schema/components/devices.py
@@ -38,6 +38,7 @@ from aind_data_schema_models.units import (
     UnitlessUnit,
     VoltageUnit,
 )
+from aind_data_schema_models.mouse_anatomy import MouseAnatomyModel
 from pydantic import Field, ValidationInfo, field_validator, model_validator
 from typing_extensions import Annotated
 
@@ -553,6 +554,7 @@ class LickSpout(Device):
 class LickSpoutAssembly(DataModel):
     """Description of multiple lick spouts, possibly mounted on a stage"""
 
+    name: str = Field(..., title="Lick spout assembly name")
     lick_spouts: List[LickSpout] = Field(..., title="Water spouts")
     motorized_stage: Optional[MotorizedStage] = Field(default=None, title="Motorized stage")
 
@@ -633,6 +635,26 @@ class Scanner(Device):
 
     magnetic_strength: float = Field(..., title="Magnetic strength (T)")
     magnetic_strength_unit: MagneticFieldUnit = Field(..., title="Magnetic strength unit")
+
+
+class MyomatrixContact(DataModel):
+    """Description of a contact on a myomatrix thread"""
+
+    body_part: MouseAnatomyModel = Field(..., title="Body part of contact insertion", description="Use MouseBodyParts")
+    relative_position: AnatomicalRelative = Field(
+        ..., title="Relative position", description="Position relative to procedures coordinate system"
+    )
+    muscle: MouseAnatomyModel = Field(..., title="Muscle of contact insertion", description="Use MouseEmgMuscles")
+    in_muscle: bool = Field(..., title="In muscle")
+
+
+class MyomatrixThread(DataModel):
+    """Description of a thread of a myomatrix array"""
+
+    ground_electrode_location: MouseAnatomyModel = Field(
+        ..., title="Location of ground electrode", description="Use GroundWireLocations"
+    )
+    contacts: List[MyomatrixContact] = Field(..., title="Contacts")
 
 
 class MyomatrixArray(Device):

--- a/src/aind_data_schema/components/devices.py
+++ b/src/aind_data_schema/components/devices.py
@@ -661,3 +661,4 @@ class MyomatrixArray(Device):
     """Description of a Myomatrix array"""
 
     array_type: MyomatrixArrayType = Field(..., title="Array type")
+    threads: List[MyomatrixThread] = Field(..., title="Array threads")

--- a/src/aind_data_schema/components/reagent.py
+++ b/src/aind_data_schema/components/reagent.py
@@ -1,13 +1,40 @@
 """Classes to define reagents"""
 
 from datetime import date
-from typing import Optional
+from typing import Optional, List
+from enum import Enum
+from pydantic import Field
 
 from aind_data_schema_models.organizations import Organization
 from aind_data_schema_models.pid_names import PIDName
-from pydantic import Field
+from aind_data_schema_models.units import ConcentrationUnit, SizeUnit
+from aind_data_schema_models.species import Species
 
 from aind_data_schema.base import DataModel
+
+
+class StainType(str, Enum):
+    """Stain types for probes describing what is being labeled"""
+
+    RNA = "RNA"
+    NUCLEAR = "Nuclear"
+    FILL = "Fill"
+
+
+class Fluorophore(str, Enum):
+    """Fluorophores used in HCR and Immunolabeling"""
+
+    ALEXA_405 = "Alexa Fluor 405"
+    ALEXA_488 = "Alexa Fluor 488"
+    ALEXA_546 = "Alexa Fluor 546"
+    ALEXA_568 = "Alexa Fluor 568"
+    ALEXA_594 = "Alexa Fluor 594"
+    ALEXA_633 = "Alexa Fluor 633"
+    ALEXA_647 = "Alexa Fluor 647"
+    ATTO_488 = "ATTO 488"
+    ATTO_565 = "ATTO 565"
+    ATTO_643 = "ATTO 643"
+    CY3 = "Cyanine Cy 3"
 
 
 class Reagent(DataModel):
@@ -18,3 +45,42 @@ class Reagent(DataModel):
     rrid: Optional[PIDName] = Field(default=None, title="Research Resource ID")
     lot_number: str = Field(..., title="Lot number")
     expiration_date: Optional[date] = Field(default=None, title="Lot expiration date")
+
+
+class Readout(Reagent):
+    """Description of a readout"""
+
+    fluorophore: Fluorophore = Field(..., title="Fluorophore")
+    excitation_wavelength: int = Field(..., title="Excitation wavelength (nm)")
+    excitation_wavelength_unit: SizeUnit = Field(default=SizeUnit.NM, title="Excitation wavelength unit")
+    stain_type: StainType = Field(..., title="Stain type")
+
+
+class HCRReadout(Readout):
+    """Description of a readout for HCR"""
+
+    initiator_name: str = Field(..., title="Initiator name")
+    stain_type: StainType = Field(..., title="Stain type")
+
+
+class OligoProbe(Reagent):
+    """Description of an oligonucleotide probe"""
+
+    species: Species.ONE_OF = Field(..., title="Species")
+    gene: PIDName = Field(..., title="Gene name, accession number, and registry")
+    probe_sequences: List[str] = Field(..., title="Probe sequences")
+    readout: Readout = Field(..., title="Readout")
+
+
+class HCRProbe(OligoProbe):
+    """Description of an oligo probe used for HCR"""
+
+    initiator_name: str = Field(..., title="Initiator name")
+    readout: HCRReadout = Field(..., title="Readout")
+
+
+class Stain(Reagent):
+    """Description of a non-oligo probe stain"""
+
+    concentration: float = Field(..., title="Concentration")
+    concentration_unit: ConcentrationUnit = Field(default=ConcentrationUnit.UM, title="Concentration unit")

--- a/src/aind_data_schema/components/reagent.py
+++ b/src/aind_data_schema/components/reagent.py
@@ -7,10 +7,18 @@ from pydantic import Field
 
 from aind_data_schema_models.organizations import Organization
 from aind_data_schema_models.pid_names import PIDName
-from aind_data_schema_models.units import ConcentrationUnit, SizeUnit
+from aind_data_schema_models.units import ConcentrationUnit, SizeUnit, MassUnit
 from aind_data_schema_models.species import Species
 
 from aind_data_schema.base import DataModel
+
+
+class ImmunolabelClass(str, Enum):
+    """Type of antibodies"""
+
+    PRIMARY = "Primary"
+    SECONDARY = "Secondary"
+    CONJUGATE = "Conjugate"
 
 
 class StainType(str, Enum):
@@ -84,3 +92,13 @@ class Stain(Reagent):
 
     concentration: float = Field(..., title="Concentration")
     concentration_unit: ConcentrationUnit = Field(default=ConcentrationUnit.UM, title="Concentration unit")
+
+
+class Antibody(Reagent):
+    """Description of an antibody used in immunolableing"""
+
+    immunolabel_class: ImmunolabelClass = Field(..., title="Immunolabel class")
+    fluorophore: Optional[Fluorophore] = Field(default=None, title="Fluorophore")
+    mass: float = Field(..., title="Mass of antibody")
+    mass_unit: MassUnit = Field(default=MassUnit.UG, title="Mass unit")
+    notes: Optional[str] = Field(default=None, title="Notes")

--- a/src/aind_data_schema/core/acquisition.py
+++ b/src/aind_data_schema/core/acquisition.py
@@ -134,7 +134,7 @@ class DataStream(DataModel):
     connections: List[Connection] = Field(
         default=[],
         title="Connections",
-        description="Connections that are specific to this acquisition, and are not present in the Instrument"
+        description="Connections that are specific to this acquisition, and are not present in the Instrument",
     )
 
     @model_validator(mode="after")

--- a/src/aind_data_schema/core/acquisition.py
+++ b/src/aind_data_schema/core/acquisition.py
@@ -31,6 +31,7 @@ from aind_data_schema.components.coordinates import CoordinateSystem
 from aind_data_schema.components.devices import Camera, CameraAssembly, EphysAssembly, FiberAssembly
 from aind_data_schema.components.identifiers import Code, Person
 from aind_data_schema.components.measurements import CALIBRATIONS, Maintenance
+from aind_data_schema.core.instrument import Connection
 from aind_data_schema.core.procedures import Anaesthetic
 from aind_data_schema.utils.merge import merge_notes, merge_optional_list
 from aind_data_schema.utils.validators import subject_specimen_id_compatibility
@@ -130,6 +131,12 @@ class DataStream(DataModel):
         ]
     ] = Field(..., title="Device configurations")
 
+    connections: List[Connection] = Field(
+        default=[],
+        title="Connections",
+        description="Connections that are specific to this acquisition, and are not present in the Instrument"
+    )
+
     @model_validator(mode="after")
     def check_modality_config_requirements(self):
         """Check that the required devices are present for the modalities"""
@@ -141,6 +148,15 @@ class DataStream(DataModel):
             for group in CONFIG_REQUIREMENTS[modality]:
                 if not any(isinstance(config, device) for config in self.configurations for device in group):
                     raise ValueError(f"Missing required devices for modality {modality} in {self.configurations}")
+
+        return self
+
+    @model_validator(mode="after")
+    def check_connections(self):
+        """Check that every device in a Connection is present in the active_devices list"""
+        for connection in self.connections:
+            if not any(device in self.active_devices for device in connection.device_names):
+                raise ValueError(f"Missing devices in active_devices list for connection {connection}")
 
         return self
 

--- a/src/aind_data_schema/core/metadata.py
+++ b/src/aind_data_schema/core/metadata.py
@@ -268,16 +268,16 @@ class Metadata(DataCoreModel):
 
         if values.instrument:
             for component in values.instrument.components:
-                device_names.extend(component.name)
+                device_names.append(component.name)
         if values.procedures:
             for device in values.procedures.implanted_devices:
-                device_names.extend(device.name)
+                device_names.append(device.name)
 
         # Check if all active devices are in the available devices
         if not all(device in device_names for device in active_devices):
             missing_devices = set(active_devices) - set(device_names)
             raise ValueError(
-                f"Active devices '{missing_devices}' were not found in either the Instrument.components or"
+                f"Active devices '{missing_devices}' were not found in either the Instrument.components or "
                 f"Procedures.implanted_devices."
             )
 
@@ -292,10 +292,10 @@ class Metadata(DataCoreModel):
 
         if self.instrument:
             for component in self.instrument.components:
-                device_names.extend(component.name)
+                device_names.append(component.name)
         if self.procedures:
             for device in self.procedures.implanted_devices:
-                device_names.extend(device.name)
+                device_names.append(device.name)
 
         # Check if all connection devices are in the available devices
         if self.acquisition:

--- a/src/aind_data_schema/core/metadata.py
+++ b/src/aind_data_schema/core/metadata.py
@@ -254,10 +254,39 @@ class Metadata(DataCoreModel):
         return self
 
     @model_validator(mode="after")
-    def validate_acquisition_connections(self):
-        """Validate for Acquisition.acquisition_connections
+    @classmethod
+    def validate_acquisition_active_devices(cls, values):
+        """Ensure that all Acquisition.data_streams.active_devices exist in either the instrument or procedures."""
 
-        Ensures that all connections map between devices either in the instrument OR procedures"""
+        active_devices = []
+
+        if values.acquisition:
+            for data_stream in values.acquisition.data_streams:
+                active_devices.extend(data_stream.active_devices)
+
+        device_names = []
+
+        if values.instrument:
+            for component in values.instrument.components:
+                device_names.extend(component.name)
+        if values.procedures:
+            for device in values.procedures.implanted_devices:
+                device_names.extend(device.name)
+
+        # Check if all active devices are in the available devices
+        if not all(device in device_names for device in active_devices):
+            missing_devices = set(active_devices) - set(device_names)
+            raise ValueError(
+                f"Active devices '{missing_devices}' were not found in either the Instrument.components or"
+                f"Procedures.implanted_devices."
+            )
+
+        return values
+
+    @model_validator(mode="after")
+    def validate_acquisition_connections(self):
+        """Validate for Acquisition.data_streams.connections that all connections map between devices either in the
+        instrument OR procedures"""
 
         device_names = []
 

--- a/src/aind_data_schema/core/procedures.py
+++ b/src/aind_data_schema/core/procedures.py
@@ -475,7 +475,7 @@ class ProbeImplant(DataModel):
     protocol_id: Optional[str] = Field(default=None, title="Protocol ID", description="DOI for protocols.io")
     implanted_device_names: List[str] = Field(
         ..., title="Implanted device names", description="Devices must exist in Procedures.implanted_devices"
-    )
+    )  # note: exact field name is used by a validator
 
     targeted_structure: CCFStructure.ONE_OF = Field(..., title="Targeted structure")
     coordinate: Coordinate = Field(..., title="Stereotactic coordinate")
@@ -505,7 +505,9 @@ class MyomatrixInsertion(DataModel):
     protocol_id: Optional[str] = Field(default=None, title="Protocol ID", description="DOI for protocols.io")
 
     ground_electrode: GroundWireImplant = Field(..., title="Ground electrode")
-    implanted_device_name: str = Field(..., title="Myomatrix array", description="Must match a MyomatrixArray in Procedures.implanted_devices")
+    implanted_device_name: str = Field(
+        ..., title="Myomatrix array", description="Must match a MyomatrixArray in Procedures.implanted_devices"
+    )  # note: exact field name is used by a validator
 
 
 class Perfusion(DataModel):
@@ -640,7 +642,8 @@ class Procedures(DataCoreModel):
     @classmethod
     def validate_implanted_device_names(cls, values):
         """Validate that all implanted device names appear in the device list"""
-        recursive_device_name_check(values, values.implanted_devices)
+        implanted_device_names = [device.name for device in values.implanted_devices]
+        recursive_device_name_check(values, implanted_device_names)
 
         return values
 

--- a/src/aind_data_schema/core/procedures.py
+++ b/src/aind_data_schema/core/procedures.py
@@ -29,15 +29,7 @@ from aind_data_schema.components.devices import FiberProbe, MyomatrixArray
 from aind_data_schema.components.identifiers import Person
 from aind_data_schema.components.reagent import Reagent, OligoProbe, HCRProbe, Stain, Antibody
 from aind_data_schema.utils.merge import merge_notes
-from aind_data_schema.utils.validators import subject_specimen_id_compatibility
-
-
-class ImmunolabelClass(str, Enum):
-    """Type of antibodies"""
-
-    PRIMARY = "Primary"
-    SECONDARY = "Secondary"
-    CONJUGATE = "Conjugate"
+from aind_data_schema.utils.validators import subject_specimen_id_compatibility, recursive_device_name_check
 
 
 class SectionOrientation(str, Enum):
@@ -641,6 +633,14 @@ class Procedures(DataCoreModel):
 
             if any(not subject_specimen_id_compatibility(subject_id, spec_id) for spec_id in specimen_ids):
                 raise ValueError("specimen_id must be an extension of the subject_id.")
+
+        return values
+
+    @model_validator(mode="after")
+    @classmethod
+    def validate_implanted_device_names(cls, values):
+        """Validate that all implanted device names appear in the device list"""
+        recursive_device_name_check(values, values.implanted_devices)
 
         return values
 

--- a/src/aind_data_schema/core/procedures.py
+++ b/src/aind_data_schema/core/procedures.py
@@ -25,9 +25,9 @@ from typing_extensions import Annotated
 
 from aind_data_schema.base import AwareDatetimeWithDefault, DataCoreModel, DataModel
 from aind_data_schema.components.coordinates import Coordinate, CoordinateSystem, Origin
-from aind_data_schema.components.devices import FiberProbe, MyomatrixArray, MyomatrixThread
+from aind_data_schema.components.devices import FiberProbe, MyomatrixArray
 from aind_data_schema.components.identifiers import Person
-from aind_data_schema.components.reagent import Reagent, OligoProbe, HCRProbe, Stain, Fluorophore
+from aind_data_schema.components.reagent import Reagent, OligoProbe, HCRProbe, Stain, Antibody
 from aind_data_schema.utils.merge import merge_notes
 from aind_data_schema.utils.validators import subject_specimen_id_compatibility
 
@@ -156,16 +156,6 @@ class HCRSeries(DataModel):
     hcr_rounds: List[HybridizationChainReaction] = Field(..., title="Hybridization Chain Reaction rounds")
     strip_qc_compatible: bool = Field(..., title="Strip QC compatible")
     cell_id: Optional[str] = Field(default=None, title="Cell ID")
-
-
-class Antibody(Reagent):
-    """Description of an antibody used in immunolableing"""
-
-    immunolabel_class: ImmunolabelClass = Field(..., title="Immunolabel class")
-    fluorophore: Optional[Fluorophore] = Field(default=None, title="Fluorophore")
-    mass: Decimal = Field(..., title="Mass of antibody")
-    mass_unit: MassUnit = Field(default=MassUnit.UG, title="Mass unit")
-    notes: Optional[str] = Field(default=None, title="Notes")
 
 
 class Sectioning(DataModel):

--- a/src/aind_data_schema/core/procedures.py
+++ b/src/aind_data_schema/core/procedures.py
@@ -491,7 +491,9 @@ class ProbeImplant(DataModel):
     """Description of a probe (fiber, ephys) implant procedure"""
 
     protocol_id: Optional[str] = Field(default=None, title="Protocol ID", description="DOI for protocols.io")
-    implanted_device_names: List[str] = Field(..., title="Implanted device names", description="Devices must exist in Procedures.implanted_devices")
+    implanted_device_names: List[str] = Field(
+        ..., title="Implanted device names", description="Devices must exist in Procedures.implanted_devices"
+    )
 
     targeted_structure: CCFStructure.ONE_OF = Field(..., title="Targeted structure")
     coordinate: Coordinate = Field(..., title="Stereotactic coordinate")

--- a/src/aind_data_schema/core/procedures.py
+++ b/src/aind_data_schema/core/procedures.py
@@ -621,9 +621,7 @@ class Procedures(DataCoreModel):
     specimen_procedures: List[SpecimenProcedure] = Field(default=[], title="Specimen Procedures")
 
     # Implanted devices
-    implanted_devices: List[Union[FiberProbe, MyomatrixArray]] = Field(
-        default=[], title="Implanted devices"
-    )
+    implanted_devices: List[Union[FiberProbe, MyomatrixArray]] = Field(default=[], title="Implanted devices")
 
     # Coordinate system
     coordinate_system: Optional[CoordinateSystem] = Field(

--- a/src/aind_data_schema/core/procedures.py
+++ b/src/aind_data_schema/core/procedures.py
@@ -520,10 +520,10 @@ class WaterRestriction(DataModel):
 class MyomatrixInsertion(DataModel):
     """Description of a Myomatrix array insertion for EMG"""
 
-    ground_electrode: GroundWireImplant = Field(..., title="Ground electrode")
     protocol_id: Optional[str] = Field(default=None, title="Protocol ID", description="DOI for protocols.io")
-    myomatrix_array: MyomatrixArray = Field(..., title="Myomatrix array")
-    threads: List[MyomatrixThread] = Field(..., title="Array threads")
+
+    ground_electrode: GroundWireImplant = Field(..., title="Ground electrode")
+    implanted_device_name: str = Field(..., title="Myomatrix array", description="Must match a MyomatrixArray in Procedures.implanted_devices")
 
 
 class Perfusion(DataModel):
@@ -651,13 +651,6 @@ class Procedures(DataCoreModel):
 
             if any(not subject_specimen_id_compatibility(subject_id, spec_id) for spec_id in specimen_ids):
                 raise ValueError("specimen_id must be an extension of the subject_id.")
-
-        return values
-
-    @model_validator(mode="after")
-    @classmethod
-    def validate_implanted_devices(cls, values):
-        """Validate that all implanted devices exist"""
 
         return values
 

--- a/src/aind_data_schema/core/processing.py
+++ b/src/aind_data_schema/core/processing.py
@@ -105,6 +105,7 @@ class Processing(DataCoreModel):
     describedBy: str = Field(default=_DESCRIBED_BY_URL, json_schema_extra={"const": _DESCRIBED_BY_URL})
     schema_version: SkipValidation[Literal["2.0.50"]] = Field(default="2.0.50")
 
+    pipelines: List[Code]
     data_processes: List[DataProcess] = Field(..., title="Data processing")
     notes: Optional[str] = Field(default=None, title="Notes")
 

--- a/src/aind_data_schema/core/processing.py
+++ b/src/aind_data_schema/core/processing.py
@@ -105,7 +105,6 @@ class Processing(DataCoreModel):
     describedBy: str = Field(default=_DESCRIBED_BY_URL, json_schema_extra={"const": _DESCRIBED_BY_URL})
     schema_version: SkipValidation[Literal["2.0.50"]] = Field(default="2.0.50")
 
-    pipelines: List[Code]
     data_processes: List[DataProcess] = Field(..., title="Data processing")
     notes: Optional[str] = Field(default=None, title="Notes")
 

--- a/src/aind_data_schema/utils/compatibility_check.py
+++ b/src/aind_data_schema/utils/compatibility_check.py
@@ -24,29 +24,6 @@ class InstrumentAcquisitionCompatibility:
         else:
             return None
 
-    def _compare_stream_devices(self) -> Optional[ValueError]:
-        """Compare acquisition active devices against instrument devices"""
-
-        active_devices = []
-        for stream in getattr(self.acquisition, "data_streams", []):
-            active_devices.extend(getattr(stream, "active_devices", []))
-
-        component_names = [comp.name for comp in self.inst.components if hasattr(comp, "name")]
-
-        for device in active_devices:
-            if device not in component_names:
-                return ValueError(f"Active device {device} in acquisition does not match any device in the instrument.")
-
-    # def _compare_mouse_platform_name(self) -> Optional[ValueError]:
-    #     """Compares mouse_platform_name"""
-
-    #     component_names = [comp.name for comp in self.inst.components if hasattr(comp, "name")]
-
-    #     if self.acquisition.mouse_platform_name not in component_names:
-    #         return ValueError(
-    #             f"Mouse platform {self.acquisition.mouse_platform_name} can't be found in the instrument's components"
-    #         )
-
     def _compare_stimulus_devices(self) -> Optional[ValueError]:
         """Compares stimulus device names"""
         acquisition_stimulus_devices = [
@@ -69,7 +46,6 @@ class InstrumentAcquisitionCompatibility:
         """
         comparisons = [
             self._compare_instrument_id(),
-            self._compare_stream_devices(),
             self._compare_stimulus_devices(),
         ]
         error_messages = [str(error) for error in comparisons if error]

--- a/src/aind_data_schema/utils/validators.py
+++ b/src/aind_data_schema/utils/validators.py
@@ -144,3 +144,32 @@ def recursive_check_paths(obj: Any, directory: Optional[Path] = None):
     elif hasattr(obj, "__dict__"):
         for value in vars(obj).values():
             recursive_check_paths(value, directory)
+
+
+def recursive_device_name_check(obj: Any, implanted_devices: List[str]):
+    """Recursively check for `implanted_device_name` or `implanted_device_names` fields against `implanted_devices`."""
+
+    if isinstance(obj, Enum):
+        return
+
+    if hasattr(obj, "implanted_device_name") and obj.implanted_device_name not in implanted_devices:
+        raise ValueError(
+            f"implanted_device_name {obj.implanted_device_name} not found in implanted_devices {implanted_devices}"
+        )
+
+    if hasattr(obj, "implanted_device_names"):
+        missing = [name for name in obj.implanted_device_names if name not in implanted_devices]
+        if missing:
+            raise ValueError(
+                f"implanted_device_names {missing} not found in implanted_devices {implanted_devices}"
+            )
+
+    items = (
+        vars(obj).values() if hasattr(obj, "__dict__") else
+        obj.values() if isinstance(obj, dict) else
+        obj if isinstance(obj, (list, tuple, set)) else
+        []
+    )
+
+    for item in items:
+        recursive_device_name_check(item, implanted_devices)

--- a/src/aind_data_schema/utils/validators.py
+++ b/src/aind_data_schema/utils/validators.py
@@ -160,15 +160,12 @@ def recursive_device_name_check(obj: Any, implanted_devices: List[str]):
     if hasattr(obj, "implanted_device_names"):
         missing = [name for name in obj.implanted_device_names if name not in implanted_devices]
         if missing:
-            raise ValueError(
-                f"implanted_device_names {missing} not found in implanted_devices {implanted_devices}"
-            )
+            raise ValueError(f"implanted_device_names {missing} not found in implanted_devices {implanted_devices}")
 
     items = (
-        vars(obj).values() if hasattr(obj, "__dict__") else
-        obj.values() if isinstance(obj, dict) else
-        obj if isinstance(obj, (list, tuple, set)) else
-        []
+        vars(obj).values()
+        if hasattr(obj, "__dict__")
+        else obj.values() if isinstance(obj, dict) else obj if isinstance(obj, (list, tuple, set)) else []
     )
 
     for item in items:

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -27,6 +27,7 @@ from aind_data_schema.core.acquisition import (
     AcquisitionSubjectDetails,
 )
 from aind_data_schema_models.brain_atlas import CCFStructure
+from aind_data_schema.core.instrument import Connection
 
 
 class AcquisitionTest(unittest.TestCase):
@@ -373,6 +374,38 @@ class AcquisitionTest(unittest.TestCase):
             ],
         )
         self.assertIsNotNone(stream)
+
+    def test_check_connections(self):
+        """Test that every device in a Connection is present in the active_devices list"""
+
+        # Test valid connections
+        stream = DataStream(
+            stream_start_time=datetime.now(),
+            stream_end_time=datetime.now(),
+            modalities=[],
+            active_devices=["DeviceA", "DeviceB"],
+            configurations=[],
+            connections=[
+                Connection(device_names=["DeviceA"]),
+                Connection(device_names=["DeviceB"]),
+            ],
+        )
+        self.assertIsNotNone(stream)
+
+        # Test invalid connections
+        with self.assertRaises(ValueError) as context:
+            DataStream(
+                stream_start_time=datetime.now(),
+                stream_end_time=datetime.now(),
+                modalities=[],
+                active_devices=["DeviceA"],
+                configurations=[],
+                connections=[
+                    Connection(device_names=["DeviceA"]),
+                    Connection(device_names=["DeviceB"]),
+                ],
+            )
+        self.assertIn("Missing devices in active_devices list for connection", str(context.exception))
 
 
 if __name__ == "__main__":

--- a/tests/test_inst_acq_compatibility.py
+++ b/tests/test_inst_acq_compatibility.py
@@ -994,6 +994,7 @@ class TestInstrumentAcquisitionCompatibility(unittest.TestCase):
         ]
         stimulus_devices = [
             d.LickSpoutAssembly(
+                name="Lick spout assembly",
                 lick_spouts=[
                     d.LickSpout(
                         name="Left spout",

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -366,6 +366,7 @@ stimulus_devices = [
         ],
     ),
     LickSpoutAssembly(
+        name="Lick spout assembly",
         lick_spouts=[
             LickSpout(
                 name="Left spout",

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -25,7 +25,7 @@ from aind_data_schema.core.procedures import (
     Surgery,
 )
 from aind_data_schema.core.processing import Processing, DataProcess, ProcessName, ProcessStage
-from aind_data_schema.core.instrument import Instrument, Connection, ConnectionData
+from aind_data_schema.core.instrument import Instrument, Connection
 from aind_data_schema.core.subject import Subject
 from aind_data_schema.components.subjects import BreedingInfo, Housing, Sex, Species, MouseSubject
 
@@ -388,7 +388,10 @@ class TestMetadata(unittest.TestCase):
                 acquisition=acquisition,
             )
         self.assertIn(
-            "Active devices '{'Missing Device'}' were not found in either the Instrument.components or Procedures.implanted_devices.",
+            (
+                "Active devices '{'Missing Device'}' were not found in either "
+                "the Instrument.components or Procedures.implanted_devices."
+            ),
             str(context.exception),
         )
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -347,6 +347,13 @@ class TestMetadata(unittest.TestCase):
             ],
             modalities=[],
         )
+        procedures = Procedures.model_construct(
+            implanted_devices=[
+                EphysProbe.model_construct(name="Probe A"),
+                Laser.model_construct(name="Laser A"),
+            ],
+            subject_procedures=[],
+        )
         acquisition = Acquisition.model_construct(
             instrument_id="Test",
             data_streams=[
@@ -359,6 +366,7 @@ class TestMetadata(unittest.TestCase):
             location="Test Location",
             instrument=instrument,
             acquisition=acquisition,
+            procedures=procedures,
         )
         self.assertIsNotNone(metadata)
 
@@ -395,6 +403,13 @@ class TestMetadata(unittest.TestCase):
             ],
             modalities=[],
         )
+        procedures = Procedures.model_construct(
+            implanted_devices=[
+                EphysProbe.model_construct(name="Probe A"),
+                Laser.model_construct(name="Laser A"),
+            ],
+            subject_procedures=[],
+        )
         acquisition = Acquisition.model_construct(
             instrument_id="Test",
             data_streams=[
@@ -407,6 +422,7 @@ class TestMetadata(unittest.TestCase):
             location="Test Location",
             instrument=instrument,
             acquisition=acquisition,
+            procedures=procedures,
         )
         self.assertIsNotNone(metadata)
 

--- a/tests/test_procedures.py
+++ b/tests/test_procedures.py
@@ -11,10 +11,8 @@ from pydantic import ValidationError
 from aind_data_schema.components.devices import FiberProbe
 from aind_data_schema.components.identifiers import Person
 from aind_data_schema.core.procedures import (
-    FiberImplant,
     BrainInjection,
     NonViralMaterial,
-    OphysProbe,
     Procedures,
     Sectioning,
     SpecimenProcedure,
@@ -27,6 +25,7 @@ from aind_data_schema.core.procedures import (
     Craniotomy,
     CraniotomyType,
     HCRSeries,
+    ProbeImplant,
 )
 from aind_data_schema_models.brain_atlas import CCFStructure
 from aind_data_schema.components.coordinates import (
@@ -133,6 +132,17 @@ class ProceduresTests(unittest.TestCase):
         p = Procedures(
             subject_id="12345",
             coordinate_system=CoordinateSystemLibrary.BREGMA_ARI,
+            implanted_devices=[
+                FiberProbe(
+                    name="Probe A",
+                    manufacturer=Organization.DORIC,
+                    model="8",
+                    core_diameter=2,
+                    numerical_aperture=1,
+                    ferrule_material="Ceramic",
+                    total_length=10,
+                )
+            ],
             subject_procedures=[
                 Surgery(
                     start_date=self.start_date,
@@ -229,29 +239,17 @@ class ProceduresTests(unittest.TestCase):
                             ],
                             targeted_structure=CCFStructure.VISP6A,
                         ),
-                        FiberImplant(
+                        ProbeImplant(
                             protocol_id="dx.doi.org/120.123/fkjd",
-                            probes=[
-                                OphysProbe(
-                                    ophys_probe=FiberProbe(
-                                        name="Probe A",
-                                        manufacturer=Organization.DORIC,
-                                        model="8",
-                                        core_diameter=2,
-                                        numerical_aperture=1,
-                                        ferrule_material="Ceramic",
-                                        total_length=10,
-                                    ),
-                                    targeted_structure=CCFStructure.MOP,
-                                    coordinate=Coordinate(
-                                        system_name="BREGMA_ARID",
-                                        position=[1, 2, 0, 2],
-                                        angles=Rotation(
-                                            angles=[10, 0, 0],
-                                        ),
-                                    ),
-                                )
-                            ],
+                            implanted_device_names=["Probe A"],
+                            targeted_structure=CCFStructure.MOP,
+                            coordinate=Coordinate(
+                                system_name="BREGMA_ARID",
+                                position=[1, 2, 0, 2],
+                                angles=Rotation(
+                                    angles=[10, 0, 0],
+                                ),
+                            ),
                         ),
                     ],
                 )

--- a/tests/test_utils_validators.py
+++ b/tests/test_utils_validators.py
@@ -8,6 +8,7 @@ from aind_data_schema.utils.validators import (
     recursive_coord_system_check,
     recursive_get_all_names,
     recursive_check_paths,
+    recursive_device_name_check,
     SystemNameException,
     AxisCountException,
     CoordinateSystemException,
@@ -17,6 +18,7 @@ from pydantic import BaseModel
 from aind_data_schema.components.coordinates import Coordinate
 from aind_data_schema.components.wrappers import AssetPath
 from pathlib import Path
+from pydantic import BaseModel
 
 
 class TestCompatibilityCheck(unittest.TestCase):
@@ -385,6 +387,59 @@ class TestRecursiveCheckPaths(unittest.TestCase):
         test_path = AssetPath("relative/path/to/file.txt")
         recursive_check_paths(test_path, None)
         mock_warning.assert_not_called()
+
+
+class TestImplantedDevice(BaseModel):
+    """Test class with implanted_device_name"""
+    implanted_device_name: str
+
+
+class TestImplantedDeviceNames(BaseModel):
+    """Test class with implanted_device_names"""
+    implanted_device_names: list[str]
+
+
+class TestRecursiveDeviceNameCheck(unittest.TestCase):
+    """Tests for recursive_device_name_check function"""
+
+    def setUp(self):
+        """Set up test data"""
+        self.implanted_devices = ["Device1", "Device2", "Device3"]
+
+    def test_valid_implanted_device_name(self):
+        """Test valid implanted device name"""
+        obj = TestImplantedDevice(
+            implanted_device_name="Device1",
+        )
+        recursive_device_name_check(obj, self.implanted_devices)
+
+    def test_invalid_implanted_device_name(self):
+        """Test invalid implanted device name"""
+        obj = TestImplantedDevice(
+            implanted_device_name="InvalidDevice",
+        )
+        with self.assertRaises(ValueError) as context:
+            recursive_device_name_check(obj, self.implanted_devices)
+        self.assertIn("implanted_device_name InvalidDevice not found in implanted_devices", str(context.exception))
+
+    def test_valid_implanted_device_names(self):
+        """Test valid implanted device names"""
+        obj = TestImplantedDeviceNames(
+            implanted_device_names=["Device1", "Device2"],
+        )
+        recursive_device_name_check(obj, self.implanted_devices)
+
+    def test_invalid_implanted_device_names(self):
+        """Test invalid implanted device names"""
+        obj = TestImplantedDeviceNames(
+            implanted_device_names=["Device1", "InvalidDevice"],
+        )
+        with self.assertRaises(ValueError) as context:
+            recursive_device_name_check(obj, self.implanted_devices)
+        self.assertIn(
+            "implanted_device_names ['InvalidDevice'] not found in implanted_devices",
+            str(context.exception),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_utils_validators.py
+++ b/tests/test_utils_validators.py
@@ -18,7 +18,6 @@ from pydantic import BaseModel
 from aind_data_schema.components.coordinates import Coordinate
 from aind_data_schema.components.wrappers import AssetPath
 from pathlib import Path
-from pydantic import BaseModel
 
 
 class TestCompatibilityCheck(unittest.TestCase):
@@ -391,11 +390,13 @@ class TestRecursiveCheckPaths(unittest.TestCase):
 
 class TestImplantedDevice(BaseModel):
     """Test class with implanted_device_name"""
+
     implanted_device_name: str
 
 
 class TestImplantedDeviceNames(BaseModel):
     """Test class with implanted_device_names"""
+
     implanted_device_names: list[str]
 
 


### PR DESCRIPTION
This PR makes it possible to create new `Connection` objects in an acquisition. This is useful for fiber, where day-to-day the fibers might be connected in different patterns or not connected at all. Since this PR impacts implant devices I'm also making that change here, so `Procedures.implanted_devices` is now the location where you put an ephys or fiber probe, and you refer to that object by name in the corresponding implant procedure.

Other changes:
- Noticed that LickSpoutAssembly was missing it's `name` field, causing problems for one of the new device name validators
- Moved a bunch of Reagant subclasses into the reagent.py file, should have done that a while ago.
- Moved some validators up to Metadata where we now have to ensure that devices listed in `DataStream.active_devices` are *either* in instrument or in procedures
- `ProbeImplant` replaces `OphysProbe` and `FiberImplant` and the missing chronic Neuropixels implant procedure. All three now require you to place your device in the `implanted_devices` list and then reference by name.