### PR TITLE
feat: adding CurationMetric to QCEvaluation.metrics options

### DIFF
--- a/src/aind_data_schema/core/quality_control.py
+++ b/src/aind_data_schema/core/quality_control.py
@@ -84,6 +84,7 @@ class CurationMetric(QCMetric):
     """Description of a curation metric"""
 
     value: List[Any] = Field(..., title="Curation value")
+    type: str = Field(..., title="Curation type")
     curation_history: List[CurationHistory] = Field(default=[], title="Curation history")
 
 

--- a/src/aind_data_schema/core/quality_control.py
+++ b/src/aind_data_schema/core/quality_control.py
@@ -2,12 +2,13 @@
 
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, List, Literal, Optional, Union
+from typing import Any, List, Literal, Optional, Union, Annotated
 
 from aind_data_schema_models.modalities import Modality
 from pydantic import BaseModel, Field, SkipValidation, field_validator, model_validator
 
 from aind_data_schema.base import AwareDatetimeWithDefault, DataCoreModel, DataModel
+from aind_data_schema.components.identifiers import Person
 from aind_data_schema.utils.merge import merge_notes
 
 
@@ -72,6 +73,20 @@ class QCMetric(BaseModel):
         return v
 
 
+class CurationHistory(BaseModel):
+    """Schema to track curator name and timestamp for curation events"""
+
+    curator: Person = Field(..., title="Curator")
+    timestamp: datetime = Field(..., title="Timestamp")
+
+
+class CurationMetric(QCMetric):
+    """Description of a curation metric"""
+
+    value: List[Any] = Field(..., title="Curation value")
+    curation_history: List[CurationHistory] = Field(default=[], title="Curation history")
+
+
 class QCEvaluation(DataModel):
     """Description of one evaluation stage, with one or more metrics"""
 
@@ -79,7 +94,7 @@ class QCEvaluation(DataModel):
     stage: Stage = Field(..., title="Evaluation stage")
     name: str = Field(..., title="Evaluation name")
     description: Optional[str] = Field(default=None, title="Evaluation description")
-    metrics: List[QCMetric] = Field(..., title="QC metrics")
+    metrics: List[Annotated[Union[QCMetric, CurationMetric], Field(discriminator="object_type")]] = Field(..., title="QC and curation metrics")
     tags: Optional[List[str]] = Field(
         default=None, title="Tags", description="Tags can be used to group QCEvaluation objects into groups"
     )


### PR DESCRIPTION
This PR adds the classes `CurationMetric` and `CurationHistory` to the QC concepts. This adds support for curations in aind-data-schema without needing to use the CurationMetric object from https://github.com/AllenNeuralDynamics/aind-qcportal-schema/blob/dev/src/aind_qcportal_schema/metric_value.py

CurationMetric objects still take arbitrary `value` types. Typically the value will be some kind of dictionary mapping units/neurons/etc to their curation status.

Panels in the QC Portal can parse the `type` field to determine what tool will get shown to the user for a particular curation.

This change should help support curations which seem to be important in a number of places (spike sorting, ophys, neuron tracing, etc)