### PR TITLE
Simplify types by defining Annotated Field with discriminator in base

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 dynamic = ["version"]
 
 dependencies = [
-    'aind-data-schema-models>=2.7',
+    'aind-data-schema-models>=2.7, <3.0',
     'dictdiffer',
     'pydantic>=2.7',
     'inflection',

--- a/src/aind_data_schema/base.py
+++ b/src/aind_data_schema/base.py
@@ -96,7 +96,8 @@ class GenericModel(BaseModel, extra="allow"):
 
 
 T = TypeVar("T")
-DiscriminatedList = List[Annotated[T, Field(discriminator="object_type")]]
+Discriminated = Annotated[T, Field(discriminator="object_type")]
+DiscriminatedList = List[Discriminated[T]]
 
 
 class DataModel(BaseModel):

--- a/src/aind_data_schema/base.py
+++ b/src/aind_data_schema/base.py
@@ -5,7 +5,7 @@ import logging
 import warnings
 import re
 from pathlib import Path
-from typing import Any, ClassVar, Generic, Literal, Optional, TypeVar, get_args
+from typing import Any, ClassVar, Generic, Literal, Optional, TypeVar, get_args, List
 
 from pydantic import (
     AwareDatetime,
@@ -96,6 +96,9 @@ class GenericModel(BaseModel, extra="allow"):
 
 
 GenericModelType = TypeVar("GenericModelType", bound=GenericModel)
+
+T = TypeVar("T")
+DiscriminatedList = List[Annotated[T, Field(discriminator="object_type")]]
 
 
 class DataModel(BaseModel, Generic[GenericModelType]):

--- a/src/aind_data_schema/base.py
+++ b/src/aind_data_schema/base.py
@@ -5,7 +5,7 @@ import logging
 import warnings
 import re
 from pathlib import Path
-from typing import Any, ClassVar, Generic, Literal, Optional, TypeVar, get_args, List
+from typing import Any, ClassVar, Literal, Optional, TypeVar, get_args, List
 
 from pydantic import (
     AwareDatetime,
@@ -95,13 +95,11 @@ class GenericModel(BaseModel, extra="allow"):
         return self
 
 
-GenericModelType = TypeVar("GenericModelType", bound=GenericModel)
-
 T = TypeVar("T")
 DiscriminatedList = List[Annotated[T, Field(discriminator="object_type")]]
 
 
-class DataModel(BaseModel, Generic[GenericModelType]):
+class DataModel(BaseModel):
     """BaseModel that disallows extra fields
 
     Also performs validation checks / coercion / upgrades where necessary

--- a/src/aind_data_schema/components/acquisition_configs.py
+++ b/src/aind_data_schema/components/acquisition_configs.py
@@ -21,7 +21,7 @@ from aind_data_schema_models.units import (
 from pydantic import Field, field_validator, model_validator
 from pydantic_core.core_schema import ValidationInfo
 
-from aind_data_schema.base import DataModel, GenericModelType
+from aind_data_schema.base import DataModel, GenericModel
 from aind_data_schema.components.coordinates import Coordinate, CoordinateSystem, Scale, Transform
 from aind_data_schema.components.tile import AcquisitionTile, Channel
 from aind_data_schema.components.identifiers import Code
@@ -381,7 +381,7 @@ class MRIScan(DeviceConfig):
             ProcessName.SKULL_STRIPPING,
         ]
     ] = Field([])
-    additional_scan_parameters: GenericModelType = Field(..., title="Parameters")
+    additional_scan_parameters: GenericModel = Field(..., title="Parameters")
     notes: Optional[str] = Field(default=None, title="Notes", validate_default=True)
 
     @field_validator("notes", mode="after")

--- a/src/aind_data_schema/components/coordinates.py
+++ b/src/aind_data_schema/components/coordinates.py
@@ -7,7 +7,6 @@ from aind_data_schema_models.atlas import AtlasName
 from aind_data_schema_models.coordinates import AxisName, Direction, Origin
 from aind_data_schema_models.units import AngleUnit, SizeUnit
 from pydantic import Field
-from typing_extensions import Annotated
 
 from aind_data_schema.base import DataModel, DiscriminatedList
 from aind_data_schema.components.wrappers import AssetPath
@@ -217,9 +216,7 @@ class Transform(DataModel):
     system_name: str = Field(
         ..., title="Coordinate system name"
     )  # note: this field's exact name is used by a validator
-    transforms: DiscriminatedList[Translation | Rotation | Scale | Affine] = (
-        Field(..., title="Transform")
-    )
+    transforms: DiscriminatedList[Translation | Rotation | Scale | Affine] = Field(..., title="Transform")
 
 
 class CoordinateTransform(DataModel):
@@ -227,12 +224,9 @@ class CoordinateTransform(DataModel):
 
     input: str = Field(..., title="Input coordinate system")
     output: str = Field(..., title="Output coordinate system")
-    transforms: List[
-        Annotated[
-            Union[Translation, Rotation, Scale, Affine, NonlinearTransform],
-            Field(discriminator="object_type"),
-        ]
-    ] = Field(..., title="Transform")
+    transforms: DiscriminatedList[Translation | Rotation | Scale | Affine | NonlinearTransform] = Field(
+        ..., title="Transform"
+    )
 
 
 class Coordinate(DataModel):

--- a/src/aind_data_schema/components/coordinates.py
+++ b/src/aind_data_schema/components/coordinates.py
@@ -9,7 +9,7 @@ from aind_data_schema_models.units import AngleUnit, SizeUnit
 from pydantic import Field
 from typing_extensions import Annotated
 
-from aind_data_schema.base import DataModel
+from aind_data_schema.base import DataModel, DiscriminatedList
 from aind_data_schema.components.wrappers import AssetPath
 
 
@@ -217,7 +217,7 @@ class Transform(DataModel):
     system_name: str = Field(
         ..., title="Coordinate system name"
     )  # note: this field's exact name is used by a validator
-    transforms: List[Annotated[Union[Translation, Rotation, Scale, Affine], Field(discriminator="object_type")]] = (
+    transforms: DiscriminatedList[Translation | Rotation | Scale | Affine] = (
         Field(..., title="Transform")
     )
 

--- a/src/aind_data_schema/components/devices.py
+++ b/src/aind_data_schema/components/devices.py
@@ -42,7 +42,7 @@ from aind_data_schema_models.mouse_anatomy import MouseAnatomyModel
 from pydantic import Field, ValidationInfo, field_validator, model_validator
 from typing_extensions import Annotated
 
-from aind_data_schema.base import DataModel, GenericModel
+from aind_data_schema.base import DataModel, GenericModel, Discriminated
 from aind_data_schema.components.coordinates import AxisName, Scale, Coordinate
 from aind_data_schema.components.identifiers import Software
 
@@ -300,7 +300,7 @@ class LightAssembly(DataModel):
 
     # required fields
     name: str = Field(..., title="Light assembly name")
-    light: Annotated[Union[Laser, LightEmittingDiode, Lamp], Field(discriminator="object_type")]
+    light: Discriminated[Laser | LightEmittingDiode | Lamp]
     lens: Lens = Field(..., title="Lens")
 
     # optional fields
@@ -324,8 +324,8 @@ class NeuropixelsBasestation(DAQDevice):
     ports: List[ProbePort] = Field(..., title="Basestation ports")
 
     # fixed values
-    data_interface: Literal[DataInterface.PXI] = DataInterface.PXI
-    manufacturer: Annotated[Union[type(Organization.IMEC)], Field(default=Organization.IMEC, discriminator="name")]
+    data_interface: DataInterface = DataInterface.PXI
+    manufacturer: Organization.DAQ_DEVICE_MANUFACTURERS = Organization.IMEC
 
 
 class OpenEphysAcquisitionBoard(DAQDevice):
@@ -599,9 +599,8 @@ class Olfactometer(HarpDevice):
     """Description of an olfactometer for odor stimuli"""
 
     manufacturer: Organization.DAQ_DEVICE_MANUFACTURERS = Field(default=Organization.CHAMPALIMAUD)
-    harp_device_type: Annotated[
-        Union[type(HarpDeviceType.OLFACTOMETER)], Field(default=HarpDeviceType.OLFACTOMETER, discriminator="name")
-    ]
+    
+    harp_device_type: HarpDeviceType.ONE_OF = Field(HarpDeviceType.OLFACTOMETER, frozen=True, title="Type of Harp device")
     channels: List[OlfactometerChannel]
 
 

--- a/src/aind_data_schema/components/devices.py
+++ b/src/aind_data_schema/components/devices.py
@@ -599,8 +599,10 @@ class Olfactometer(HarpDevice):
     """Description of an olfactometer for odor stimuli"""
 
     manufacturer: Organization.DAQ_DEVICE_MANUFACTURERS = Field(default=Organization.CHAMPALIMAUD)
-    
-    harp_device_type: HarpDeviceType.ONE_OF = Field(HarpDeviceType.OLFACTOMETER, frozen=True, title="Type of Harp device")
+
+    harp_device_type: HarpDeviceType.ONE_OF = Field(
+        HarpDeviceType.OLFACTOMETER, frozen=True, title="Type of Harp device"
+    )
     channels: List[OlfactometerChannel]
 
 

--- a/src/aind_data_schema/components/devices.py
+++ b/src/aind_data_schema/components/devices.py
@@ -42,7 +42,7 @@ from aind_data_schema_models.mouse_anatomy import MouseAnatomyModel
 from pydantic import Field, ValidationInfo, field_validator, model_validator
 from typing_extensions import Annotated
 
-from aind_data_schema.base import DataModel, GenericModelType
+from aind_data_schema.base import DataModel, GenericModel
 from aind_data_schema.components.coordinates import AxisName, Scale, Coordinate
 from aind_data_schema.components.identifiers import Software
 
@@ -56,7 +56,7 @@ class Device(DataModel):
     model: Optional[str] = Field(default=None, title="Model")
 
     # Additional fields
-    additional_settings: Optional[GenericModelType] = Field(default=None, title="Additional parameters")
+    additional_settings: Optional[GenericModel] = Field(default=None, title="Additional parameters")
     notes: Optional[str] = Field(default=None, title="Notes")
 
 

--- a/src/aind_data_schema/components/devices.py
+++ b/src/aind_data_schema/components/devices.py
@@ -3,7 +3,7 @@
 from datetime import date
 from decimal import Decimal
 from enum import Enum
-from typing import List, Literal, Optional, Union
+from typing import List, Literal, Optional
 
 from aind_data_schema_models.coordinates import AnatomicalRelative
 from aind_data_schema_models.devices import (
@@ -40,7 +40,6 @@ from aind_data_schema_models.units import (
 )
 from aind_data_schema_models.mouse_anatomy import MouseAnatomyModel
 from pydantic import Field, ValidationInfo, field_validator, model_validator
-from typing_extensions import Annotated
 
 from aind_data_schema.base import DataModel, GenericModel, Discriminated
 from aind_data_schema.components.coordinates import AxisName, Scale, Coordinate

--- a/src/aind_data_schema/components/identifiers.py
+++ b/src/aind_data_schema/components/identifiers.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Optional
 from aind_data_schema_models.registries import Registry, _Orcid
 from pydantic import Field
 
-from aind_data_schema.base import DataModel, GenericModelType, DiscriminatedList
+from aind_data_schema.base import DataModel, GenericModel, DiscriminatedList
 
 
 class ExternalPlatforms(str, Enum):
@@ -80,7 +80,7 @@ class Code(DataModel):
     input_data: Optional[DiscriminatedList[DataAsset | CombinedData]] = Field(
         default=None, title="Input data", description="Input data used in the code or script"
     )
-    parameters: Optional[GenericModelType] = Field(
+    parameters: Optional[GenericModel] = Field(
         default=None, title="Parameters", description="Parameters used in the code or script"
     )
 

--- a/src/aind_data_schema/components/identifiers.py
+++ b/src/aind_data_schema/components/identifiers.py
@@ -2,12 +2,12 @@
 
 from enum import Enum
 from pathlib import Path
-from typing import Annotated, Dict, List, Optional, Union
+from typing import Dict, List, Optional
 
 from aind_data_schema_models.registries import Registry, _Orcid
 from pydantic import Field
 
-from aind_data_schema.base import DataModel, GenericModelType
+from aind_data_schema.base import DataModel, GenericModelType, DiscriminatedList
 
 
 class ExternalPlatforms(str, Enum):
@@ -77,7 +77,7 @@ class Code(DataModel):
     language: Optional[str] = Field(default=None, title="Programming language", description="Programming language used")
     language_version: Optional[str] = Field(default=None, title="Programming language version")
 
-    input_data: Optional[List[Annotated[Union[DataAsset, CombinedData], Field(discriminator="object_type")]]] = Field(
+    input_data: Optional[DiscriminatedList[DataAsset | CombinedData]] = Field(
         default=None, title="Input data", description="Input data used in the code or script"
     )
     parameters: Optional[GenericModelType] = Field(

--- a/src/aind_data_schema/components/measurements.py
+++ b/src/aind_data_schema/components/measurements.py
@@ -1,10 +1,10 @@
 """Calibration data models"""
 
-from typing import Annotated, List, Literal, Optional, Union
+from typing import List, Literal, Optional
 
 from aind_data_schema_models.units import UNITS, PowerUnit, TimeUnit, VolumeUnit
 
-from aind_data_schema.base import AwareDatetimeWithDefault, Field
+from aind_data_schema.base import AwareDatetimeWithDefault, Discriminated, Field
 from aind_data_schema.components.acquisition_configs import DeviceConfig
 from aind_data_schema.components.reagent import Reagent
 
@@ -51,14 +51,7 @@ class LaserCalibration(Calibration):
     )
 
 
-CALIBRATIONS = Annotated[
-    Union[
-        Calibration,
-        LiquidCalibration,
-        LaserCalibration,
-    ],
-    Field(discriminator="object_type"),
-]
+CALIBRATIONS = Discriminated[Calibration | LiquidCalibration | LaserCalibration]
 
 
 class Maintenance(DeviceConfig):

--- a/src/aind_data_schema/components/stimulus.py
+++ b/src/aind_data_schema/components/stimulus.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 from aind_data_schema_models.units import ConcentrationUnit, FrequencyUnit, PowerUnit, TimeUnit
 from pydantic import Field, model_validator
 
-from aind_data_schema.base import DataModel, GenericModel, GenericModelType
+from aind_data_schema.base import DataModel, GenericModel, GenericModel
 
 
 class PulseShape(str, Enum):
@@ -48,7 +48,7 @@ class OptoStimulation(GenericModel):
         description="Duration of baseline recording prior to first pulse train",
     )
     baseline_duration_unit: TimeUnit = Field(default=TimeUnit.S, title="Baseline duration unit")
-    other_parameters: GenericModelType = Field(GenericModel(), title="Other parameters")
+    other_parameters: GenericModel = Field(GenericModel(), title="Other parameters")
     notes: Optional[str] = Field(default=None, title="Notes")
 
 
@@ -56,7 +56,7 @@ class VisualStimulation(GenericModel):
     """Description of visual stimulus parameters. Provides a high level description of stimulus."""
 
     stimulus_name: str = Field(..., title="Stimulus name")
-    stimulus_parameters: GenericModelType = Field(
+    stimulus_parameters: GenericModel = Field(
         GenericModel(),
         title="Stimulus parameters",
         description="Define and list the parameter values used (e.g. all TF or orientation values)",
@@ -82,7 +82,7 @@ class PhotoStimulationGroup(DataModel):
     spiral_duration_unit: TimeUnit = Field(default=TimeUnit.S, title="Spiral duration unit")
     inter_spiral_interval: Decimal = Field(..., title="Inter trial interval (s)")
     inter_spiral_interval_unit: TimeUnit = Field(default=TimeUnit.S, title="Inter trial interval unit")
-    other_parameters: GenericModelType = Field(GenericModel(), title="Other parameters")
+    other_parameters: GenericModel = Field(GenericModel(), title="Other parameters")
     notes: Optional[str] = Field(default=None, title="Notes")
 
 
@@ -94,7 +94,7 @@ class PhotoStimulation(GenericModel):
     groups: List[PhotoStimulationGroup] = Field(..., title="Groups")
     inter_trial_interval: Decimal = Field(..., title="Inter trial interval (s)")
     inter_trial_interval_unit: TimeUnit = Field(default=TimeUnit.S, title="Inter trial interval unit")
-    other_parameters: GenericModelType = Field(GenericModel(), title="Other parameters")
+    other_parameters: GenericModel = Field(GenericModel(), title="Other parameters")
     notes: Optional[str] = Field(default=None, title="Notes")
 
 

--- a/src/aind_data_schema/components/stimulus.py
+++ b/src/aind_data_schema/components/stimulus.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 from aind_data_schema_models.units import ConcentrationUnit, FrequencyUnit, PowerUnit, TimeUnit
 from pydantic import Field, model_validator
 
-from aind_data_schema.base import DataModel, GenericModel, GenericModel
+from aind_data_schema.base import DataModel, GenericModel
 
 
 class PulseShape(str, Enum):

--- a/src/aind_data_schema/core/acquisition.py
+++ b/src/aind_data_schema/core/acquisition.py
@@ -13,7 +13,6 @@ from aind_data_schema.base import (
     DataModel,
     DiscriminatedList,
     GenericModel,
-    GenericModel,
 )
 from aind_data_schema.components.acquisition_configs import (
     AirPuffConfig,

--- a/src/aind_data_schema/core/acquisition.py
+++ b/src/aind_data_schema/core/acquisition.py
@@ -1,13 +1,20 @@
-""" schema describing imaging acquisition """
+"""schema describing imaging acquisition"""
 
 from decimal import Decimal
-from typing import Annotated, List, Literal, Optional, Union
+from typing import List, Literal, Optional
 
 from aind_data_schema_models.modalities import Modality
 from aind_data_schema_models.units import MassUnit, VolumeUnit
 from pydantic import Field, SkipValidation, model_validator
 
-from aind_data_schema.base import AwareDatetimeWithDefault, DataCoreModel, DataModel, GenericModel, GenericModel
+from aind_data_schema.base import (
+    AwareDatetimeWithDefault,
+    DataCoreModel,
+    DataModel,
+    DiscriminatedList,
+    GenericModel,
+    GenericModel,
+)
 from aind_data_schema.components.acquisition_configs import (
     AirPuffConfig,
     DetectorConfig,
@@ -109,26 +116,21 @@ class DataStream(DataModel):
         description="Device names must match devices in the Instrument",
     )
 
-    configurations: List[
-        Annotated[
-            Union[
-                LightEmittingDiodeConfig,
-                LaserConfig,
-                ManipulatorConfig,
-                DomeModule,
-                DetectorConfig,
-                PatchCordConfig,
-                FiberAssemblyConfig,
-                FieldOfView,
-                SlapFieldOfView,
-                Stack,
-                MRIScan,
-                InVitroImagingConfig,
-                LickSpoutConfig,
-                AirPuffConfig,
-            ],
-            Field(discriminator="object_type"),
-        ]
+    configurations: DiscriminatedList[
+        LightEmittingDiodeConfig
+        | LaserConfig
+        | ManipulatorConfig
+        | DomeModule
+        | DetectorConfig
+        | PatchCordConfig
+        | FiberAssemblyConfig
+        | FieldOfView
+        | SlapFieldOfView
+        | Stack
+        | MRIScan
+        | InVitroImagingConfig
+        | LickSpoutConfig
+        | AirPuffConfig
     ] = Field(..., title="Device configurations")
 
     connections: List[Connection] = Field(
@@ -190,17 +192,9 @@ class StimulusEpoch(DataModel):
         description="Device names must match devices in the Instrument",
     )
 
-    configurations: List[
-        Annotated[
-            Union[
-                SpeakerConfig,
-                LightEmittingDiodeConfig,
-                LaserConfig,
-                MousePlatformConfig,
-            ],
-            Field(discriminator="object_type"),
-        ]
-    ] = Field(default=[], title="Device configurations")
+    configurations: DiscriminatedList[SpeakerConfig | LightEmittingDiodeConfig | LaserConfig | MousePlatformConfig] = (
+        Field(default=[], title="Device configurations")
+    )
 
 
 class Acquisition(DataCoreModel):

--- a/src/aind_data_schema/core/acquisition.py
+++ b/src/aind_data_schema/core/acquisition.py
@@ -7,7 +7,7 @@ from aind_data_schema_models.modalities import Modality
 from aind_data_schema_models.units import MassUnit, VolumeUnit
 from pydantic import Field, SkipValidation, model_validator
 
-from aind_data_schema.base import AwareDatetimeWithDefault, DataCoreModel, DataModel, GenericModel, GenericModelType
+from aind_data_schema.base import AwareDatetimeWithDefault, DataCoreModel, DataModel, GenericModel, GenericModel
 from aind_data_schema.components.acquisition_configs import (
     AirPuffConfig,
     DetectorConfig,
@@ -84,7 +84,7 @@ class AcquisitionSubjectDetails(DataModel):
 class PerformanceMetrics(DataModel):
     """Summary of a StimulusEpoch"""
 
-    output_parameters: GenericModelType = Field(default=GenericModel(), title="Additional metrics")
+    output_parameters: GenericModel = Field(default=GenericModel(), title="Additional metrics")
     reward_consumed_during_epoch: Optional[Decimal] = Field(default=None, title="Reward consumed during training (uL)")
     reward_consumed_unit: Optional[VolumeUnit] = Field(default=None, title="Reward consumed unit")
     trials_total: Optional[int] = Field(default=None, title="Total trials")

--- a/src/aind_data_schema/core/instrument.py
+++ b/src/aind_data_schema/core/instrument.py
@@ -2,14 +2,13 @@
 
 from datetime import date
 from enum import Enum
-from typing import Dict, List, Literal, Optional, Union
+from typing import Dict, List, Literal, Optional
 
 from aind_data_schema_models.modalities import Modality
 from aind_data_schema_models.organizations import Organization
 from pydantic import Field, SkipValidation, ValidationInfo, field_validator, model_validator
-from typing_extensions import Annotated
 
-from aind_data_schema.base import DataCoreModel, DataModel
+from aind_data_schema.base import DataCoreModel, DataModel, DiscriminatedList
 from aind_data_schema.components.coordinates import CoordinateSystem
 from aind_data_schema.components.devices import (
     AdditionalImagingDevice,
@@ -130,49 +129,44 @@ class Instrument(DataCoreModel):
         description="List of all connections between devices in the instrument",
     )
 
-    components: List[
-        Annotated[
-            Union[
-                Monitor,
-                Olfactometer,
-                LickSpout,
-                LickSpoutAssembly,
-                AirPuffDevice,
-                Speaker,
-                CameraAssembly,
-                Enclosure,
-                EphysAssembly,
-                FiberAssembly,
-                LaserAssembly,
-                FiberPatchCord,
-                Laser,
-                LightEmittingDiode,
-                Lamp,
-                Detector,
-                Objective,
-                Scanner,
-                Filter,
-                Lens,
-                DigitalMicromirrorDevice,
-                PolygonalScanner,
-                PockelsCell,
-                HarpDevice,
-                NeuropixelsBasestation,
-                OpenEphysAcquisitionBoard,
-                MotorizedStage,
-                ScanningStage,
-                AdditionalImagingDevice,
-                Disc,
-                Wheel,
-                Tube,
-                Treadmill,
-                Arena,
-                DAQDevice,
-                Computer,
-                Device,
-            ],
-            Field(discriminator="object_type"),
-        ]
+    components: DiscriminatedList[
+        Monitor
+        | Olfactometer
+        | LickSpout
+        | LickSpoutAssembly
+        | AirPuffDevice
+        | Speaker
+        | CameraAssembly
+        | Enclosure
+        | EphysAssembly
+        | FiberAssembly
+        | LaserAssembly
+        | FiberPatchCord
+        | Laser
+        | LightEmittingDiode
+        | Lamp
+        | Detector
+        | Objective
+        | Scanner
+        | Filter
+        | Lens
+        | DigitalMicromirrorDevice
+        | PolygonalScanner
+        | PockelsCell
+        | HarpDevice
+        | NeuropixelsBasestation
+        | OpenEphysAcquisitionBoard
+        | MotorizedStage
+        | ScanningStage
+        | AdditionalImagingDevice
+        | Disc
+        | Wheel
+        | Tube
+        | Treadmill
+        | Arena
+        | DAQDevice
+        | Computer
+        | Device
     ] = Field(
         ...,
         title="Components",

--- a/src/aind_data_schema/core/model.py
+++ b/src/aind_data_schema/core/model.py
@@ -1,11 +1,11 @@
 """schema describing an analysis model"""
 
-from typing import Annotated, Any, List, Literal, Optional, Union
+from typing import Any, List, Literal, Optional
 
 from aind_data_schema_models.system_architecture import ModelArchitecture
 from pydantic import Field
 
-from aind_data_schema.base import DataCoreModel, DataModel, GenericModel, GenericModelType
+from aind_data_schema.base import DataCoreModel, DataModel, GenericModel, GenericModelType, DiscriminatedList
 from aind_data_schema.components.identifiers import Code, Software
 from aind_data_schema.core.processing import DataProcess, ProcessName
 
@@ -66,7 +66,7 @@ class Model(DataCoreModel):
     )
     intended_use: str = Field(..., title="Intended model use", description="Semantic description of intended use")
     limitations: Optional[str] = Field(default=None, title="Model limitations")
-    training: List[Annotated[Union[ModelTraining, ModelPretraining], Field(discriminator="object_type")]] = Field(
+    training: DiscriminatedList[ModelTraining | ModelPretraining] = Field(
         ..., title="Training", min_length=1
     )
     evaluations: List[ModelEvaluation] = Field(default=[], title="Evaluations")

--- a/src/aind_data_schema/core/model.py
+++ b/src/aind_data_schema/core/model.py
@@ -5,7 +5,7 @@ from typing import Any, List, Literal, Optional
 from aind_data_schema_models.system_architecture import ModelArchitecture
 from pydantic import Field
 
-from aind_data_schema.base import DataCoreModel, DataModel, GenericModel, GenericModelType, DiscriminatedList
+from aind_data_schema.base import DataCoreModel, DataModel, GenericModel, DiscriminatedList
 from aind_data_schema.components.identifiers import Code, Software
 from aind_data_schema.core.processing import DataProcess, ProcessName
 
@@ -59,7 +59,7 @@ class Model(DataCoreModel):
     )
     architecture: ModelArchitecture = Field(..., title="architecture", description="Model architecture / type of model")
     software_framework: Optional[Software] = Field(default=None, title="Software framework")
-    architecture_parameters: GenericModelType = Field(
+    architecture_parameters: GenericModel = Field(
         default=GenericModel(),
         title="Architecture parameters",
         description="Parameters of model architecture, such as input signature or number of layers.",

--- a/src/aind_data_schema/core/model.py
+++ b/src/aind_data_schema/core/model.py
@@ -66,8 +66,6 @@ class Model(DataCoreModel):
     )
     intended_use: str = Field(..., title="Intended model use", description="Semantic description of intended use")
     limitations: Optional[str] = Field(default=None, title="Model limitations")
-    training: DiscriminatedList[ModelTraining | ModelPretraining] = Field(
-        ..., title="Training", min_length=1
-    )
+    training: DiscriminatedList[ModelTraining | ModelPretraining] = Field(..., title="Training", min_length=1)
     evaluations: List[ModelEvaluation] = Field(default=[], title="Evaluations")
     notes: Optional[str] = Field(default=None, title="Notes")

--- a/src/aind_data_schema/core/procedures.py
+++ b/src/aind_data_schema/core/procedures.py
@@ -20,7 +20,6 @@ from aind_data_schema_models.units import (
     VolumeUnit,
 )
 from pydantic import Field, SkipValidation, field_validator, model_validator
-from typing_extensions import Annotated
 
 from aind_data_schema.base import AwareDatetimeWithDefault, DataCoreModel, DataModel, DiscriminatedList
 from aind_data_schema.components.coordinates import Coordinate, CoordinateSystem, Origin

--- a/src/aind_data_schema/core/procedures.py
+++ b/src/aind_data_schema/core/procedures.py
@@ -1,4 +1,4 @@
-""" schema for various Procedures """
+"""schema for various Procedures"""
 
 from datetime import date
 from decimal import Decimal
@@ -22,7 +22,7 @@ from aind_data_schema_models.units import (
 from pydantic import Field, SkipValidation, field_validator, model_validator
 from typing_extensions import Annotated
 
-from aind_data_schema.base import AwareDatetimeWithDefault, DataCoreModel, DataModel
+from aind_data_schema.base import AwareDatetimeWithDefault, DataCoreModel, DataModel, DiscriminatedList
 from aind_data_schema.components.coordinates import Coordinate, CoordinateSystem, Origin
 from aind_data_schema.components.devices import FiberProbe, MyomatrixArray
 from aind_data_schema.components.identifiers import Person
@@ -201,17 +201,7 @@ class SpecimenProcedure(DataModel):
     )
     protocol_id: Optional[List[str]] = Field(default=None, title="Protocol ID", description="DOI for protocols.io")
 
-    procedure_details: List[
-        Annotated[
-            Union[
-                HCRSeries,
-                Antibody,
-                PlanarSectioning,
-                Reagent,
-            ],
-            Field(discriminator="object_type"),
-        ]
-    ] = Field(
+    procedure_details: DiscriminatedList[HCRSeries | Antibody | PlanarSectioning | Reagent] = Field(
         default=[],
         title="Procedure details",
         description="",
@@ -426,9 +416,9 @@ class InjectionDynamics(DataModel):
 class Injection(DataModel):
     """Description of an injection procedure"""
 
-    injection_materials: List[
-        Annotated[Union[ViralMaterial, NonViralMaterial], Field(..., discriminator="material_type")]
-    ] = Field(..., title="Injection material", min_length=1)
+    injection_materials: DiscriminatedList[ViralMaterial | NonViralMaterial] = Field(
+        ..., title="Injection material", min_length=1
+    )
     targeted_structure: Optional[MouseAnatomyModel] = Field(
         default=None, title="Injection target", description="Use InjectionTargets"
     )
@@ -569,22 +559,17 @@ class Surgery(DataModel):
         description="Coordinates measured during the procedure, for example Bregma and Lambda",
     )
 
-    procedures: List[
-        Annotated[
-            Union[
-                CatheterImplant,
-                Craniotomy,
-                ProbeImplant,
-                Headframe,
-                BrainInjection,
-                Injection,
-                MyomatrixInsertion,
-                GenericSurgeryProcedure,
-                Perfusion,
-                SampleCollection,
-            ],
-            Field(discriminator="object_type"),
-        ]
+    procedures: DiscriminatedList[
+        CatheterImplant
+        | Craniotomy
+        | ProbeImplant
+        | Headframe
+        | BrainInjection
+        | Injection
+        | MyomatrixInsertion
+        | GenericSurgeryProcedure
+        | Perfusion
+        | SampleCollection
     ] = Field(title="Procedures", min_length=1)
     notes: Optional[str] = Field(default=None, title="Notes")
 
@@ -601,12 +586,9 @@ class Procedures(DataCoreModel):
         description="Unique identifier for the subject. If this is not a Allen LAS ID, indicate this in the Notes.",
         title="Subject ID",
     )
-    subject_procedures: List[
-        Annotated[
-            Union[Surgery, TrainingProtocol, WaterRestriction, GenericSubjectProcedure],
-            Field(discriminator="object_type"),
-        ]
-    ] = Field(default=[], title="Subject Procedures")
+    subject_procedures: DiscriminatedList[Surgery | TrainingProtocol | WaterRestriction | GenericSubjectProcedure] = (
+        Field(default=[], title="Subject Procedures")
+    )
     specimen_procedures: List[SpecimenProcedure] = Field(default=[], title="Specimen Procedures")
 
     # Implanted devices

--- a/src/aind_data_schema/core/processing.py
+++ b/src/aind_data_schema/core/processing.py
@@ -9,7 +9,7 @@ from aind_data_schema_models.process_names import ProcessName
 from aind_data_schema_models.units import MemoryUnit, UnitlessUnit
 from pydantic import Field, SkipValidation, ValidationInfo, field_validator, model_validator
 
-from aind_data_schema.base import AwareDatetimeWithDefault, DataCoreModel, DataModel, GenericModel, GenericModelType
+from aind_data_schema.base import AwareDatetimeWithDefault, DataCoreModel, DataModel, GenericModel
 from aind_data_schema.components.identifiers import Code, Person
 from aind_data_schema.components.wrappers import AssetPath
 from aind_data_schema.utils.merge import merge_notes, merge_optional_list
@@ -68,7 +68,7 @@ class DataProcess(DataModel):
     output_path: Optional[AssetPath] = Field(
         default=None, title="Output path", description="Path to processing outputs, if stored."
     )
-    output_parameters: GenericModelType = Field(
+    output_parameters: GenericModel = Field(
         default=GenericModel(), description="Output parameters", title="Outputs"
     )
     notes: Optional[str] = Field(default=None, title="Notes", validate_default=True)

--- a/src/aind_data_schema/core/processing.py
+++ b/src/aind_data_schema/core/processing.py
@@ -68,9 +68,7 @@ class DataProcess(DataModel):
     output_path: Optional[AssetPath] = Field(
         default=None, title="Output path", description="Path to processing outputs, if stored."
     )
-    output_parameters: GenericModel = Field(
-        default=GenericModel(), description="Output parameters", title="Outputs"
-    )
+    output_parameters: GenericModel = Field(default=GenericModel(), description="Output parameters", title="Outputs")
     notes: Optional[str] = Field(default=None, title="Notes", validate_default=True)
     resources: Optional[ResourceUsage] = Field(default=None, title="Process resource usage")
 

--- a/src/aind_data_schema/core/subject.py
+++ b/src/aind_data_schema/core/subject.py
@@ -1,10 +1,10 @@
 """ schema for mostly mouse metadata """
 
-from typing import Annotated, Literal, Optional, Union
+from typing import Literal, Optional
 
 from pydantic import Field, SkipValidation
 
-from aind_data_schema.base import DataCoreModel
+from aind_data_schema.base import DataCoreModel, Discriminated
 from aind_data_schema.components.subjects import HumanSubject, MouseSubject
 
 
@@ -20,12 +20,6 @@ class Subject(DataCoreModel):
         title="Subject ID",
     )
 
-    subject_details: Annotated[
-        Union[
-            MouseSubject,
-            HumanSubject,
-        ],
-        Field(discriminator="object_type"),
-    ] = Field(..., title="Subject Details")
+    subject_details: Discriminated[MouseSubject | HumanSubject] = Field(..., title="Subject Details")
 
     notes: Optional[str] = Field(default=None, title="Notes")


### PR DESCRIPTION
This is the simplification I mentioned to you - should be functionally equivalent I believe, and tests all run.
Defines `Discriminated = Annotated[T, Field(discriminator="object_type")]` and uses that to cut out a bunch of boilerplate