### PR TITLE
fix: allow uncontrolled strings as coordinate system origins

### DIFF
--- a/src/aind_data_schema/components/coordinates.py
+++ b/src/aind_data_schema/components/coordinates.py
@@ -198,7 +198,7 @@ class CoordinateSystem(DataModel):
 
     name: str = Field(..., title="Name")
 
-    origin: Origin = Field(..., title="Origin", description="Defines the position of (0,0,0) in the coordinate system")
+    origin: Origin | str = Field(..., title="Origin", description="Defines the position of (0,0,0) in the coordinate system")
     axes: List[Axis] = Field(..., title="Axis names", description="Axis names and directions")
     axis_unit: SizeUnit = Field(..., title="Size unit")
 

--- a/src/aind_data_schema/components/coordinates.py
+++ b/src/aind_data_schema/components/coordinates.py
@@ -198,7 +198,9 @@ class CoordinateSystem(DataModel):
 
     name: str = Field(..., title="Name")
 
-    origin: Origin | str = Field(..., title="Origin", description="Defines the position of (0,0,0) in the coordinate system")
+    origin: Origin | str = Field(
+        ..., title="Origin", description="Defines the position of (0,0,0) in the coordinate system"
+    )
     axes: List[Axis] = Field(..., title="Axis names", description="Axis names and directions")
     axis_unit: SizeUnit = Field(..., title="Size unit")
 


### PR DESCRIPTION
This PR allows users to use uncontrolled strings to describe the origin of a coordinate system. We strongly prefer that they give us a defined Origin from the enum, but we need this for other kinds of situations like blood vessels, etc.