### PR TITLE
refactor: remove material_type, redundant with object_type

### DIFF
--- a/docs/source/example_workflow/example_workflow.py
+++ b/docs/source/example_workflow/example_workflow.py
@@ -101,7 +101,6 @@ def generate_procedures(mouse: dict, proc_row: dict, coords: List[float]) -> Pro
                         protocol_id=protocol,
                         injection_materials=[
                             ViralMaterial(
-                                material_type="Virus",
                                 name=proc_row["virus_name"],
                                 titer=proc_row["virus_titer"],
                             )

--- a/examples/ophys_procedures.py
+++ b/examples/ophys_procedures.py
@@ -78,7 +78,6 @@ p = Procedures(
                     protocol_id="5678",
                     injection_materials=[
                         ViralMaterial(
-                            material_type="Virus",
                             name="AAV2/1-Syn-Flex-ChrimsonR-tdT",
                             addgene_id=PIDName(
                                 registry=Registry.ADDGENE,

--- a/examples/procedures.py
+++ b/examples/procedures.py
@@ -59,7 +59,6 @@ surgery1 = Surgery(
             protocol_id="5678",
             injection_materials=[
                 ViralMaterial(
-                    material_type="Virus",
                     name="AAV2-Flex-ChrimsonR",
                     tars_identifiers=TarsVirusIdentifiers(
                         virus_tars_id="AiV222",

--- a/src/aind_data_schema/core/procedures.py
+++ b/src/aind_data_schema/core/procedures.py
@@ -359,7 +359,6 @@ class TarsVirusIdentifiers(DataModel):
 class ViralMaterial(DataModel):
     """Description of viral material for injections"""
 
-    material_type: Literal["Virus"] = Field(default="Virus", title="Injection material type")
     name: str = Field(
         ...,
         title="Full genome name",
@@ -380,7 +379,6 @@ class ViralMaterial(DataModel):
 class NonViralMaterial(Reagent):
     """Description of a non-viral injection material"""
 
-    material_type: Literal["Reagent"] = Field(default="Reagent", title="Injection material type")
     concentration: Optional[float] = Field(
         default=None, title="Concentration", description="Must provide concentration unit"
     )

--- a/tests/test_procedures.py
+++ b/tests/test_procedures.py
@@ -174,7 +174,6 @@ class ProceduresTests(unittest.TestCase):
                             protocol_id="134",
                             injection_materials=[
                                 ViralMaterial(
-                                    material_type="Virus",
                                     name="AAV2-Flex-ChrimsonR",
                                     tars_identifiers=TarsVirusIdentifiers(
                                         virus_tars_id="AiV222",
@@ -200,7 +199,6 @@ class ProceduresTests(unittest.TestCase):
                             protocol_id="234",
                             injection_materials=[
                                 NonViralMaterial(
-                                    material_type="Reagent",
                                     name="drug_xyz",
                                     source=Organization.AI,
                                     lot_number="12345",
@@ -222,7 +220,6 @@ class ProceduresTests(unittest.TestCase):
                             coordinate_system_name="BREGMA_ARI",
                             injection_materials=[
                                 ViralMaterial(
-                                    material_type="Virus",
                                     name="AAV2-Flex-ChrimsonR",
                                     tars_identifiers=TarsVirusIdentifiers(
                                         virus_tars_id="AiV222",
@@ -377,7 +374,6 @@ class ProceduresTests(unittest.TestCase):
             ],
             injection_materials=[
                 ViralMaterial(
-                    material_type="Virus",
                     name="AAV2-Flex-ChrimsonR",
                     tars_identifiers=TarsVirusIdentifiers(
                         virus_tars_id="AiV222",
@@ -409,7 +405,6 @@ class ProceduresTests(unittest.TestCase):
                 ],
                 injection_materials=[
                     ViralMaterial(
-                        material_type="Virus",
                         name="AAV2-Flex-ChrimsonR",
                         tars_identifiers=TarsVirusIdentifiers(
                             virus_tars_id="AiV222",


### PR DESCRIPTION
PR removes the `material_type` field from Viral and NonViralMaterial. These fields are redundant with the `object_type` field that all objects now share.