### PR TITLE
feat: exploring how to add support for curriculums

### DIFF
--- a/src/aind_data_schema/components/subject_procedures.py
+++ b/src/aind_data_schema/components/subject_procedures.py
@@ -46,6 +46,11 @@ class TrainingProtocol(DataModel):
     protocol_id: Optional[str] = Field(default=None, title="Training protocol ID")
     start_date: date = Field(..., title="Training protocol start date")
     end_date: Optional[date] = Field(default=None, title="Training protocol end date")
+    curriculum_code: Optional[Code] = Field(
+        default=None,
+        title="Curriculum code",
+        description="Code describing the directed graph used for the training curriculum",
+    )
     notes: Optional[str] = Field(default=None, title="Notes")
 
 

--- a/src/aind_data_schema/components/subject_procedures.py
+++ b/src/aind_data_schema/components/subject_procedures.py
@@ -9,7 +9,7 @@ from pydantic import Field
 
 from aind_data_schema.base import DataModel, DiscriminatedList
 from aind_data_schema.components.coordinates import CoordinateSystem, Translation
-from aind_data_schema.components.identifiers import Person
+from aind_data_schema.components.identifiers import Person, Code
 from aind_data_schema.components.injection_procedures import Injection
 from aind_data_schema.components.surgery_procedures import (
     Anaesthetic,

--- a/src/aind_data_schema/core/acquisition.py
+++ b/src/aind_data_schema/core/acquisition.py
@@ -174,14 +174,26 @@ class StimulusEpoch(DataModel):
     performance_metrics: Optional[PerformanceMetrics] = Field(default=None, title="Performance metrics")
     notes: Optional[str] = Field(default=None, title="Notes")
 
+    # Devices and configurations
     active_devices: List[str] = Field(
         default=[],
         title="Active devices",
         description="Device names must match devices in the Instrument",
     )
-
     configurations: DiscriminatedList[SpeakerConfig | LightEmittingDiodeConfig | LaserConfig | MousePlatformConfig] = (
         Field(default=[], title="Device configurations")
+    )
+
+    # Training protocol
+    training_protocol_name: Optional[str] = Field(
+        default=None,
+        title="Training protocol name",
+        description="Name of the training protocol used during the acquisition, must match a protocol in the Procedures",
+    )
+    curriculum_status: Optional[str] = Field(
+        default=None,
+        title="Curriculum status",
+        description="Status within the training protocol curriculum",
     )
 
 

--- a/src/aind_data_schema/core/acquisition.py
+++ b/src/aind_data_schema/core/acquisition.py
@@ -188,7 +188,9 @@ class StimulusEpoch(DataModel):
     training_protocol_name: Optional[str] = Field(
         default=None,
         title="Training protocol name",
-        description="Name of the training protocol used during the acquisition, must match a protocol in the Procedures",
+        description=(
+            "Name of the training protocol used during the acquisition, " "must match a protocol in the Procedures"
+        ),
     )
     curriculum_status: Optional[str] = Field(
         default=None,

--- a/src/aind_data_schema/core/metadata.py
+++ b/src/aind_data_schema/core/metadata.py
@@ -262,7 +262,7 @@ class Metadata(DataCoreModel):
             for stimulus_epoch in self.acquisition.stimulus_epochs:
                 if stimulus_epoch.training_protocol_name:
                     if stimulus_epoch.training_protocol_name not in training_protocol_names:
-                        raise ValueError(
+                        warnings.warn(
                             f"Training protocol '{stimulus_epoch.training_protocol_name}' in StimulusEpoch "
                             f"not found in Procedures. Available protocols: {training_protocol_names}"
                         )

--- a/src/aind_data_schema/core/metadata.py
+++ b/src/aind_data_schema/core/metadata.py
@@ -25,6 +25,7 @@ from aind_data_schema.core.data_description import DataDescription
 from aind_data_schema.core.instrument import Instrument
 from aind_data_schema.core.model import Model
 from aind_data_schema.core.procedures import Injection, Procedures, Surgery
+from aind_data_schema.components.subject_procedures import TrainingProtocol
 from aind_data_schema.core.processing import Processing
 from aind_data_schema.core.quality_control import QualityControl
 from aind_data_schema.core.subject import Subject
@@ -242,6 +243,28 @@ class Metadata(DataCoreModel):
                     if not all(device in device_names for device in connection.device_names):
                         raise ValueError(
                             f"Connection '{connection}' contains devices not found in instrument or procedures."
+                        )
+
+        return self
+
+    @model_validator(mode="after")
+    def validate_training_protocol_references(self):
+        """Validate that training_protocol_name in StimulusEpoch matches a TrainingProtocol in procedures"""
+
+        if self.acquisition and self.procedures:
+            # Get all training protocol names from procedures
+            training_protocol_names = []
+            for procedure in self.procedures.subject_procedures:
+                if isinstance(procedure, TrainingProtocol):
+                    training_protocol_names.append(procedure.training_name)
+
+            # Check each stimulus epoch's training_protocol_name
+            for stimulus_epoch in self.acquisition.stimulus_epochs:
+                if stimulus_epoch.training_protocol_name:
+                    if stimulus_epoch.training_protocol_name not in training_protocol_names:
+                        raise ValueError(
+                            f"Training protocol '{stimulus_epoch.training_protocol_name}' in StimulusEpoch "
+                            f"not found in Procedures. Available protocols: {training_protocol_names}"
                         )
 
         return self

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -24,6 +24,8 @@ from aind_data_schema.core.processing import DataProcess, Processing, ProcessNam
 from aind_data_schema.core.subject import Subject
 from examples.aibs_smartspim_instrument import inst as spim_inst
 from examples.ephys_instrument import inst as ephys_inst
+from aind_data_schema.components.subject_procedures import TrainingProtocol
+from aind_data_schema.core.acquisition import StimulusEpoch
 
 EXAMPLES_DIR = Path(__file__).parents[1] / "examples"
 EPHYS_INST_JSON = EXAMPLES_DIR / "ephys_instrument.json"
@@ -424,6 +426,102 @@ class TestMetadata(unittest.TestCase):
             "in an individual procedure's implanted_device field.",
             str(context.exception),
         )
+
+    def test_validate_training_protocol_references(self):
+        """Tests that training protocol references are validated correctly."""
+
+        # Case where training protocol references match
+        training_protocol = TrainingProtocol.model_construct(training_name="Protocol A")
+        procedures = Procedures.model_construct(subject_procedures=[training_protocol])
+        stimulus_epoch = StimulusEpoch.model_construct(training_protocol_name="Protocol A")
+        acquisition = Acquisition.model_construct(
+            instrument_id="Test",
+            stimulus_epochs=[stimulus_epoch],
+            data_streams=[],
+            subject_details=AcquisitionSubjectDetails.model_construct(),
+        )
+
+        metadata = Metadata(
+            name="Test Metadata",
+            location="Test Location",
+            procedures=procedures,
+            acquisition=acquisition,
+        )
+        self.assertIsNotNone(metadata)
+
+        # Case where training protocol reference doesn't match
+        stimulus_epoch_invalid = StimulusEpoch.model_construct(training_protocol_name="Missing Protocol")
+        acquisition_invalid = Acquisition.model_construct(
+            instrument_id="Test",
+            stimulus_epochs=[stimulus_epoch_invalid],
+            data_streams=[],
+            subject_details=AcquisitionSubjectDetails.model_construct(),
+        )
+
+        with self.assertRaises(ValueError) as context:
+            Metadata(
+                name="Test Metadata",
+                location="Test Location",
+                procedures=procedures,
+                acquisition=acquisition_invalid,
+            )
+        self.assertIn(
+            (
+                "Training protocol 'Missing Protocol' in StimulusEpoch not found in Procedures."
+                " Available protocols: ['Protocol A']"
+            ),
+            str(context.exception),
+        )
+
+        # Case where no training protocols exist in procedures
+        procedures_empty = Procedures.model_construct(subject_procedures=[])
+        with self.assertRaises(ValueError) as context:
+            Metadata(
+                name="Test Metadata",
+                location="Test Location",
+                procedures=procedures_empty,
+                acquisition=acquisition_invalid,
+            )
+        self.assertIn(
+            (
+                "Training protocol 'Missing Protocol' in StimulusEpoch not found in Procedures. "
+                "Available protocols: []"
+            ),
+            str(context.exception),
+        )
+
+        # Case where stimulus epoch has no training protocol name (should pass)
+        stimulus_epoch_none = StimulusEpoch.model_construct(training_protocol_name=None)
+        acquisition_none = Acquisition.model_construct(
+            instrument_id="Test",
+            data_streams=[],
+            stimulus_epochs=[stimulus_epoch_none],
+            subject_details=AcquisitionSubjectDetails.model_construct(),
+        )
+
+        metadata_none = Metadata(
+            name="Test Metadata",
+            location="Test Location",
+            procedures=procedures,
+            acquisition=acquisition_none,
+        )
+        self.assertIsNotNone(metadata_none)
+
+        # Case where acquisition is None (should pass)
+        metadata_no_acquisition = Metadata(
+            name="Test Metadata",
+            location="Test Location",
+            procedures=procedures,
+        )
+        self.assertIsNotNone(metadata_no_acquisition)
+
+        # Case where procedures is None (should pass)
+        metadata_no_procedures = Metadata(
+            name="Test Metadata",
+            location="Test Location",
+            acquisition=acquisition,
+        )
+        self.assertIsNotNone(metadata_no_procedures)
 
 
 if __name__ == "__main__":

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -465,7 +465,7 @@ class TestMetadata(unittest.TestCase):
                 procedures=procedures,
                 acquisition=acquisition_invalid,
             )
-        
+
         warning_messages = [str(warning.message) for warning in w.warnings]
         self.assertIn(
             (
@@ -485,7 +485,7 @@ class TestMetadata(unittest.TestCase):
                 procedures=procedures_empty,
                 acquisition=acquisition_invalid,
             )
-        
+
         warning_messages = [str(warning.message) for warning in w.warnings]
         self.assertIn(
             (

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -458,37 +458,43 @@ class TestMetadata(unittest.TestCase):
             subject_details=AcquisitionSubjectDetails.model_construct(),
         )
 
-        with self.assertRaises(ValueError) as context:
-            Metadata(
+        with self.assertWarns(UserWarning) as w:
+            metadata = Metadata(
                 name="Test Metadata",
                 location="Test Location",
                 procedures=procedures,
                 acquisition=acquisition_invalid,
             )
+        
+        warning_messages = [str(warning.message) for warning in w.warnings]
         self.assertIn(
             (
                 "Training protocol 'Missing Protocol' in StimulusEpoch not found in Procedures."
                 " Available protocols: ['Protocol A']"
             ),
-            str(context.exception),
+            warning_messages,
         )
+        self.assertIsNotNone(metadata)
 
         # Case where no training protocols exist in procedures
         procedures_empty = Procedures.model_construct(subject_procedures=[])
-        with self.assertRaises(ValueError) as context:
-            Metadata(
+        with self.assertWarns(UserWarning) as w:
+            metadata = Metadata(
                 name="Test Metadata",
                 location="Test Location",
                 procedures=procedures_empty,
                 acquisition=acquisition_invalid,
             )
+        
+        warning_messages = [str(warning.message) for warning in w.warnings]
         self.assertIn(
             (
                 "Training protocol 'Missing Protocol' in StimulusEpoch not found in Procedures. "
                 "Available protocols: []"
             ),
-            str(context.exception),
+            warning_messages,
         )
+        self.assertIsNotNone(metadata)
 
         # Case where stimulus epoch has no training protocol name (should pass)
         stimulus_epoch_none = StimulusEpoch.model_construct(training_protocol_name=None)

--- a/tests/test_quality_control.py
+++ b/tests/test_quality_control.py
@@ -413,19 +413,22 @@ class QualityControlTests(unittest.TestCase):
         q = QualityControl(metrics=test_metrics, default_grouping=["test_group", "test_group2", "tag1"])
 
         # Check that the status field was built correctly
-        self.assertEqual(q.status, {
-            # Stages
-            "Processing": Status.PASS,
-            "Raw data": Status.FAIL,
-            # Modalities
-            "behavior": Status.FAIL,
-            "behavior-videos": Status.PENDING,
-            "ecephys": Status.PASS,
-            # Tags
-            "test_group": Status.PASS,
-            "test_group2": Status.FAIL,
-            "tag1": Status.PENDING,
-        })
+        self.assertEqual(
+            q.status,
+            {
+                # Stages
+                "Processing": Status.PASS,
+                "Raw data": Status.FAIL,
+                # Modalities
+                "behavior": Status.FAIL,
+                "behavior-videos": Status.PENDING,
+                "ecephys": Status.PASS,
+                # Tags
+                "test_group": Status.PASS,
+                "test_group2": Status.FAIL,
+                "tag1": Status.PENDING,
+            },
+        )
 
         self.assertEqual(q.evaluate_status(), Status.FAIL)
         self.assertEqual(q.evaluate_status(modality=Modality.BEHAVIOR), Status.FAIL)


### PR DESCRIPTION
PR adds curriculum support for training protocols:

- TrainingProtocol.curriculum_code: Code <- stores the actual code for the curriculum
- StimulusEpoch.training_protocol_name <- name pointing to the training protocol
- StimulusEpoch.curriculum_status <- uncontrolled string for users to put things like "Off curriculum", "Training Stage 1", etc