### PR TITLE
refactor: remove redundant file missing warning in validator

### DIFF
--- a/src/aind_data_schema/core/metadata.py
+++ b/src/aind_data_schema/core/metadata.py
@@ -136,17 +136,11 @@ class Metadata(DataCoreModel):
     def validate_expected_files_by_modality(self):
         """Validator warns users if required files are missing"""
 
-        validated = False
         for file in REQUIRED_FILE_SETS.keys():
             if getattr(self, file):
                 for file in REQUIRED_FILE_SETS[file]:
                     if not getattr(self, file):
                         warnings.warn(f"Metadata missing required file: {file}")
-                validated = True
-        if not validated:
-            warnings.warn(
-                f"Metadata must contain at least one of the following files: {list(REQUIRED_FILE_SETS.keys())}"
-            )
 
         return self
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -315,20 +315,6 @@ class TestMetadata(unittest.TestCase):
         self.assertIn("Metadata missing required file: instrument", warning_messages)
         self.assertIn("Metadata missing required file: acquisition", warning_messages)
 
-        # Test case where no required files exist
-        with self.assertWarns(UserWarning) as w:
-            Metadata(
-                name="655019_2023-04-03T181709",
-                location="bucket",
-                # No required files provided
-            )
-
-        warning_messages = [str(warning.message) for warning in w.warnings]
-        self.assertIn(
-            "Metadata must contain at least one of the following files: ['subject', 'processing', 'model']",
-            warning_messages,
-        )
-
     def test_validate_acquisition_connections(self):
         """Tests that acquisition connections are validated correctly."""
         # Case where all connection devices are present in instrument components


### PR DESCRIPTION
This PR reduces a redundant warning that a required file is missing, which was causing issues when invalid files were passed to `create_metadata_json`