### PR TITLE
refactor: soften time validation

### DIFF
--- a/src/aind_data_schema/components/subjects.py
+++ b/src/aind_data_schema/components/subjects.py
@@ -3,7 +3,7 @@
 from datetime import date as date_type
 from datetime import time
 from enum import Enum
-from typing import Annotated, List, Optional
+from typing import List, Optional
 
 from aind_data_schema_models.organizations import Organization
 from aind_data_schema_models.pid_names import PIDName
@@ -12,7 +12,6 @@ from pydantic import Field, field_validator, model_validator
 from pydantic_core.core_schema import ValidationInfo
 
 from aind_data_schema.base import DataModel
-from aind_data_schema.utils.validators import TimeValidation
 
 
 class Sex(str, Enum):
@@ -82,7 +81,7 @@ class MouseSubject(DataModel):
     """Description of a mouse subject"""
 
     sex: Sex = Field(..., title="Sex")
-    date_of_birth: Annotated[date_type, TimeValidation.BEFORE] = Field(..., title="Date of birth")
+    date_of_birth: date_type = Field(..., title="Date of birth")
     strain: Strain.ONE_OF = Field(..., title="Strain")
     species: Species.ONE_OF = Field(..., title="Species")
     alleles: List[PIDName] = Field(default=[], title="Alleles", description="Allele names and persistent IDs")

--- a/src/aind_data_schema/components/subjects.py
+++ b/src/aind_data_schema/components/subjects.py
@@ -3,7 +3,7 @@
 from datetime import date as date_type
 from datetime import time
 from enum import Enum
-from typing import List, Optional
+from typing import Annotated, List, Optional
 
 from aind_data_schema_models.organizations import Organization
 from aind_data_schema_models.pid_names import PIDName
@@ -13,6 +13,7 @@ from pydantic_core.core_schema import ValidationInfo
 
 from aind_data_schema.base import DataModel
 from aind_data_schema.components.devices import Device
+from aind_data_schema.utils.validators import TimeValidation
 
 
 class Sex(str, Enum):
@@ -82,7 +83,7 @@ class MouseSubject(DataModel):
     """Description of a mouse subject"""
 
     sex: Sex = Field(..., title="Sex")
-    date_of_birth: date_type = Field(..., title="Date of birth")
+    date_of_birth: Annotated[date_type, TimeValidation.BEFORE] = Field(..., title="Date of birth")
     strain: Strain.ONE_OF = Field(..., title="Strain")
     species: Species.ONE_OF = Field(..., title="Species")
     alleles: List[PIDName] = Field(default=[], title="Alleles", description="Allele names and persistent IDs")

--- a/src/aind_data_schema/core/metadata.py
+++ b/src/aind_data_schema/core/metadata.py
@@ -327,13 +327,13 @@ class Metadata(DataCoreModel):
                 if name_creation_time:
                     try:
                         validate_creation_time_after_midnight(name_creation_time, self.acquisition.acquisition_end_time)
-                    except ValueError as e:
-                        # Re-raise with more specific context for data_description.name
-                        raise ValueError(
+                    except ValueError:
+                        # Issue a warning instead of raising an error
+                        warnings.warn(
                             f"Creation time from data_description.name ({name_creation_time}) "
-                            f"must be on or after midnight of the acquisition day "
+                            f"should be on or after midnight of the acquisition day "
                             f"({self.acquisition.acquisition_end_time.date()})"
-                        ) from e
+                        )
 
         return self
 

--- a/src/aind_data_schema/core/metadata.py
+++ b/src/aind_data_schema/core/metadata.py
@@ -313,6 +313,12 @@ class Metadata(DataCoreModel):
                     acquisition_start_time=acquisition_start_time,
                     acquisition_end_time=acquisition_end_time,
                 )
+            if self.subject:
+                recursive_time_validation_check(
+                    self.subject,
+                    acquisition_start_time=acquisition_start_time,
+                    acquisition_end_time=acquisition_end_time,
+                )
             if self.instrument:
                 recursive_time_validation_check(
                     self.instrument,

--- a/src/aind_data_schema/core/metadata.py
+++ b/src/aind_data_schema/core/metadata.py
@@ -331,8 +331,8 @@ class Metadata(DataCoreModel):
                         # Issue a warning instead of raising an error
                         warnings.warn(
                             f"Creation time from data_description.name ({name_creation_time}) "
-                            f"should be on or after midnight of the acquisition day "
-                            f"({self.acquisition.acquisition_end_time.date()})"
+                            f"should be close to the acquisition end time "
+                            f"({self.acquisition.acquisition_end_time})"
                         )
 
         return self

--- a/src/aind_data_schema/core/metadata.py
+++ b/src/aind_data_schema/core/metadata.py
@@ -289,12 +289,6 @@ class Metadata(DataCoreModel):
                     acquisition_start_time=acquisition_start_time,
                     acquisition_end_time=acquisition_end_time,
                 )
-            if self.subject:
-                recursive_time_validation_check(
-                    self.subject,
-                    acquisition_start_time=acquisition_start_time,
-                    acquisition_end_time=acquisition_end_time,
-                )
             if self.instrument:
                 recursive_time_validation_check(
                     self.instrument,

--- a/src/aind_data_schema/utils/validators.py
+++ b/src/aind_data_schema/utils/validators.py
@@ -90,19 +90,19 @@ def recursive_time_validation_check(data, acquisition_start_time=None, acquisiti
     _time_validation_recurse_helper(data, acquisition_start_time, acquisition_end_time)
 
 
+def _convert_to_comparable(value, reference_datetime):
+    """Convert date to datetime using the timezone from reference, or return as-is if already datetime"""
+    if isinstance(value, date) and not isinstance(value, datetime):
+        # Convert date to datetime at midnight with same timezone as reference
+        return datetime.combine(value, datetime.min.time()).replace(tzinfo=reference_datetime.tzinfo)
+    return value
+
+
 def _validate_time_constraint(field_value, time_validation, start_time, end_time, field_name):
     """Validate a single time field against the specified constraint."""
 
-    # Handle conversion between date and datetime objects for comparison
-    def convert_to_comparable(value, reference_datetime):
-        """Convert date to datetime using the timezone from reference, or return as-is if already datetime"""
-        if isinstance(value, date) and not isinstance(value, datetime):
-            # Convert date to datetime at midnight with same timezone as reference
-            return datetime.combine(value, datetime.min.time()).replace(tzinfo=reference_datetime.tzinfo)
-        return value
-
     # Convert field_value to be comparable with start_time and end_time
-    comparable_field_value = convert_to_comparable(field_value, start_time)
+    comparable_field_value = _convert_to_comparable(field_value, start_time)
 
     if time_validation == TimeValidation.BETWEEN:
         if not (start_time <= comparable_field_value <= end_time):

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -624,7 +624,7 @@ class TestMetadata(unittest.TestCase):
             # Should have issued a warning
             self.assertEqual(len(warning_list), 1)
             self.assertIn("Creation time from data_description.name", str(warning_list[0].message))
-            self.assertIn("should be on or after midnight of the acquisition day", str(warning_list[0].message))
+            self.assertIn("should be close to the acquisition end time", str(warning_list[0].message))
 
         # Test case where data_description is None (should pass)
         metadata_no_data_desc = Metadata(
@@ -641,85 +641,6 @@ class TestMetadata(unittest.TestCase):
             data_description=data_description,
         )
         self.assertIsNotNone(metadata_no_acquisition)
-
-    def test_validate_time_constraints_subject(self):
-        """Tests that time constraints are validated for subject with date_of_birth"""
-
-        # Create acquisition with specific times
-        acquisition_start = datetime(2023, 4, 3, 18, 0, 0, tzinfo=timezone.utc)
-        acquisition_end = datetime(2023, 4, 3, 19, 0, 0, tzinfo=timezone.utc)
-
-        acquisition = Acquisition.model_construct(
-            instrument_id="Test",
-            acquisition_start_time=acquisition_start,
-            acquisition_end_time=acquisition_end,
-            data_streams=[],
-            subject_details=AcquisitionSubjectDetails.model_construct(),
-        )
-
-        # Test case where subject's date_of_birth is before acquisition (should pass)
-        valid_birth_date = datetime(2022, 1, 1, tzinfo=timezone.utc).date()
-        valid_subject = Subject(
-            subject_id="123456",
-            subject_details=MouseSubject(
-                species=Species.HOUSE_MOUSE,
-                strain=Strain.C57BL_6J,
-                sex=Sex.MALE,
-                date_of_birth=valid_birth_date,
-                source=Organization.AI,
-                genotype="wt",
-                breeding_info=BreedingInfo(
-                    breeding_group="Test",
-                    maternal_id="123",
-                    maternal_genotype="wt",
-                    paternal_id="456",
-                    paternal_genotype="wt",
-                ),
-                housing=Housing(cage_id="123"),
-            ),
-        )
-
-        # This should pass - birth date is before acquisition
-        metadata_valid_birth = Metadata(
-            name="Test Metadata",
-            location="Test Location",
-            subject=valid_subject,
-            acquisition=acquisition,
-        )
-        self.assertIsNotNone(metadata_valid_birth)
-
-        # Test case where subject's date_of_birth is after acquisition end (should fail)
-        invalid_birth_date = datetime(2023, 4, 4, tzinfo=timezone.utc).date()  # After acquisition
-        invalid_subject = Subject(
-            subject_id="123456",
-            subject_details=MouseSubject(
-                species=Species.HOUSE_MOUSE,
-                strain=Strain.C57BL_6J,
-                sex=Sex.MALE,
-                date_of_birth=invalid_birth_date,
-                source=Organization.AI,
-                genotype="wt",
-                breeding_info=BreedingInfo(
-                    breeding_group="Test",
-                    maternal_id="123",
-                    maternal_genotype="wt",
-                    paternal_id="456",
-                    paternal_genotype="wt",
-                ),
-                housing=Housing(cage_id="123"),
-            ),
-        )
-
-        # This should fail - birth date is after acquisition end
-        with self.assertRaises(ValueError) as context:
-            Metadata(
-                name="Test Metadata",
-                location="Test Location",
-                subject=invalid_subject,
-                acquisition=acquisition,
-            )
-        self.assertIn("must be before", str(context.exception))
-        self.assertIn("date_of_birth", str(context.exception))
 
     def test_validate_time_constraints_processing(self):
         """Tests that time constraints are validated for processing with start_date_time and end_date_time"""

--- a/tests/test_utils_validators.py
+++ b/tests/test_utils_validators.py
@@ -1,7 +1,7 @@
 """ Tests for compatibility check utilities """
 
 import unittest
-from datetime import datetime, timezone, timedelta
+from datetime import date, datetime, timezone, timedelta
 from enum import Enum
 from pathlib import Path
 from typing import Annotated
@@ -17,6 +17,7 @@ from aind_data_schema.utils.validators import (
     CoordinateSystemException,
     SystemNameException,
     TimeValidation,
+    _convert_to_comparable,
     _recurse_helper,
     _system_check_helper,
     _time_validation_recurse_helper,
@@ -681,6 +682,29 @@ class TestValidateCreationTimeAfterMidnight(unittest.TestCase):
         with self.assertRaises(ValueError) as context:
             validate_creation_time_after_midnight(creation_date, self.reference_time)
         self.assertIn("must be on or after midnight", str(context.exception))
+
+
+class TestConvertToComparable(unittest.TestCase):
+    """Tests for _convert_to_comparable function"""
+
+    def test_convert_date_to_datetime(self):
+        """Test converting date to datetime with timezone from reference"""
+        reference_time = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        test_date = date(2023, 1, 2)
+
+        result = _convert_to_comparable(test_date, reference_time)
+
+        expected = datetime(2023, 1, 2, 0, 0, 0, tzinfo=timezone.utc)
+        self.assertEqual(result, expected)
+
+    def test_return_datetime_unchanged(self):
+        """Test that datetime objects are returned unchanged"""
+        reference_time = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        test_datetime = datetime(2023, 1, 2, 10, 30, 0, tzinfo=timezone.utc)
+
+        result = _convert_to_comparable(test_datetime, reference_time)
+
+        self.assertEqual(result, test_datetime)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Reduce errors in data_description.name to just a warning
- Refactors the time validation code a bit to make it easier to test