### PR TITLE
refactor: flatten connection

### DIFF
--- a/examples/aibs_smartspim_instrument.py
+++ b/examples/aibs_smartspim_instrument.py
@@ -16,7 +16,7 @@ from aind_data_schema.components.devices import (
     Microscope,
 )
 from aind_data_schema_models.modalities import Modality
-from aind_data_schema.components.connections import Connection, ConnectionData, ConnectionDirection
+from aind_data_schema.components.connections import Connection
 from aind_data_schema.core.instrument import Instrument
 from aind_data_schema.components.coordinates import (
     CoordinateSystemLibrary,
@@ -175,46 +175,29 @@ com_device = Device(
 
 connections = [
     Connection(
-        device_names=["COM Device", "Laser Launch"],
-        connection_data={
-            "Laser Launch": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-            "COM Device": ConnectionData(
-                direction=ConnectionDirection.SEND,
-                port="COM4",
-            ),
-        },
+        source_device="COM Device",
+        source_port="COM4",
+        target_device="Laser Launch",
     ),
     Connection(
-        device_names=["Sample stage Z", "Sample stage X", "Sample stage Y", "ASI Tiger"],
-        connection_data={
-            "ASI Tiger": ConnectionData(
-                direction=ConnectionDirection.SEND,
-                port="COM3",
-            ),
-            "Sample stage Z": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-            "Sample stage Y": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-            "Sample stage X": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-        },
+        source_device="ASI Tiger",
+        source_port="COM3",
+        target_device="Sample stage Z",
     ),
     Connection(
-        device_names=["Lens 1", "MightyZap"],
-        connection_data={
-            "MightyZap": ConnectionData(
-                direction=ConnectionDirection.SEND,
-                port="COM9",
-            ),
-            "Lens 1": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-        },
+        source_device="ASI Tiger",
+        source_port="COM3",
+        target_device="Sample stage X",
+    ),
+    Connection(
+        source_device="ASI Tiger",
+        source_port="COM3",
+        target_device="Sample stage Y",
+    ),
+    Connection(
+        source_device="MightyZap",
+        source_port="COM9",
+        target_device="Lens 1",
     ),
 ]
 

--- a/examples/aind_smartspim_instrument.py
+++ b/examples/aind_smartspim_instrument.py
@@ -11,7 +11,7 @@ from aind_data_schema.components.devices import (
     ScanningStage,
     Device,
 )
-from aind_data_schema.components.connections import Connection, ConnectionData, ConnectionDirection
+from aind_data_schema.components.connections import Connection
 from aind_data_schema.core.instrument import (
     Detector,
     Instrument,
@@ -218,40 +218,19 @@ com_device = Device(
 
 connections = [
     Connection(
-        device_names=["COM Device", "Laser Launch"],
-        connection_data={
-            "Laser Launch": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-            "COM Device": ConnectionData(
-                direction=ConnectionDirection.SEND,
-                port="COM4",
-            ),
-        },
+        source_device="COM Device",
+        source_port="COM4",
+        target_device="Laser Launch",
     ),
     Connection(
-        device_names=["COM Device", "ASI Tiger"],
-        connection_data={
-            "ASI Tiger": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-            "COM Device": ConnectionData(
-                direction=ConnectionDirection.SEND,
-                port="COM3",
-            ),
-        },
+        source_device="COM Device",
+        source_port="COM3",
+        target_device="ASI Tiger",
     ),
     Connection(
-        device_names=["COM Device", "MightyZap"],
-        connection_data={
-            "MightyZap": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-            "COM Device": ConnectionData(
-                direction=ConnectionDirection.SEND,
-                port="COM9",
-            ),
-        },
+        source_device="COM Device",
+        source_port="COM9",
+        target_device="MightyZap",
     ),
 ]
 

--- a/examples/ephys_instrument.py
+++ b/examples/ephys_instrument.py
@@ -28,7 +28,7 @@ from aind_data_schema.components.devices import (
     Computer,
 )
 from aind_data_schema.components.measurements import Calibration
-from aind_data_schema.components.connections import Connection, ConnectionData, ConnectionDirection
+from aind_data_schema.components.connections import Connection
 from aind_data_schema.core.instrument import Instrument
 from aind_data_schema_models.units import PowerUnit
 from aind_data_schema_models.coordinates import AnatomicalRelative
@@ -62,52 +62,51 @@ harp = HarpDevice(
 
 connections = [
     Connection(
-        device_names=["Harp Behavior", "Face Camera"],
-        connection_data={
-            "Harp Behavior": ConnectionData(port="DO0", direction=ConnectionDirection.SEND),
-            "Face Camera": ConnectionData(direction=ConnectionDirection.RECEIVE),
-        },
+        source_device="Harp Behavior",
+        source_port="DO0",
+        target_device="Face Camera",
     ),
     Connection(
-        device_names=["Harp Behavior", "Body Camera"],
-        connection_data={
-            "Harp Behavior": ConnectionData(port="DO1", direction=ConnectionDirection.SEND),
-            "Body Camera": ConnectionData(direction=ConnectionDirection.RECEIVE),
-        },
+        source_device="Harp Behavior",
+        source_port="DO1",
+        target_device="Body Camera",
     ),
     Connection(
-        device_names=["Harp Behavior", "Running Wheel"],
-        connection_data={
-            "Harp Behavior": ConnectionData(port="AI0", direction=ConnectionDirection.RECEIVE),
-            "Running Wheel": ConnectionData(direction=ConnectionDirection.SEND),
-        },
+        source_device="Running Wheel",
+        target_device="Harp Behavior",
+        target_port="AI0",
     ),
     Connection(
-        device_names=["Harp Behavior", "Face Camera", "Body Camera", computer_names["Behavior computer"]],
-        connection_data={
-            "Harp Behavior": ConnectionData(direction=ConnectionDirection.SEND),
-            "Face Camera": ConnectionData(direction=ConnectionDirection.SEND),
-            "Body Camera": ConnectionData(direction=ConnectionDirection.SEND),
-            computer_names["Behavior computer"]: ConnectionData(direction=ConnectionDirection.RECEIVE),
-        },
+        source_device="Harp Behavior",
+        target_device=computer_names["Behavior computer"],
     ),
     Connection(
-        device_names=[
-            computer_names["Ephys computer"],
-            "Basestation Slot 3",
-            "stick microscope 1",
-            "stick microscope 2",
-            "stick microscope 3",
-            "stick microscope 4",
-        ],
-        connection_data={
-            computer_names["Ephys computer"]: ConnectionData(direction=ConnectionDirection.RECEIVE),
-            "Basestation Slot 3": ConnectionData(direction=ConnectionDirection.SEND),
-            "stick microscope 1": ConnectionData(direction=ConnectionDirection.SEND),
-            "stick microscope 2": ConnectionData(direction=ConnectionDirection.SEND),
-            "stick microscope 3": ConnectionData(direction=ConnectionDirection.SEND),
-            "stick microscope 4": ConnectionData(direction=ConnectionDirection.SEND),
-        },
+        source_device="Face Camera",
+        target_device=computer_names["Behavior computer"],
+    ),
+    Connection(
+        source_device="Body Camera",
+        target_device=computer_names["Behavior computer"],
+    ),
+    Connection(
+        source_device="Basestation Slot 3",
+        target_device=computer_names["Ephys computer"],
+    ),
+    Connection(
+        source_device="stick microscope 1",
+        target_device=computer_names["Ephys computer"],
+    ),
+    Connection(
+        source_device="stick microscope 2",
+        target_device=computer_names["Ephys computer"],
+    ),
+    Connection(
+        source_device="stick microscope 3",
+        target_device=computer_names["Ephys computer"],
+    ),
+    Connection(
+        source_device="stick microscope 4",
+        target_device=computer_names["Ephys computer"],
     ),
 ]
 

--- a/examples/exaspim_instrument.py
+++ b/examples/exaspim_instrument.py
@@ -18,7 +18,7 @@ from aind_data_schema.components.devices import (
     Computer,
     Microscope,
 )
-from aind_data_schema.components.connections import Connection, ConnectionData, ConnectionDirection
+from aind_data_schema.components.connections import Connection
 from aind_data_schema.core.instrument import Instrument
 from aind_data_schema_models.modalities import Modality
 from aind_data_schema.components.coordinates import CoordinateSystemLibrary
@@ -209,111 +209,48 @@ com_device = Device(
 
 connections = [
     Connection(
-        device_names=["COM Device", "Laser Launch"],
-        connection_data={
-            "Laser Launch": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-            "COM Device": ConnectionData(
-                direction=ConnectionDirection.SEND,
-                port="COM4",
-            ),
-        },
+        source_device="COM Device",
+        source_port="COM4",
+        target_device="Laser Launch",
     ),
     Connection(
-        device_names=["COM Device", "ASI Tiger"],
-        connection_data={
-            "ASI Tiger": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-            "COM Device": ConnectionData(
-                direction=ConnectionDirection.SEND,
-                port="COM3",
-            ),
-        },
+        source_device="COM Device",
+        source_port="COM3",
+        target_device="ASI Tiger",
     ),
     Connection(
-        device_names=["Dev2", "LAS-08308"],
-        connection_data={
-            "LAS-08308": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-            "Dev2": ConnectionData(
-                direction=ConnectionDirection.SEND,
-                port="3",
-            ),
-        },
+        source_device="Dev2",
+        source_port="3",
+        target_device="LAS-08308",
     ),
     Connection(
-        device_names=["Dev2", "539251"],
-        connection_data={
-            "539251": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-            "Dev2": ConnectionData(
-                direction=ConnectionDirection.SEND,
-                port="5",
-            ),
-        },
+        source_device="Dev2",
+        source_port="5",
+        target_device="539251",
     ),
     Connection(
-        device_names=["Dev2", "LAS-08309"],
-        connection_data={
-            "LAS-08309": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-            "Dev2": ConnectionData(
-                direction=ConnectionDirection.SEND,
-                port="4",
-            ),
-        },
+        source_device="Dev2",
+        source_port="4",
+        target_device="LAS-08309",
     ),
     Connection(
-        device_names=["Dev2", "stage-x"],
-        connection_data={
-            "stage-x": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-            "Dev2": ConnectionData(
-                direction=ConnectionDirection.SEND,
-                port="2",
-            ),
-        },
+        source_device="Dev2",
+        source_port="2",
+        target_device="stage-x",
     ),
     Connection(
-        device_names=["Dev2", "TL-1"],
-        connection_data={
-            "TL-1": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-            "Dev2": ConnectionData(
-                direction=ConnectionDirection.SEND,
-                port="0",
-            ),
-        },
+        source_device="Dev2",
+        source_port="0",
+        target_device="TL-1",
     ),
     Connection(
-        device_names=["Dev2", "LAS-08307"],
-        connection_data={
-            "LAS-08307": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-            "Dev2": ConnectionData(
-                direction=ConnectionDirection.SEND,
-                port="6",
-            ),
-        },
+        source_device="Dev2",
+        source_port="6",
+        target_device="LAS-08307",
     ),
     Connection(
-        device_names=["Dev2", "Dev2-PC"],
-        connection_data={
-            "Dev2-PC": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-            "Dev2": ConnectionData(
-                direction=ConnectionDirection.SEND,
-            ),
-        },
+        source_device="Dev2",
+        target_device="Dev2-PC",
     ),
 ]
 

--- a/examples/fip_behavior_instrument.py
+++ b/examples/fip_behavior_instrument.py
@@ -29,7 +29,7 @@ from aind_data_schema.components.devices import (
     Tube,
     Computer,
 )
-from aind_data_schema.components.connections import Connection, ConnectionData, ConnectionDirection
+from aind_data_schema.components.connections import Connection
 from aind_data_schema.core.instrument import Instrument
 from aind_data_schema.components.identifiers import Software
 from aind_data_schema.components.coordinates import (
@@ -121,97 +121,41 @@ harp_behavior = HarpDevice(
 
 connections = [
     Connection(
-        device_names=["Harp Behavior", "Solenoid Left"],
-        connection_data={
-            "Harp Behavior": ConnectionData(
-                direction=ConnectionDirection.SEND,
-                port="DO0",
-            ),
-            "Solenoid Left": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-        },
+        source_device="Harp Behavior",
+        source_port="DO0",
+        target_device="Solenoid Left",
     ),
     Connection(
-        device_names=["Harp Behavior", "Solenoid Right"],
-        connection_data={
-            "Harp Behavior": ConnectionData(
-                direction=ConnectionDirection.SEND,
-                port="DO1",
-            ),
-            "Solenoid Right": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-        },
+        source_device="Harp Behavior",
+        source_port="DO1",
+        target_device="Solenoid Right",
     ),
     Connection(
-        device_names=["Harp Behavior", "Janelia_Lick_Detector Left"],
-        connection_data={
-            "Harp Behavior": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-                port="DI0",
-            ),
-            "Janelia_Lick_Detector Left": ConnectionData(
-                direction=ConnectionDirection.SEND,
-            ),
-        },
+        source_device="Janelia_Lick_Detector Left",
+        target_device="Harp Behavior",
+        target_port="DI0",
     ),
     Connection(
-        device_names=["Harp Behavior", "Janelia_Lick_Detector Right"],
-        connection_data={
-            "Harp Behavior": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-                port="DI1",
-            ),
-            "Janelia_Lick_Detector Right": ConnectionData(
-                direction=ConnectionDirection.SEND,
-            ),
-        },
+        source_device="Janelia_Lick_Detector Right",
+        target_device="Harp Behavior",
+        target_port="DI1",
     ),
     Connection(
-        device_names=["Harp Behavior", "Photometry Clock"],
-        connection_data={
-            "Harp Behavior": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-                port="DI3",
-            ),
-            "Photometry Clock": ConnectionData(
-                direction=ConnectionDirection.SEND,
-            ),
-        },
+        source_device="Photometry Clock",
+        target_device="Harp Behavior",
+        target_port="DI3",
     ),
     Connection(
-        device_names=["W10DTJK7N0M3", "Side face camera"],
-        connection_data={
-            "W10DTJK7N0M3": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-            "Side face camera": ConnectionData(
-                direction=ConnectionDirection.SEND,
-            ),
-        },
+        source_device="Side face camera",
+        target_device="W10DTJK7N0M3",
     ),
     Connection(
-        device_names=["W10DTJK7N0M3", "Bottom face camera"],
-        connection_data={
-            "W10DTJK7N0M3": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-            "Bottom face camera": ConnectionData(
-                direction=ConnectionDirection.SEND,
-            ),
-        },
+        source_device="Bottom face camera",
+        target_device="W10DTJK7N0M3",
     ),
     Connection(
-        device_names=["behavior_computer", "Harp Behavior"],
-        connection_data={
-            "behavior_computer": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-            "Harp Behavior": ConnectionData(
-                direction=ConnectionDirection.SEND,
-            ),
-        },
+        source_device="Harp Behavior",
+        target_device="behavior_computer",
     ),
 ]
 

--- a/examples/fip_ophys_acquisition.py
+++ b/examples/fip_ophys_acquisition.py
@@ -13,7 +13,7 @@ from aind_data_schema.core.acquisition import (
     AcquisitionSubjectDetails,
     PerformanceMetrics,
 )
-from aind_data_schema.components.connections import Connection, ConnectionData, ConnectionDirection
+from aind_data_schema.components.connections import Connection
 from aind_data_schema.components.configs import (
     Channel,
     DetectorConfig,
@@ -191,155 +191,73 @@ patch_cord_d_config = PatchCordConfig(
 
 # Define connections between patch cords, detectors, and implanted fibers
 connections = [
-    # Connection between Patch Cord A and Fiber 0 (implant)
+    # Connection between Patch Cord A and Fiber 0 (implant) - bidirectional
     Connection(
-        device_names=["Patch Cord A", "Fiber 0"],
-        connection_data={
-            "Patch Cord A": ConnectionData(
-                direction=ConnectionDirection.SEND_AND_RECEIVE,
-            ),
-            "Fiber 0": ConnectionData(
-                direction=ConnectionDirection.SEND_AND_RECEIVE,
-            ),
-        },
+        source_device="Patch Cord A",
+        target_device="Fiber 0",
+        send_and_receive=True,
     ),
-    # Connection between Patch Cord B and Fiber 1 (implant)
+    # Connection between Patch Cord B and Fiber 1 (implant) - bidirectional
     Connection(
-        device_names=["Patch Cord B", "Fiber 1"],
-        connection_data={
-            "Patch Cord B": ConnectionData(
-                direction=ConnectionDirection.SEND_AND_RECEIVE,
-            ),
-            "Fiber 1": ConnectionData(
-                direction=ConnectionDirection.SEND_AND_RECEIVE,
-            ),
-        },
+        source_device="Patch Cord B",
+        target_device="Fiber 1",
+        send_and_receive=True,
     ),
     # Connections between Patch Cord A and detectors for different channels
     Connection(
-        device_names=["Patch Cord A", "Red CMOS"],
-        connection_data={
-            "Patch Cord A": ConnectionData(
-                direction=ConnectionDirection.SEND,
-                port="Fiber 0_red",
-            ),
-            "Red CMOS": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-        },
+        source_device="Patch Cord A",
+        source_port="Fiber 0_red",
+        target_device="Red CMOS",
     ),
     Connection(
-        device_names=["Patch Cord A", "Green CMOS"],
-        connection_data={
-            "Patch Cord A": ConnectionData(
-                direction=ConnectionDirection.SEND,
-                port="Fiber 0_green",
-            ),
-            "Green CMOS": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-        },
+        source_device="Patch Cord A",
+        source_port="Fiber 0_green",
+        target_device="Green CMOS",
     ),
     Connection(
-        device_names=["Patch Cord A", "Green CMOS"],
-        connection_data={
-            "Patch Cord A": ConnectionData(
-                direction=ConnectionDirection.SEND,
-                port="Fiber 0_isosbestic",
-            ),
-            "Green CMOS": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-                port="isosbestic",
-            ),
-        },
+        source_device="Patch Cord A",
+        source_port="Fiber 0_isosbestic",
+        target_device="Green CMOS",
+        target_port="isosbestic",
     ),
     # Connections between Patch Cord B and detectors
     Connection(
-        device_names=["Patch Cord B", "Green CMOS"],
-        connection_data={
-            "Patch Cord B": ConnectionData(
-                direction=ConnectionDirection.SEND,
-                port="Fiber 1_green",
-            ),
-            "Green CMOS": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-        },
+        source_device="Patch Cord B",
+        source_port="Fiber 1_green",
+        target_device="Green CMOS",
     ),
     Connection(
-        device_names=["Patch Cord B", "Green CMOS"],
-        connection_data={
-            "Patch Cord B": ConnectionData(
-                direction=ConnectionDirection.SEND,
-                port="Fiber 1_isosbestic",
-            ),
-            "Green CMOS": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-                port="isosbestic",
-            ),
-        },
+        source_device="Patch Cord B",
+        source_port="Fiber 1_isosbestic",
+        target_device="Green CMOS",
+        target_port="isosbestic",
     ),
     # Connections between LEDs and Patch Cord A
     Connection(
-        device_names=["470nm LED", "Patch Cord A"],
-        connection_data={
-            "470nm LED": ConnectionData(
-                direction=ConnectionDirection.SEND,
-            ),
-            "Patch Cord A": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-                port="Fiber 0_green",
-            ),
-        },
+        source_device="470nm LED",
+        target_device="Patch Cord A",
+        target_port="Fiber 0_green",
     ),
     Connection(
-        device_names=["415nm LED", "Patch Cord A"],
-        connection_data={
-            "415nm LED": ConnectionData(
-                direction=ConnectionDirection.SEND,
-            ),
-            "Patch Cord A": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-                port="Fiber 0_isosbestic",
-            ),
-        },
+        source_device="415nm LED",
+        target_device="Patch Cord A",
+        target_port="Fiber 0_isosbestic",
     ),
     Connection(
-        device_names=["565nm LED", "Patch Cord A"],
-        connection_data={
-            "565nm LED": ConnectionData(
-                direction=ConnectionDirection.SEND,
-            ),
-            "Patch Cord A": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-                port="Fiber 0_red",
-            ),
-        },
+        source_device="565nm LED",
+        target_device="Patch Cord A",
+        target_port="Fiber 0_red",
     ),
     # Connections between LEDs and Patch Cord B
     Connection(
-        device_names=["470nm LED", "Patch Cord B"],
-        connection_data={
-            "470nm LED": ConnectionData(
-                direction=ConnectionDirection.SEND,
-            ),
-            "Patch Cord B": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-                port="Fiber 1_green",
-            ),
-        },
+        source_device="470nm LED",
+        target_device="Patch Cord B",
+        target_port="Fiber 1_green",
     ),
     Connection(
-        device_names=["415nm LED", "Patch Cord B"],
-        connection_data={
-            "415nm LED": ConnectionData(
-                direction=ConnectionDirection.SEND,
-            ),
-            "Patch Cord B": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-                port="Fiber 1_isosbestic",
-            ),
-        },
+        source_device="415nm LED",
+        target_device="Patch Cord B",
+        target_port="Fiber 1_isosbestic",
     ),
 ]
 

--- a/examples/fip_ophys_instrument.py
+++ b/examples/fip_ophys_instrument.py
@@ -7,7 +7,7 @@ from aind_data_schema_models.units import FrequencyUnit, PowerUnit
 
 import aind_data_schema.components.devices as d
 import aind_data_schema.core.instrument as r
-from aind_data_schema.components.connections import Connection, ConnectionData, ConnectionDirection
+from aind_data_schema.components.connections import Connection
 from aind_data_schema.components.identifiers import Software
 from aind_data_schema.components.coordinates import CoordinateSystemLibrary
 from aind_data_schema.components.measurements import Calibration
@@ -251,97 +251,41 @@ daq = d.HarpDevice(
 )
 connections = [
     Connection(
-        device_names=["Harp Behavior", "Solenoid Left"],
-        connection_data={
-            "Harp Behavior": ConnectionData(
-                direction=ConnectionDirection.SEND,
-                port="DO0",
-            ),
-            "Solenoid Left": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-        },
+        source_device="Harp Behavior",
+        source_port="DO0",
+        target_device="Solenoid Left",
     ),
     Connection(
-        device_names=["Harp Behavior", "Solenoid Right"],
-        connection_data={
-            "Harp Behavior": ConnectionData(
-                direction=ConnectionDirection.SEND,
-                port="DO1",
-            ),
-            "Solenoid Right": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-        },
+        source_device="Harp Behavior",
+        source_port="DO1",
+        target_device="Solenoid Right",
     ),
     Connection(
-        device_names=["Harp Behavior", "Janelia_Lick_Detector Left"],
-        connection_data={
-            "Harp Behavior": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-                port="DI0",
-            ),
-            "Janelia_Lick_Detector Left": ConnectionData(
-                direction=ConnectionDirection.SEND,
-            ),
-        },
+        source_device="Janelia_Lick_Detector Left",
+        target_device="Harp Behavior",
+        target_port="DI0",
     ),
     Connection(
-        device_names=["Harp Behavior", "Janelia_Lick_Detector Right"],
-        connection_data={
-            "Harp Behavior": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-                port="DI1",
-            ),
-            "Janelia_Lick_Detector Right": ConnectionData(
-                direction=ConnectionDirection.SEND,
-            ),
-        },
+        source_device="Janelia_Lick_Detector Right",
+        target_device="Harp Behavior",
+        target_port="DI1",
     ),
     Connection(
-        device_names=["Harp Behavior", "Photometry Clock"],
-        connection_data={
-            "Harp Behavior": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-                port="DI3",
-            ),
-            "Photometry Clock": ConnectionData(
-                direction=ConnectionDirection.SEND,
-            ),
-        },
+        source_device="Photometry Clock",
+        target_device="Harp Behavior",
+        target_port="DI3",
     ),
     Connection(
-        device_names=["W10DTJK7N0M3", "Side face camera"],
-        connection_data={
-            "W10DTJK7N0M3": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-            "Side face camera": ConnectionData(
-                direction=ConnectionDirection.SEND,
-            ),
-        },
+        source_device="Side face camera",
+        target_device="W10DTJK7N0M3",
     ),
     Connection(
-        device_names=["W10DTJK7N0M3", "Bottom face camera"],
-        connection_data={
-            "W10DTJK7N0M3": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-            "Bottom face camera": ConnectionData(
-                direction=ConnectionDirection.SEND,
-            ),
-        },
+        source_device="Bottom face camera",
+        target_device="W10DTJK7N0M3",
     ),
     Connection(
-        device_names=["W10DTJK7N0M3", "Harp Behavior"],
-        connection_data={
-            "W10DTJK7N0M3": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-            "Harp Behavior": ConnectionData(
-                direction=ConnectionDirection.SEND,
-            ),
-        },
+        source_device="Harp Behavior",
+        target_device="W10DTJK7N0M3",
     ),
 ]
 

--- a/examples/multiplane_ophys_instrument.py
+++ b/examples/multiplane_ophys_instrument.py
@@ -33,7 +33,7 @@ from aind_data_schema.components.devices import (
 )
 from aind_data_schema.components.devices import Objective
 from aind_data_schema.components.identifiers import Software
-from aind_data_schema.components.connections import Connection, ConnectionData, ConnectionDirection
+from aind_data_schema.components.connections import Connection
 from aind_data_schema.core.instrument import Instrument
 
 instrument = Instrument(
@@ -359,82 +359,33 @@ instrument = Instrument(
     ],
     connections=[
         Connection(
-            device_names=["SYNC DAQ", "MESO1STIM"],
-            connection_data={
-                "SYNC DAQ": ConnectionData(
-                    direction=ConnectionDirection.RECEIVE,
-                    port="P0.3",
-                ),
-                "MESO1STIM": ConnectionData(
-                    direction=ConnectionDirection.SEND,
-                ),
-            },
+            source_device="MESO1STIM",
+            target_device="SYNC DAQ",
+            target_port="P0.3",
         ),
         Connection(
-            device_names=["Video Monitor", "Behavior Camera"],
-            connection_data={
-                "Video Monitor": ConnectionData(
-                    direction=ConnectionDirection.RECEIVE,
-                ),
-                "Behavior Camera": ConnectionData(
-                    direction=ConnectionDirection.SEND,
-                ),
-            },
+            source_device="Behavior Camera",
+            target_device="Video Monitor",
         ),
         Connection(
-            device_names=["Video Monitor", "Eye Camera"],
-            connection_data={
-                "Video Monitor": ConnectionData(
-                    direction=ConnectionDirection.RECEIVE,
-                ),
-                "Eye Camera": ConnectionData(
-                    direction=ConnectionDirection.SEND,
-                ),
-            },
+            source_device="Eye Camera",
+            target_device="Video Monitor",
         ),
         Connection(
-            device_names=["Video Monitor", "Face Camera"],
-            connection_data={
-                "Video Monitor": ConnectionData(
-                    direction=ConnectionDirection.RECEIVE,
-                ),
-                "Face Camera": ConnectionData(
-                    direction=ConnectionDirection.SEND,
-                ),
-            },
+            source_device="Face Camera",
+            target_device="Video Monitor",
         ),
         Connection(
-            device_names=["VBEB DAQ", "MESO1STIM"],
-            connection_data={
-                "VBEB DAQ": ConnectionData(
-                    direction=ConnectionDirection.RECEIVE,
-                ),
-                "MESO1STIM": ConnectionData(
-                    direction=ConnectionDirection.SEND,
-                ),
-            },
+            source_device="MESO1STIM",
+            target_device="VBEB DAQ",
         ),
         Connection(
-            device_names=["SYNC DAQ", "MESO1SYNC"],
-            connection_data={
-                "SYNC DAQ": ConnectionData(
-                    direction=ConnectionDirection.RECEIVE,
-                ),
-                "MESO1SYNC": ConnectionData(
-                    direction=ConnectionDirection.SEND,
-                ),
-            },
+            source_device="MESO1SYNC",
+            target_device="SYNC DAQ",
         ),
         Connection(
-            device_names=["STIM DAQ", "MESO1STIM"],
-            connection_data={
-                "STIM DAQ": ConnectionData(
-                    direction=ConnectionDirection.RECEIVE,
-                ),
-                "MESO1STIM": ConnectionData(
-                    direction=ConnectionDirection.SEND,
-                ),
-            },
+            source_device="MESO1STIM",
+            target_device="STIM DAQ",
         ),
     ],
     calibrations=[],

--- a/examples/ophys_acquisition.py
+++ b/examples/ophys_acquisition.py
@@ -9,57 +9,29 @@ from aind_data_schema.core.acquisition import (
     DataStream,
     AcquisitionSubjectDetails,
 )
-from aind_data_schema.components.connections import Connection, ConnectionData, ConnectionDirection
+from aind_data_schema.components.connections import Connection
 from aind_data_schema.components.configs import Channel, DetectorConfig, PatchCordConfig, LaserConfig
 
 t = datetime(2022, 7, 12, 7, 00, 00, tzinfo=timezone.utc)
 
 connections = [
     Connection(
-        device_names=["Patch Cord A", "Fiber A"],
-        connection_data={
-            "Patch Cord A": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-            "Fiber A": ConnectionData(
-                direction=ConnectionDirection.SEND,
-            ),
-        },
+        source_device="Fiber A",
+        target_device="Patch Cord A",
     ),
     Connection(
-        device_names=["Patch Cord A", "Hamamatsu Camera"],
-        connection_data={
-            "Patch Cord A": ConnectionData(
-                direction=ConnectionDirection.SEND,
-            ),
-            "Hamamatsu Camera": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-        },
+        source_device="Patch Cord A",
+        target_device="Hamamatsu Camera",
     ),
     Connection(
-        device_names=["Patch Cord B", "Fiber B"],
-        connection_data={
-            "Patch Cord B": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-            "Fiber B": ConnectionData(
-                direction=ConnectionDirection.SEND,
-                port="ROI 0",
-            ),
-        },
+        source_device="Fiber B",
+        source_port="ROI 0",
+        target_device="Patch Cord B",
     ),
     Connection(
-        device_names=["Patch Cord B", "Hamamatsu Camera"],
-        connection_data={
-            "Patch Cord B": ConnectionData(
-                direction=ConnectionDirection.SEND,
-            ),
-            "Hamamatsu Camera": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-                port="ROI 1",
-            ),
-        },
+        source_device="Patch Cord B",
+        target_device="Hamamatsu Camera",
+        target_port="ROI 1",
     ),
 ]
 

--- a/src/aind_data_schema/components/connections.py
+++ b/src/aind_data_schema/components/connections.py
@@ -11,13 +11,9 @@ class Connection(DataModel):
     """Description of a connection between devices in an instrument"""
 
     source_device: str = Field(..., title="Source device name")
-    source_port: Optional[str] = Field(
-        default=None, title="Source device port index/name"
-    )
+    source_port: Optional[str] = Field(default=None, title="Source device port index/name")
     target_device: str = Field(..., title="Target device name")
-    target_port: Optional[str] = Field(
-        default=None, title="Target device port index/name"
-    )
+    target_port: Optional[str] = Field(default=None, title="Target device port index/name")
     send_and_receive: bool = Field(
         default=False,
         title="Send and receive",

--- a/src/aind_data_schema/components/connections.py
+++ b/src/aind_data_schema/components/connections.py
@@ -1,39 +1,25 @@
 """Components for describing connections between devices"""
 
-from enum import Enum
-from typing import Dict, List, Optional
+from typing import Optional
 
-from pydantic import Field, model_validator
+from pydantic import Field
 
 from aind_data_schema.base import DataModel
-
-
-class ConnectionDirection(str, Enum):
-    """Direction of a connection"""
-
-    SEND = "Send"
-    RECEIVE = "Receive"
-    SEND_AND_RECEIVE = "Send and receive"
-
-
-class ConnectionData(DataModel):
-    """Configuration data for a device connection including direction and port information"""
-
-    direction: Optional[ConnectionDirection] = Field(default=None, title="Connection direction")
-    port: Optional[str] = Field(default=None, title="Connection port index/name")
 
 
 class Connection(DataModel):
     """Description of a connection between devices in an instrument"""
 
-    device_names: List[str] = Field(..., title="Names of connected devices")
-    connection_data: Dict[str, ConnectionData] = Field(default={}, title="Connection data")
-
-    @model_validator(mode="after")
-    def validate_connection_data(cls, self):
-        """Check that all keys in connection_data exist in device_names"""
-        for key in self.connection_data.keys():
-            if key not in self.device_names:
-                raise ValueError(f"Connection data key '{key}' does not exist in device names")
-
-        return self
+    source_device: str = Field(..., title="Source device name")
+    source_port: Optional[str] = Field(
+        default=None, title="Source device port index/name"
+    )
+    target_device: str = Field(..., title="Target device name")
+    target_port: Optional[str] = Field(
+        default=None, title="Target device port index/name"
+    )
+    send_and_receive: bool = Field(
+        default=False,
+        title="Send and receive",
+        description="Whether the connection is bidirectional (send and receive data)",
+    )

--- a/src/aind_data_schema/core/acquisition.py
+++ b/src/aind_data_schema/core/acquisition.py
@@ -164,8 +164,10 @@ class DataStream(DataModel):
         """Check that every device in a Connection is present in the active_devices list"""
         for connection in self.connections:
             # Check that both source and target devices are in active_devices
-            if (connection.source_device not in self.active_devices or
-                    connection.target_device not in self.active_devices):
+            if (
+                connection.source_device not in self.active_devices
+                or connection.target_device not in self.active_devices
+            ):
                 missing_devices = []
                 if connection.source_device not in self.active_devices:
                     missing_devices.append(connection.source_device)

--- a/src/aind_data_schema/core/acquisition.py
+++ b/src/aind_data_schema/core/acquisition.py
@@ -163,8 +163,18 @@ class DataStream(DataModel):
     def check_connections(self):
         """Check that every device in a Connection is present in the active_devices list"""
         for connection in self.connections:
-            if not any(device in self.active_devices for device in connection.device_names):
-                raise ValueError(f"Missing devices in active_devices list for connection {connection}")
+            # Check that both source and target devices are in active_devices
+            if (connection.source_device not in self.active_devices or
+                    connection.target_device not in self.active_devices):
+                missing_devices = []
+                if connection.source_device not in self.active_devices:
+                    missing_devices.append(connection.source_device)
+                if connection.target_device not in self.active_devices:
+                    missing_devices.append(connection.target_device)
+                raise ValueError(
+                    f"Missing devices in active_devices list for connection "
+                    f"from '{connection.source_device}' to '{connection.target_device}': {missing_devices}"
+                )
 
         return self
 

--- a/src/aind_data_schema/core/instrument.py
+++ b/src/aind_data_schema/core/instrument.py
@@ -202,9 +202,15 @@ class Instrument(DataCoreModel):
         device_names = Instrument.get_component_names(self)
 
         for connection in self.connections:
-            for device_name in connection.device_names:
-                if device_name not in device_names:
-                    raise ValueError(f"Device name validation error: '{device_name}' is not part of the instrument.")
+            # Check both source and target devices exist
+            if connection.source_device not in device_names:
+                raise ValueError(
+                    f"Device name validation error: '{connection.source_device}' is not part of the instrument."
+                )
+            if connection.target_device not in device_names:
+                raise ValueError(
+                    f"Device name validation error: '{connection.target_device}' is not part of the instrument."
+                )
 
         return self
 

--- a/src/aind_data_schema/core/metadata.py
+++ b/src/aind_data_schema/core/metadata.py
@@ -236,9 +236,17 @@ class Metadata(DataCoreModel):
             data_streams = self.acquisition.data_streams
             for data_stream in data_streams:
                 for connection in data_stream.connections:
-                    if not all(device in device_names for device in connection.device_names):
+                    # Check both source and target devices exist
+                    missing_devices = []
+                    if connection.source_device not in device_names:
+                        missing_devices.append(connection.source_device)
+                    if connection.target_device not in device_names:
+                        missing_devices.append(connection.target_device)
+                    
+                    if missing_devices:
                         raise ValueError(
-                            f"Connection '{connection}' contains devices not found in instrument or procedures."
+                            f"Connection from '{connection.source_device}' to '{connection.target_device}' "
+                            f"contains devices not found in instrument or procedures: {missing_devices}"
                         )
 
         return self

--- a/src/aind_data_schema/core/metadata.py
+++ b/src/aind_data_schema/core/metadata.py
@@ -242,7 +242,7 @@ class Metadata(DataCoreModel):
                         missing_devices.append(connection.source_device)
                     if connection.target_device not in device_names:
                         missing_devices.append(connection.target_device)
-                    
+
                     if missing_devices:
                         raise ValueError(
                             f"Connection from '{connection.source_device}' to '{connection.target_device}' "

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -293,21 +293,6 @@ class AcquisitionTest(unittest.TestCase):
         )
         self.assertIsNotNone(stream)
 
-        # Test invalid connections
-        with self.assertRaises(ValueError) as context:
-            DataStream(
-                stream_start_time=datetime.now(),
-                stream_end_time=datetime.now(),
-                modalities=[],
-                active_devices=["DeviceA"],
-                configurations=[],
-                connections=[
-                    Connection(device_names=["DeviceA"]),
-                    Connection(device_names=["DeviceB"]),
-                ],
-            )
-        self.assertIn("Missing devices in active_devices list for connection", str(context.exception))
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -293,6 +293,21 @@ class AcquisitionTest(unittest.TestCase):
         )
         self.assertIsNotNone(stream)
 
+        # Test invalid connections
+        with self.assertRaises(ValueError) as context:
+            DataStream(
+                stream_start_time=datetime.now(),
+                stream_end_time=datetime.now(),
+                modalities=[],
+                active_devices=["DeviceA"],
+                configurations=[],
+                connections=[
+                    Connection(device_names=["DeviceA"]),
+                    Connection(device_names=["DeviceB"]),
+                ],
+            )
+        self.assertIn("Missing devices in active_devices list for connection", str(context.exception))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -303,7 +303,7 @@ class AcquisitionTest(unittest.TestCase):
                 configurations=[],
                 connections=[
                     Connection(source_device="DeviceA", target_device="SomeTarget"),
-                    Connection(source_device="DeviceB", target_device="SomeTarget"),
+                    Connection(source_device="SomeTarget", target_device="DeviceA"),
                 ],
             )
         self.assertIn("Missing devices in active_devices list for connection", str(context.exception))

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -287,8 +287,8 @@ class AcquisitionTest(unittest.TestCase):
             active_devices=["DeviceA", "DeviceB"],
             configurations=[],
             connections=[
-                Connection(device_names=["DeviceA"]),
-                Connection(device_names=["DeviceB"]),
+                Connection(source_device="DeviceA", target_device="SomeTarget"),
+                Connection(source_device="DeviceB", target_device="SomeTarget"),
             ],
         )
         self.assertIsNotNone(stream)

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -302,8 +302,21 @@ class AcquisitionTest(unittest.TestCase):
                 active_devices=["DeviceA"],
                 configurations=[],
                 connections=[
-                    Connection(source_device="DeviceA", target_device="SomeTarget"),
                     Connection(source_device="SomeTarget", target_device="DeviceA"),
+                ],
+            )
+        self.assertIn("Missing devices in active_devices list for connection", str(context.exception))
+
+        # Test invalid connections
+        with self.assertRaises(ValueError) as context:
+            DataStream(
+                stream_start_time=datetime.now(),
+                stream_end_time=datetime.now(),
+                modalities=[],
+                active_devices=["DeviceA"],
+                configurations=[],
+                connections=[
+                    Connection(source_device="DeviceA", target_device="SomeTarget"),
                 ],
             )
         self.assertIn("Missing devices in active_devices list for connection", str(context.exception))

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -302,8 +302,8 @@ class AcquisitionTest(unittest.TestCase):
                 active_devices=["DeviceA"],
                 configurations=[],
                 connections=[
-                    Connection(device_names=["DeviceA"]),
-                    Connection(device_names=["DeviceB"]),
+                    Connection(source_device="DeviceA", target_device="SomeTarget"),
+                    Connection(source_device="DeviceB", target_device="SomeTarget"),
                 ],
             )
         self.assertIn("Missing devices in active_devices list for connection", str(context.exception))

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -284,7 +284,7 @@ class AcquisitionTest(unittest.TestCase):
             stream_start_time=datetime.now(),
             stream_end_time=datetime.now(),
             modalities=[],
-            active_devices=["DeviceA", "DeviceB"],
+            active_devices=["DeviceA", "DeviceB", "SomeTarget"],
             configurations=[],
             connections=[
                 Connection(source_device="DeviceA", target_device="SomeTarget"),

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -475,6 +475,46 @@ class InstrumentTests(unittest.TestCase):
 
         self.assertIn("Device name validation error: 'Not a real device'", str(context.exception))
 
+        with self.assertRaises(ValueError) as context:
+            Instrument(
+                instrument_id="123_EPHYS1-OPTO_20220101",
+                modification_date=date(2020, 10, 10),
+                modalities=[Modality.ECEPHYS, Modality.FIB],
+                coordinate_system=CoordinateSystemLibrary.BREGMA_ARI,
+                components=[
+                    *daqs,
+                    *cameras,
+                    *stick_microscopes,
+                    *light_sources,
+                    *lms,
+                    *ems,
+                    *detectors,
+                    *patch_cords,
+                    *stimulus_devices,
+                    Disc(name="Disc A", radius=1),
+                    dmd,
+                ],
+                calibrations=[
+                    Calibration(
+                        calibration_date=date(2020, 10, 10),
+                        device_name="Laser A",
+                        description="Laser power calibration",
+                        input=[10, 40, 80],
+                        input_unit=PowerUnit.PERCENT,
+                        output=[2, 6, 10],
+                        output_unit=PowerUnit.MW,
+                    )
+                ],
+                connections=[
+                    Connection(
+                        target_device="Not a real device",
+                        source_device="Some other device",
+                    )
+                ],
+            )
+
+        self.assertIn("Device name validation error: 'Not a real device'", str(context.exception))
+
     def test_validator_modality_device_missing(self):
         """Test that the modality -> device validator throws validation errors when devices are missing"""
 

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -468,7 +468,7 @@ class InstrumentTests(unittest.TestCase):
                 connections=[
                     Connection(
                         source_device="Not a real device",
-                        target_device="Some other device",
+                        target_device="Neuropixels basestation",
                     )
                 ],
             )
@@ -508,7 +508,7 @@ class InstrumentTests(unittest.TestCase):
                 connections=[
                     Connection(
                         target_device="Not a real device",
-                        source_device="Some other device",
+                        source_device="Neuropixels basestation",
                     )
                 ],
             )

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -39,7 +39,7 @@ from aind_data_schema.components.devices import (
     OlfactometerChannelType,
     ScanningStage,
 )
-from aind_data_schema.components.connections import Connection, ConnectionData, ConnectionDirection
+from aind_data_schema.components.connections import Connection
 from aind_data_schema.components.measurements import Calibration
 from aind_data_schema.core.instrument import (
     DEVICES_REQUIRED,
@@ -86,107 +86,44 @@ daqs = [
 
 connections = [
     Connection(
-        device_names=["Laser A", "Neuropixels basestation"],
-        connection_data={
-            "Neuropixels basestation": ConnectionData(
-                direction=ConnectionDirection.SEND,
-                port="123",
-            ),
-            "Laser A": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-        },
+        source_device="Neuropixels basestation",
+        source_port="123",
+        target_device="Laser A",
     ),
     Connection(
-        device_names=["Probe A", "Neuropixels basestation"],
-        connection_data={
-            "Neuropixels basestation": ConnectionData(
-                direction=ConnectionDirection.SEND,
-                port="321",
-            ),
-            "Probe A": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-        },
+        source_device="Neuropixels basestation",
+        source_port="321",
+        target_device="Probe A",
     ),
     Connection(
-        device_names=["Camera A", "Neuropixels basestation"],
-        connection_data={
-            "Neuropixels basestation": ConnectionData(
-                direction=ConnectionDirection.SEND,
-                port="234",
-            ),
-            "Camera A": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-        },
+        source_device="Neuropixels basestation",
+        source_port="234",
+        target_device="Camera A",
     ),
     Connection(
-        device_names=["Disc A", "Neuropixels basestation"],
-        connection_data={
-            "Neuropixels basestation": ConnectionData(
-                direction=ConnectionDirection.SEND,
-                port="2354",
-            ),
-            "Disc A": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-        },
+        source_device="Neuropixels basestation",
+        source_port="2354",
+        target_device="Disc A",
     ),
     Connection(
-        device_names=["Neuropixels basestation", "foo"],
-        connection_data={
-            "Neuropixels basestation": ConnectionData(
-                direction=ConnectionDirection.SEND,
-            ),
-            "foo": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-        },
+        source_device="Neuropixels basestation",
+        target_device="foo",
     ),
     Connection(
-        device_names=["cam", "ASDF"],
-        connection_data={
-            "cam": ConnectionData(
-                direction=ConnectionDirection.SEND,
-            ),
-            "ASDF": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-        },
+        source_device="cam",
+        target_device="ASDF",
     ),
     Connection(
-        device_names=["Neuropixels basestation", "foo"],
-        connection_data={
-            "Neuropixels basestation": ConnectionData(
-                direction=ConnectionDirection.SEND,
-            ),
-            "foo": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-        },
+        source_device="Neuropixels basestation",
+        target_device="foo",
     ),
     Connection(
-        device_names=["Camera A", "ASDF"],
-        connection_data={
-            "Camera A": ConnectionData(
-                direction=ConnectionDirection.SEND,
-            ),
-            "ASDF": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-        },
+        source_device="Camera A",
+        target_device="ASDF",
     ),
     Connection(
-        device_names=["Olfactometer", "W10XXX000"],
-        connection_data={
-            "Olfactometer": ConnectionData(
-                direction=ConnectionDirection.SEND,
-            ),
-            "W10XXX000": ConnectionData(
-                direction=ConnectionDirection.RECEIVE,
-            ),
-        },
+        source_device="Olfactometer",
+        target_device="W10XXX000",
     ),
 ]
 
@@ -452,7 +389,8 @@ class InstrumentTests(unittest.TestCase):
                 ],
                 connections=[
                     Connection(
-                        device_names=["Olfactometer", "Laser A"],
+                        source_device="Olfactometer",
+                        target_device="Laser A",
                     )
                 ],
             )
@@ -487,7 +425,8 @@ class InstrumentTests(unittest.TestCase):
             ],
             connections=[
                 Connection(
-                    device_names=["Olfactometer", "Laser A"],
+                    source_device="Olfactometer",
+                    target_device="Laser A",
                 )
             ],
             notes="Camera target is Other",
@@ -528,7 +467,8 @@ class InstrumentTests(unittest.TestCase):
                 ],
                 connections=[
                     Connection(
-                        device_names=["Not a real device"],
+                        source_device="Not a real device",
+                        target_device="Some other device",
                     )
                 ],
             )
@@ -649,15 +589,8 @@ class InstrumentTests(unittest.TestCase):
             calibrations=[],
             connections=[
                 Connection(
-                    device_names=["Camera A", "ASDF"],
-                    connection_data={
-                        "Camera A": ConnectionData(
-                            direction=ConnectionDirection.SEND,
-                        ),
-                        "ASDF": ConnectionData(
-                            direction=ConnectionDirection.RECEIVE,
-                        ),
-                    },
+                    source_device="Camera A",
+                    target_device="ASDF",
                 )
             ],
         )
@@ -745,37 +678,20 @@ class ConnectionTest(unittest.TestCase):
         """Test the Connection schema"""
 
         connection = Connection(
-            device_names=["Laser A", "Neuropixels basestation"],
-            connection_data={
-                "Neuropixels basestation": ConnectionData(
-                    direction=ConnectionDirection.SEND,
-                    port="123",
-                ),
-                "Laser A": ConnectionData(
-                    direction=ConnectionDirection.RECEIVE,
-                ),
-            },
+            source_device="Neuropixels basestation",
+            source_port="123",
+            target_device="Laser A",
         )
         self.assertIsNotNone(connection)
 
         with self.assertRaises(ValidationError) as context:
             Connection(
-                device_names=["Camera A", "Neuropixels basestation"],
-                connection_data={
-                    "Neuropixels basestation": ConnectionData(
-                        direction=ConnectionDirection.SEND,
-                        port="123",
-                    ),
-                    "Laser A": ConnectionData(
-                        direction=ConnectionDirection.RECEIVE,
-                    ),
-                    "Camera A": ConnectionData(
-                        direction=ConnectionDirection.RECEIVE,
-                    ),
-                },
+                source_device="Camera A",
+                target_device="Invalid Target",
             )
 
-        self.assertIn("Connection data key 'Laser A' does not exist", str(context.exception))
+        # This should pass validation with the new simplified Connection schema
+        self.assertIsNotNone(context.exception)
 
     def test_validate_modalities_sorting(self):
         """Test that validate_modalities sorts modalities by their name"""

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -684,14 +684,12 @@ class ConnectionTest(unittest.TestCase):
         )
         self.assertIsNotNone(connection)
 
-        with self.assertRaises(ValidationError) as context:
-            Connection(
-                source_device="Camera A",
-                target_device="Invalid Target",
-            )
-
-        # This should pass validation with the new simplified Connection schema
-        self.assertIsNotNone(context.exception)
+        # Test that a simple connection with valid structure is created successfully
+        simple_connection = Connection(
+            source_device="Camera A",
+            target_device="Invalid Target",
+        )
+        self.assertIsNotNone(simple_connection)
 
     def test_validate_modalities_sorting(self):
         """Test that validate_modalities sorts modalities by their name"""

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -353,7 +353,7 @@ class TestMetadata(unittest.TestCase):
                     active_devices=["Probe A", "Laser A"],
                     modalities=[],
                     configurations=[],
-                    connections=[Connection(device_names=["Probe A", "Missing Device"], connection_data={})],
+                    connections=[Connection(source_device="Probe A", target_device="Missing Device")],
                 ),
             ],
             subject_details=AcquisitionSubjectDetails.model_construct(),
@@ -366,7 +366,7 @@ class TestMetadata(unittest.TestCase):
                 acquisition=acquisition,
             )
         self.assertIn(
-            "Connection 'object_type='Connection' device_names=['Probe A', 'Missing Device'] connection_data={}'",
+            "Missing Device",
             str(context.exception),
         )
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -370,6 +370,31 @@ class TestMetadata(unittest.TestCase):
             str(context.exception),
         )
 
+        # Case where source device is missing
+        acquisition_missing_source = Acquisition.model_construct(
+            instrument_id="Test",
+            data_streams=[
+                DataStream.model_construct(
+                    active_devices=["Probe A", "Laser A"],
+                    modalities=[],
+                    configurations=[],
+                    connections=[Connection(source_device="Missing Source", target_device="Laser A")],
+                ),
+            ],
+            subject_details=AcquisitionSubjectDetails.model_construct(),
+        )
+        with self.assertRaises(ValueError) as context:
+            Metadata(
+                name="Test Metadata",
+                location="Test Location",
+                instrument=instrument,
+                acquisition=acquisition_missing_source,
+            )
+        self.assertIn(
+            "Missing Source",
+            str(context.exception),
+        )
+
     def test_validate_acquisition_active_devices(self):
         """Tests that acquisition active devices are validated correctly."""
         # Case where all active devices are present in instrument components


### PR DESCRIPTION
PR removes the concept of `ConnectionData` in favor of a flat Connection object:

```
class Connection(DataModel):
    """Description of a connection between devices in an instrument"""

    source_device: str = Field(..., title="Source device name")
    source_port: Optional[str] = Field(
        default=None, title="Source device port index/name"
    )
    target_device: str = Field(..., title="Target device name")
    target_port: Optional[str] = Field(
        default=None, title="Target device port index/name"
    )
    send_and_receive: bool = Field(
        default=False,
        title="Send and receive",
        description="Whether the connection is bidirectional (send and receive data)",
    )
```

This removes extra objects and a layer of the hierarchy while still maintaining the same functionality.