### PR TITLE
fix: recursively get all component names

### DIFF
--- a/src/aind_data_schema/core/instrument.py
+++ b/src/aind_data_schema/core/instrument.py
@@ -165,12 +165,11 @@ class Instrument(DataCoreModel):
         description="List of all devices in the instrument",
     )
 
-    @classmethod
-    def get_component_names(cls, instrument: "Instrument") -> List[str]:
+    def get_component_names(self) -> List[str]:
         """Get the name field of all components, recurse into assemblies."""
 
         names = []
-        for component in instrument.components:
+        for component in self.components:
             names.extend(recursive_get_all_names(component))
         names = [name for name in names if name is not None]
 
@@ -199,7 +198,7 @@ class Instrument(DataCoreModel):
     @classmethod
     def validate_connections(cls, self):
         """validate that all connections map between devices that actually exist"""
-        device_names = Instrument.get_component_names(self)
+        device_names = self.get_component_names()
 
         for connection in self.connections:
             # Check both source and target devices exist

--- a/src/aind_data_schema/core/metadata.py
+++ b/src/aind_data_schema/core/metadata.py
@@ -203,8 +203,7 @@ class Metadata(DataCoreModel):
         device_names = []
 
         if values.instrument:
-            for component in values.instrument.components:
-                device_names.append(component.name)
+            device_names.extend(values.instrument.get_component_names())
         if values.procedures:
             device_names.extend(values.procedures.get_device_names())
 
@@ -226,8 +225,7 @@ class Metadata(DataCoreModel):
         device_names = []
 
         if self.instrument:
-            for component in self.instrument.components:
-                device_names.append(component.name)
+            device_names.extend(self.instrument.get_component_names())
         if self.procedures:
             device_names.extend(self.procedures.get_device_names())
 

--- a/src/aind_data_schema/utils/compatibility_check.py
+++ b/src/aind_data_schema/utils/compatibility_check.py
@@ -31,7 +31,7 @@ class InstrumentAcquisitionCompatibility:
             for stimulus_epoch in getattr(self.acquisition, "stimulus_epochs", [])
             for stimulus_device_name in getattr(stimulus_epoch, "active_devices")
         ]
-        instrument_component_names = [getattr(comp, "name", None) for comp in getattr(self.inst, "components", [])]
+        instrument_component_names = self.inst.get_component_names()
 
         if any(device not in instrument_component_names for device in acquisition_stimulus_devices):
             return ValueError(


### PR DESCRIPTION
The recursive `get_component_names` function wasn't being used properly in a few places and instead I was using just [device.name for device in instrument.components] which was causing nested devices to get lost.