### PR TITLE
fix: [hotfix] add missing validator for one of required file sets

### DIFF
--- a/src/aind_data_schema/core/metadata.py
+++ b/src/aind_data_schema/core/metadata.py
@@ -152,9 +152,7 @@ class Metadata(DataCoreModel):
         one_of_required = REQUIRED_FILE_SETS.keys()
 
         if not any(getattr(self, file) for file in one_of_required):
-            raise ValueError(
-                f"Metadata must contain at least one of the following files: {', '.join(one_of_required)}"
-            )
+            raise ValueError(f"Metadata must contain at least one of the following files: {', '.join(one_of_required)}")
 
         return self
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -330,7 +330,7 @@ class TestMetadata(unittest.TestCase):
             )
         self.assertIn(
             "Metadata must contain at least one of the following files: subject, processing, model",
-            str(context.exception)
+            str(context.exception),
         )
 
     def test_validate_acquisition_connections(self):


### PR DESCRIPTION
We need a validator that checks that you have at minimum a "subject", "model" or "processing" file or your metadata is invalid. Those key files then have additional requirements (e.g. if you have a subject you also need data description, procedures, instrument, and acquisition). This got flagged for me when I was running the upgrader and ran into issues with metadata that *should* fail validation for having missing files, but actually passes because the file is on the of the trigger files. For example, before this PR if you were missing a subject you would still pass validation! But if you were missing one of the files that is required *when you have a subject file* then you would fail. So this fixes that loophole.

This is a backward incompatible hotfix, it should have been in 2.0 to begin with.