### PR TITLE
hotfix: recover source_data field, including validator

### DIFF
--- a/src/aind_data_schema/core/data_description.py
+++ b/src/aind_data_schema/core/data_description.py
@@ -170,11 +170,8 @@ class DataDescription(DataCoreModel):
 
     @classmethod
     def from_raw(
-        cls,
-        data_description: "DataDescription",
-        process_name: str,
-        source_data: Optional[List[str]] = None,
-        **kwargs) -> "DataDescription":
+        cls, data_description: "DataDescription", process_name: str, source_data: Optional[List[str]] = None, **kwargs
+    ) -> "DataDescription":
         """
         Create a DataLevel.DERIVED DataDescription from a DataLevel.RAW DataDescription object.
 
@@ -229,9 +226,13 @@ class DataDescription(DataCoreModel):
 
         # Upgrade source_data
         if source_data is not None:
-            new_source_data = source_data if not data_description.source_data else data_description.source_data + source_data
+            new_source_data = (
+                source_data if not data_description.source_data else data_description.source_data + source_data
+            )
         else:
-            new_source_data = [original_name] if not data_description.source_data else data_description.source_data + [original_name]
+            new_source_data = (
+                [original_name] if not data_description.source_data else data_description.source_data + [original_name]
+            )
 
         return cls(
             subject_id=get_or_default("subject_id"),

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -311,7 +311,7 @@ class DataDescriptionTest(unittest.TestCase):
         """Test from_raw with explicitly provided source_data parameter"""
         dt = datetime.datetime.now()
         f = Funding(funder=Organization.NINDS, grant_number="grant001")
-        
+
         # Create a raw DataDescription
         da = DataDescription(
             creation_time=dt,
@@ -323,21 +323,21 @@ class DataDescriptionTest(unittest.TestCase):
             investigators=[Person(name="Jane Smith")],
             project_name="Test",
         )
-        
+
         # Test scenario 3: RAW data → DERIVED with explicit source_data
         explicit_source = ["external_dataset_1", "external_dataset_2"]
         r1 = DataDescription.from_raw(da, "spikesort-ks25", source_data=explicit_source, creation_time=dt)
-        
+
         # Should use the explicit source_data instead of the original name
         self.assertIsNotNone(r1.source_data)
         self.assertEqual(len(r1.source_data), 2)
         self.assertEqual(r1.source_data, explicit_source)
         self.assertNotIn(da.name, r1.source_data)
-        
+
         # Test scenario 4: DERIVED data → DERIVED with additional source_data
         additional_source = ["another_external_dataset"]
         r2 = DataDescription.from_raw(r1, "clustering", source_data=additional_source, creation_time=dt)
-        
+
         # Should combine existing source_data with new source_data
         self.assertIsNotNone(r2.source_data)
         self.assertEqual(len(r2.source_data), 3)  # 2 from r1 + 1 additional
@@ -348,7 +348,7 @@ class DataDescriptionTest(unittest.TestCase):
         """Test source_data behavior in chained derived data without explicit source_data"""
         dt = datetime.datetime.now()
         f = Funding(funder=Organization.NINDS, grant_number="grant001")
-        
+
         # Create a raw DataDescription
         da = DataDescription(
             creation_time=dt,
@@ -360,23 +360,23 @@ class DataDescriptionTest(unittest.TestCase):
             investigators=[Person(name="Jane Smith")],
             project_name="Test",
         )
-        
+
         # First derivation: RAW → DERIVED (should set source_data to original name)
         r1 = DataDescription.from_raw(da, "spikesort-ks25", creation_time=dt)
         self.assertEqual(r1.source_data, [da.name])
-        
+
         # Second derivation: DERIVED → DERIVED (should append to existing source_data)
         r2 = DataDescription.from_raw(r1, "clustering", creation_time=dt)
         self.assertEqual(len(r2.source_data), 2)
         self.assertEqual(r2.source_data[0], da.name)  # Original source
         self.assertEqual(r2.source_data[1], r1.name)  # Previous derived data
-        
+
         # Third derivation: should continue the chain
         r3 = DataDescription.from_raw(r2, "analysis", creation_time=dt)
         self.assertEqual(len(r3.source_data), 3)
-        self.assertEqual(r3.source_data[0], da.name)   # Original source
-        self.assertEqual(r3.source_data[1], r1.name)   # First derived
-        self.assertEqual(r3.source_data[2], r2.name)   # Second derived
+        self.assertEqual(r3.source_data[0], da.name)  # Original source
+        self.assertEqual(r3.source_data[1], r1.name)  # First derived
+        self.assertEqual(r3.source_data[2], r2.name)  # Second derived
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
PR recovers a `DataDescription.source_data` field

- Field intended to be used to track the data asset name history for an asset
- Auto-populated when users use `DataDescription.from_raw` to build their derived data descriptions, including the case where you go from raw -> derived1 -> derived2 (you get a list with the names [raw, derived1]
- Optional parameter in `from_raw` allows you to pass a list of source asset names when a data asset was created from multiple upstream assets