### PR TITLE
fix: prevent attribute error being raised when value.species == None

### DIFF
--- a/src/aind_data_schema/components/subjects.py
+++ b/src/aind_data_schema/components/subjects.py
@@ -125,7 +125,7 @@ class MouseSubject(DataModel):
         """Ensure that the species and strain.species match"""
 
         if value.strain:
-            if value.species.name != value.strain.species:
+            if not value.species or value.species.name != value.strain.species:
                 raise ValueError("The animal species and it's strain's species do not match")
 
         return value


### PR DESCRIPTION
It shouldn't be possible to trigger this, but somehow it was being triggered!