### PR TITLE
fix: deprecate the channel_index field

### DIFF
--- a/docs/source/components/devices.md
+++ b/docs/source/components/devices.md
@@ -179,7 +179,7 @@ Named input or output channel on a DAQ device
 | `channel_name` | `str` |  |
 | `channel_type` | [DaqChannelType](../aind_data_schema_models/devices.md#daqchanneltype) |  |
 | `port` | `Optional[int]` |  |
-| `channel_index` | `Optional[int]` |  |
+| <del>`channel_index`</del> | `Optional[int]` | **[DEPRECATED]** Use DAQChannel.port instead. |
 | `sample_rate` | `Optional[decimal.Decimal]` |  |
 | `sample_rate_unit` | Optional[[FrequencyUnit](../aind_data_schema_models/units.md#frequencyunit)] |  |
 | `event_based_sampling` | `Optional[bool]` |  |

--- a/examples/multiplane_ophys_instrument.py
+++ b/examples/multiplane_ophys_instrument.py
@@ -337,7 +337,6 @@ instrument = Instrument(
                     channel_name="P0.3",
                     channel_type=DaqChannelType.DI,
                     port=0,
-                    channel_index=3,
                     sample_rate=100.0,
                     sample_rate_unit=FrequencyUnit.KHZ,
                 )

--- a/src/aind_data_schema/components/devices.py
+++ b/src/aind_data_schema/components/devices.py
@@ -290,7 +290,9 @@ class DAQChannel(DataModel):
 
     # optional fields
     port: Optional[int] = Field(default=None, title="DAQ port")
-    channel_index: Optional[int] = Field(default=None, title="DAQ channel index", deprecated="Use DAQChannel.port instead")
+    channel_index: Optional[int] = Field(
+        default=None, title="DAQ channel index", deprecated="Use DAQChannel.port instead"
+    )
     sample_rate: Optional[Decimal] = Field(default=None, title="DAQ channel sample rate (Hz)")
     sample_rate_unit: Optional[FrequencyUnit] = Field(default=None, title="Sample rate unit")
     event_based_sampling: Optional[bool] = Field(

--- a/src/aind_data_schema/components/devices.py
+++ b/src/aind_data_schema/components/devices.py
@@ -4,6 +4,7 @@ from datetime import date
 from decimal import Decimal
 from enum import Enum
 from typing import List, Literal, Optional
+import warnings
 
 from aind_data_schema_models.coordinates import AnatomicalRelative
 from aind_data_schema_models.devices import (
@@ -289,12 +290,22 @@ class DAQChannel(DataModel):
 
     # optional fields
     port: Optional[int] = Field(default=None, title="DAQ port")
-    channel_index: Optional[int] = Field(default=None, title="DAQ channel index")
+    channel_index: Optional[int] = Field(default=None, title="DAQ channel index", description="[Deprecated: use port]")
     sample_rate: Optional[Decimal] = Field(default=None, title="DAQ channel sample rate (Hz)")
     sample_rate_unit: Optional[FrequencyUnit] = Field(default=None, title="Sample rate unit")
     event_based_sampling: Optional[bool] = Field(
         default=None, title="Set to true if DAQ channel is sampled at irregular intervals"
     )
+
+    @field_validator("channel_index", mode="after")
+    def deprecated_channel_index(cls, value: Optional[int]) -> Optional[int]:
+        """Warn if channel_index is used (deprecated)"""
+        if value is not None:
+            warnings.warn(
+                "DAQChannel.channel_index is deprecated. Use DAQChannel.port instead.",
+                DeprecationWarning,
+            )
+        return value
 
 
 class DAQDevice(Device):

--- a/src/aind_data_schema/components/devices.py
+++ b/src/aind_data_schema/components/devices.py
@@ -290,7 +290,7 @@ class DAQChannel(DataModel):
 
     # optional fields
     port: Optional[int] = Field(default=None, title="DAQ port")
-    channel_index: Optional[int] = Field(default=None, title="DAQ channel index", description="[Deprecated: use port]")
+    channel_index: Optional[int] = Field(default=None, title="DAQ channel index", deprecated="Use DAQChannel.port instead")
     sample_rate: Optional[Decimal] = Field(default=None, title="DAQ channel sample rate (Hz)")
     sample_rate_unit: Optional[FrequencyUnit] = Field(default=None, title="Sample rate unit")
     event_based_sampling: Optional[bool] = Field(

--- a/src/aind_data_schema/utils/docs/model_generator.py
+++ b/src/aind_data_schema/utils/docs/model_generator.py
@@ -236,6 +236,17 @@ def generate_markdown_table(model: Type[BaseModel], stop_at: Type[BaseModel]) ->
     for name, (annotation, field_info) in fields.items():
         type_str = get_type_string(annotation)
         desc = field_info.description or ""
+        
+        # Check if field is deprecated
+        is_deprecated = hasattr(field_info, 'deprecated') and field_info.deprecated
+        
+        # Format field name with strikethrough if deprecated
+        field_name = f"<del>`{name}`</del>" if is_deprecated else f"`{name}`"
+        
+        # Prefix description with [DEPRECATED] if deprecated
+        if is_deprecated:
+            deprecated_msg = field_info.deprecated if isinstance(field_info.deprecated, str) else ""
+            desc = f"**[DEPRECATED]** {deprecated_msg}. {desc}".strip()
 
         # Check of the type_str includes a markdown link [text](link)
         link_regex = r"\[.*?\]\(.*?\)"
@@ -243,9 +254,9 @@ def generate_markdown_table(model: Type[BaseModel], stop_at: Type[BaseModel]) ->
         class_regex = r"\{.*?\}"
         if re.search(link_regex, type_str) or re.search(class_regex, type_str):
             # type str has a link, don't break the link
-            rows.append(f"| `{name}` | {type_str} | {desc} |")
+            rows.append(f"| {field_name} | {type_str} | {desc} |")
         else:
-            rows.append(f"| `{name}` | `{type_str}` | {desc} |")
+            rows.append(f"| {field_name} | `{type_str}` | {desc} |")
 
     return header + "\n".join(rows) + "\n"
 

--- a/src/aind_data_schema/utils/docs/model_generator.py
+++ b/src/aind_data_schema/utils/docs/model_generator.py
@@ -236,13 +236,13 @@ def generate_markdown_table(model: Type[BaseModel], stop_at: Type[BaseModel]) ->
     for name, (annotation, field_info) in fields.items():
         type_str = get_type_string(annotation)
         desc = field_info.description or ""
-        
+
         # Check if field is deprecated
-        is_deprecated = hasattr(field_info, 'deprecated') and field_info.deprecated
-        
+        is_deprecated = hasattr(field_info, "deprecated") and field_info.deprecated
+
         # Format field name with strikethrough if deprecated
         field_name = f"<del>`{name}`</del>" if is_deprecated else f"`{name}`"
-        
+
         # Prefix description with [DEPRECATED] if deprecated
         if is_deprecated:
             deprecated_msg = field_info.deprecated if isinstance(field_info.deprecated, str) else ""

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,8 +1,10 @@
 """ test Device models"""
 
 import unittest
+import warnings
 
 from aind_data_schema_models.coordinates import AnatomicalRelative
+from aind_data_schema_models.devices import DaqChannelType
 from aind_data_schema_models.harp_types import HarpDeviceType
 from aind_data_schema_models.organizations import Organization
 
@@ -10,6 +12,7 @@ from aind_data_schema.components.coordinates import CoordinateSystemLibrary, Tra
 from aind_data_schema.components.devices import Filter, FilterType
 from aind_data_schema.components.devices import (
     AdditionalImagingDevice,
+    DAQChannel,
     DataInterface,
     Detector,
     DetectorType,
@@ -185,6 +188,24 @@ class FilterTests(unittest.TestCase):
                 center_wavelength=500,
             )
         self.assertIn("center_wavelength must be a list of wavelengths", str(e3.exception))
+
+
+class DAQChannelTests(unittest.TestCase):
+    """tests DAQChannel schemas"""
+
+    def test_deprecated_channel_index(self):
+        """Test that using channel_index raises a deprecation warning"""
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            DAQChannel(channel_name="test_channel", channel_type=DaqChannelType.DI, channel_index=1)
+
+            # Check that a deprecation warning was raised
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[0].category, DeprecationWarning))
+            self.assertIn("DAQChannel.channel_index is deprecated", str(w[0].message))
+            self.assertIn("Use DAQChannel.port instead", str(w[0].message))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
PR deprecates the channel_index field and throws a warning if a user uses the field. Also changes how the documentation handles the `deprecated` annotation to display ~~strikethrough~~ on the field name and a bold [DEPRECATED] in the description.