### PR TITLE
refactor: replace use of DiscList with DiscTuple for TRANSFORM_TYPES

### DIFF
--- a/docs/source/example_workflow/example_workflow.py
+++ b/docs/source/example_workflow/example_workflow.py
@@ -128,7 +128,7 @@ def generate_procedures(
             )
         ],
         targeted_structure=getattr(CCFv3, brain_area.upper()),
-        coordinates=[coord],  # Note: this is a list, because we could have multiple depths
+        coordinates=[(coord)],  # Note: this is a list, because we could have multiple depths
         dynamics=[
             InjectionDynamics(
                 volume=injection_volume,

--- a/examples/ophys_procedures.py
+++ b/examples/ophys_procedures.py
@@ -82,11 +82,11 @@ p = Procedures(
                     ],
                     coordinate_system_name=CoordinateSystemLibrary.BREGMA_ARID.name,
                     coordinates=[
-                        [
+                        (
                             Translation(
                                 translation=[-600, -3050, 0, 4200],
                             ),
-                        ],
+                        ),
                     ],
                     dynamics=[
                         InjectionDynamics(

--- a/examples/procedures.py
+++ b/examples/procedures.py
@@ -94,12 +94,12 @@ surgery1 = Surgery(
             ],
             coordinate_system_name=coordinate_system.name,
             coordinates=[
-                [
+                (
                     Translation(translation=[-0.85, -3.8, 0, 3.3]),
                     Rotation(
                         angles=[0, 10, 0],
                     ),
-                ],
+                ),
             ],
             dynamics=[
                 InjectionDynamics(

--- a/src/aind_data_schema/base.py
+++ b/src/aind_data_schema/base.py
@@ -5,7 +5,7 @@ import logging
 import re
 import warnings
 from pathlib import Path
-from typing import Any, ClassVar, List, Literal, Optional, TypeVar, get_args
+from typing import Any, ClassVar, List, Literal, Optional, Tuple, TypeVar, get_args
 
 from pydantic import (
     AwareDatetime,
@@ -98,6 +98,7 @@ class GenericModel(BaseModel, extra="allow"):
 T = TypeVar("T")
 Discriminated = Annotated[T, Field(discriminator="object_type")]
 DiscriminatedList = List[Discriminated[T]]
+DiscriminatedTuple = Tuple[Discriminated[T], ...]
 
 
 class DataModel(BaseModel):

--- a/src/aind_data_schema/components/coordinates.py
+++ b/src/aind_data_schema/components/coordinates.py
@@ -8,7 +8,7 @@ from aind_data_schema_models.coordinates import AxisName, Direction, Origin
 from aind_data_schema_models.units import AngleUnit, SizeUnit
 from pydantic import Field
 
-from aind_data_schema.base import DataModel, DiscriminatedList
+from aind_data_schema.base import DataModel, DiscriminatedTuple
 from aind_data_schema.components.wrappers import AssetPath
 
 
@@ -189,8 +189,8 @@ class NonlinearTransform(DataModel):
     )
 
 
-TRANSFORM_TYPES = DiscriminatedList[Translation | Rotation | Scale | Affine]
-TRANSFORM_TYPES_NONLINEAR = DiscriminatedList[Translation | Rotation | Scale | Affine | NonlinearTransform]
+TRANSFORM_TYPES = DiscriminatedTuple[Translation | Rotation | Scale | Affine]
+TRANSFORM_TYPES_NONLINEAR = DiscriminatedTuple[Translation | Rotation | Scale | Affine | NonlinearTransform]
 
 
 class CoordinateSystem(DataModel):

--- a/src/aind_data_schema/components/coordinates.py
+++ b/src/aind_data_schema/components/coordinates.py
@@ -8,7 +8,7 @@ from aind_data_schema_models.coordinates import AxisName, Direction, Origin
 from aind_data_schema_models.units import AngleUnit, SizeUnit
 from pydantic import Field
 
-from aind_data_schema.base import DataModel, DiscriminatedTuple
+from aind_data_schema.base import DataModel, DiscriminatedList
 from aind_data_schema.components.wrappers import AssetPath
 
 
@@ -189,8 +189,8 @@ class NonlinearTransform(DataModel):
     )
 
 
-TRANSFORM_TYPES = DiscriminatedTuple[Translation | Rotation | Scale | Affine]
-TRANSFORM_TYPES_NONLINEAR = DiscriminatedTuple[Translation | Rotation | Scale | Affine | NonlinearTransform]
+TRANSFORM_TYPES = DiscriminatedList[Translation | Rotation | Scale | Affine]
+TRANSFORM_TYPES_NONLINEAR = DiscriminatedList[Translation | Rotation | Scale | Affine | NonlinearTransform]
 
 
 class CoordinateSystem(DataModel):

--- a/src/aind_data_schema/components/surgery_procedures.py
+++ b/src/aind_data_schema/components/surgery_procedures.py
@@ -1,7 +1,7 @@
 """Surgery procedures components for AIND data schema."""
 
 from enum import Enum
-from typing import List, Optional, Union
+from typing import List, Optional, Tuple, Union
 
 from aind_data_schema_models.brain_atlas import BrainStructureModel
 from aind_data_schema_models.coordinates import AnatomicalRelative
@@ -176,7 +176,7 @@ class BrainInjection(Injection):
     """Description of an injection procedure into a brain"""
 
     coordinate_system_name: str = Field(..., title="Coordinate system name")
-    coordinates: List[TRANSFORM_TYPES] = Field(..., title="Injection coordinate, depth, and rotation")
+    coordinates: Tuple[TRANSFORM_TYPES] = Field(..., title="Injection coordinate, depth, and rotation")
     targeted_structure: Optional[BrainStructureModel] = Field(default=None, title="Injection targeted brain structure")
 
     @model_validator(mode="after")

--- a/tests/test_procedures.py
+++ b/tests/test_procedures.py
@@ -214,11 +214,11 @@ class ProceduresTests(unittest.TestCase):
                                 )
                             ],
                             coordinates=[
-                                [
+                                (
                                     Translation(
                                         translation=[0.5, 1, 0, 1],
                                     ),
-                                ],
+                                ),
                             ],
                             targeted_structure=CCFv3.VISP6A,
                         ),
@@ -334,16 +334,16 @@ class ProceduresTests(unittest.TestCase):
             protocol_id="abc",
             coordinate_system_name="BREGMA_ARI",
             coordinates=[
-                [
+                (
                     Translation(
                         translation=[0.5, 1, 0, 0],
                     ),
-                ],
-                [
+                ),
+                (
                     Translation(
                         translation=[0.5, 1, 0, 1],
                     ),
-                ],
+                ),
             ],
             dynamics=[
                 InjectionDynamics(
@@ -377,16 +377,16 @@ class ProceduresTests(unittest.TestCase):
                 protocol_id="abc",
                 coordinate_system_name="BREGMA_ARI",
                 coordinates=[
-                    [
+                    (
                         Translation(
                             translation=[0.5, 1, 0, 0],
                         ),
-                    ],
-                    [
+                    ),
+                    (
                         Translation(
                             translation=[0.5, 1, 0, 1],
                         ),
-                    ],
+                    ),
                 ],
                 injection_materials=[
                     ViralMaterial(


### PR DESCRIPTION
This PR creates a new type `DicriminatedTuple` and replaces the use of DiscriminatedList in TRANSFORM_TYPES. The purpose of this is to make it more clear in `BrainInjection` objects that there is a list of injections (usually multiple injections at different depths on the same trajectory), each of which is a set of Translations and/or Rotations. Previously you would get things like:

`coordinates = [[Inj0_Translation, Rotation], [Inj1_Translation, Rotation]]`

Now you get:

`coordinates = [(Inj0_Translation, Rotation), (Inj1_Translation, Rotation)]`

Making it a tiny bit more clear that this a set of transforms being applied together. This is a backwards compatible change since JSON arrays can deserialize to list or tuple.