### PR TITLE
refactor: remove custom exceptions, instead raise ValueError

### DIFF
--- a/src/aind_data_schema/utils/validators.py
+++ b/src/aind_data_schema/utils/validators.py
@@ -123,8 +123,8 @@ def _recurse_helper(data, **kwargs):
 
 def _system_check_helper(data, coordinate_system_name: Optional[str], axis_count: Optional[int]):
     """Helper function to raise errors if the coordinate_system_name or axis_count don't match"""
-    object_type = getattr(data, 'object_type', type(data).__name__)
-    
+    object_type = getattr(data, "object_type", type(data).__name__)
+
     if not coordinate_system_name or not axis_count:
         raise ValueError(
             f"CoordinateSystem is required when a Transform or Coordinate is present (object_type: {object_type})"

--- a/src/aind_data_schema/utils/validators.py
+++ b/src/aind_data_schema/utils/validators.py
@@ -23,34 +23,6 @@ class TimeValidation(Enum):
     """Time should be before the end time."""
 
 
-class CoordinateSystemException(Exception):
-    """Raised when a coordinate system is missing."""
-
-    def __init__(self):
-        """Initialize the exception."""
-        super().__init__("CoordinateSystem is required when a Transform or Coordinate is present")
-
-
-class SystemNameException(Exception):
-    """Raised when there is a system name mismatch."""
-
-    def __init__(self, expected, found):
-        """Initialize the exception with the expected and found axis counts."""
-        self.expected = expected
-        self.found = found
-        super().__init__(f"System name mismatch, expected {expected}, found {found}")
-
-
-class AxisCountException(Exception):
-    """Raised when the axis count does not match."""
-
-    def __init__(self, expected, found):
-        """Initialize the exception with the expected and found axis counts."""
-        self.expected = expected
-        self.found = found
-        super().__init__(f"Axis count mismatch, expected {expected} axes, but found {found}")
-
-
 def subject_specimen_id_compatibility(subject_id: str, specimen_id: str) -> bool:
     """Check whether a subject_id and specimen_id are compatible"""
     return subject_id in specimen_id
@@ -149,13 +121,20 @@ def _recurse_helper(data, **kwargs):
             recursive_coord_system_check(attr_value, **kwargs)
 
 
-def _system_check_helper(data, coordinate_system_name: str, axis_count: int):
+def _system_check_helper(data, coordinate_system_name: Optional[str], axis_count: Optional[int]):
     """Helper function to raise errors if the coordinate_system_name or axis_count don't match"""
+    object_type = getattr(data, 'object_type', type(data).__name__)
+    
     if not coordinate_system_name or not axis_count:
-        raise CoordinateSystemException()
+        raise ValueError(
+            f"CoordinateSystem is required when a Transform or Coordinate is present (object_type: {object_type})"
+        )
 
     if data.coordinate_system_name not in coordinate_system_name:
-        raise SystemNameException(coordinate_system_name, data.coordinate_system_name)
+        raise ValueError(
+            f"System name mismatch for {object_type}, expected {coordinate_system_name}, "
+            f"found {data.coordinate_system_name}"
+        )
 
     # Check lengths of subfields based on class types
     if hasattr(data, "__dict__"):
@@ -169,10 +148,13 @@ def _system_check_helper(data, coordinate_system_name: str, axis_count: int):
                 if sub_data and hasattr(sub_data, field_name):
                     field_value = getattr(sub_data, field_name)
                     if len(field_value) != axis_count:
-                        raise AxisCountException(axis_count, len(field_value))
+                        raise ValueError(
+                            f"Axis count mismatch for {object_type}, expected {axis_count} axes, "
+                            f"but found {len(field_value)}"
+                        )
 
 
-def recursive_coord_system_check(data, coordinate_system_name: str, axis_count: int):
+def recursive_coord_system_check(data, coordinate_system_name: Optional[str], axis_count: Optional[int]):
     """Recursively check fields, see if they are Coordinates and check if they match a List[values]
 
     Note that we just need to check if the axes all show up, not necessarily in matching order

--- a/tests/test_utils_validators.py
+++ b/tests/test_utils_validators.py
@@ -13,9 +13,6 @@ from aind_data_schema.base import AwareDatetimeWithDefault, DataModel
 from aind_data_schema.components.coordinates import Rotation, Scale, Translation
 from aind_data_schema.components.wrappers import AssetPath
 from aind_data_schema.utils.validators import (
-    AxisCountException,
-    CoordinateSystemException,
-    SystemNameException,
     TimeValidation,
     _convert_to_comparable,
     _recurse_helper,
@@ -107,27 +104,27 @@ class TestRecursiveSystemCheckHelper(unittest.TestCase):
 
     def test_system_check_helper_missing_system_name(self):
         """Test _system_check_helper with missing coordinate_system_name"""
-        with self.assertRaises(CoordinateSystemException):
+        with self.assertRaises(ValueError):
             _system_check_helper(self.translation_wrapper, None, axis_count=2)
 
     def test_system_check_helper_missing_axis_count(self):
         """Test _system_check_helper with missing axis_count"""
-        with self.assertRaises(CoordinateSystemException):
+        with self.assertRaises(ValueError):
             _system_check_helper(self.translation_wrapper, self.coordinate_system_name, axis_count=None)
 
     def test_system_check_helper_wrong_system_name(self):
         """Test _system_check_helper with wrong coordinate_system_name"""
-        with self.assertRaises(SystemNameException) as context:
+        with self.assertRaises(ValueError) as context:
             _system_check_helper(self.translation_wrapper, "WRONG_SYSTEM", axis_count=2)
-        self.assertEqual("WRONG_SYSTEM", context.exception.expected)
-        self.assertEqual(self.coordinate_system_name, context.exception.found)
+        self.assertIn("WRONG_SYSTEM", str(context.exception))
+        self.assertIn(self.coordinate_system_name, str(context.exception))
 
     def test_system_check_helper_wrong_axis_count(self):
         """Test _system_check_helper with wrong axis_count"""
-        with self.assertRaises(AxisCountException) as context:
+        with self.assertRaises(ValueError) as context:
             _system_check_helper(self.translation_wrapper, self.coordinate_system_name, axis_count=3)
-        self.assertEqual(3, context.exception.expected)
-        self.assertEqual(2, context.exception.found)
+        self.assertIn("3", str(context.exception))
+        self.assertIn("2", str(context.exception))
 
     def test_system_check_helper_multiple_axis_types(self):
         """Test _system_check_helper with multiple axis types"""
@@ -176,7 +173,7 @@ class TestRecursiveCoordSystemCheck(unittest.TestCase):
                 translation=[0.5, 1],
             ),
         )
-        with self.assertRaises(SystemNameException) as context:
+        with self.assertRaises(ValueError) as context:
             recursive_coord_system_check(data, self.coordinate_system_name, axis_count=2)
 
         self.assertIn("System name mismatch", str(context.exception))
@@ -212,7 +209,7 @@ class TestRecursiveCoordSystemCheck(unittest.TestCase):
                 translation=[0.5, 1, 2],
             ),
         )
-        with self.assertRaises(AxisCountException) as context:
+        with self.assertRaises(ValueError) as context:
             recursive_coord_system_check(data, self.coordinate_system_name, axis_count=2)
 
         self.assertIn("Axis count mismatch", str(context.exception))
@@ -227,7 +224,7 @@ class TestRecursiveCoordSystemCheck(unittest.TestCase):
 
         data = MockData(coordinate_system_name=self.coordinate_system_name)
 
-        with self.assertRaises(CoordinateSystemException) as context:
+        with self.assertRaises(ValueError) as context:
             recursive_coord_system_check(data, None, axis_count=0)
 
         self.assertIn("CoordinateSystem is required", str(context.exception))


### PR DESCRIPTION
This PR removes some custom exceptions, which weren't getting properly wrapped as ValidationError by pydantic. The intention was to raise ValidationErrors, I didn't realize that only a specific set of exceptions get wrapped.

Note there's an actual bug in the logic which will be fixed in a separate PR: https://github.com/AllenNeuralDynamics/aind-data-schema/issues/1556