### PR TITLE
Updated coordinates doc to include between-vertebrae coordinate origins

### DIFF
--- a/docs/source/aind_data_schema_models/coordinates.md
+++ b/docs/source/aind_data_schema_models/coordinates.md
@@ -64,13 +64,6 @@ Origin positions for coordinate systems
 | `ORIGIN` | `Origin` |
 | `BREGMA` | `Bregma` |
 | `LAMBDA` | `Lambda` |
-| `C1` | `C1` |
-| `C2` | `C2` |
-| `C3` | `C3` |
-| `C4` | `C4` |
-| `C5` | `C5` |
-| `C6` | `C6` |
-| `C7` | `C7` |
 | `BETWEEN_C1_C2` | `Between_C1-C2` |
 | `BETWEEN_C2_C3` | `Between_C2-C3` |
 | `BETWEEN_C3_C4` | `Between_C3-C4` |

--- a/docs/source/aind_data_schema_models/coordinates.md
+++ b/docs/source/aind_data_schema_models/coordinates.md
@@ -71,6 +71,14 @@ Origin positions for coordinate systems
 | `C5` | `C5` |
 | `C6` | `C6` |
 | `C7` | `C7` |
+| `BETWEEN_C1_C2` | `Between_C1-C2` |
+| `BETWEEN_C2_C3` | `Between_C2-C3` |
+| `BETWEEN_C3_C4` | `Between_C3-C4` |
+| `BETWEEN_C4_C5` | `Between_C4-C5` |
+| `BETWEEN_C6_C7` | `Between_C6-C7` |
+| `BETWEEN_C7_C8` | `Between_C7-C8` |
+| `BETWEEN_C8_T1` | `Between_C8-T1` |
+| `BETWEEN_T1_T2` | `Between_T1-T2` |
 | `TIP` | `Tip` |
 | `FRONT_CENTER` | `Front_center` |
 | `ARENA_CENTER` | `Arena_center` |


### PR DESCRIPTION
Solving https://github.com/AllenNeuralDynamics/aind-data-schema/issues/1564 requires a change to aind-data-schema-models. Here is the corresponding PR: https://github.com/AllenNeuralDynamics/aind-data-schema-models/pull/244.

This PR simply updates documentation to match.

Closes https://github.com/AllenNeuralDynamics/aind-data-schema/issues/1564