### PR TITLE
fix: adds check if dependency_graph is None

### DIFF
--- a/src/aind_data_schema/core/processing.py
+++ b/src/aind_data_schema/core/processing.py
@@ -182,6 +182,10 @@ class Processing(DataCoreModel):
         if not hasattr(values, "data_processes"):  # bypass for testing
             return values
 
+        # If the dependency_graph is None, then no need to validate
+        if values.dependency_graph is None:
+            return values
+
         processes = set(values.process_names)
         # Validate that all processes have a unique name
         if len(processes) != len(values.data_processes):

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -301,6 +301,33 @@ class ProcessingTest(unittest.TestCase):
             Processing(data_processes=[process1, process2], dependency_graph=invalid_graph)
         self.assertIn("data_processes must include all processes in dependency_graph", str(e.exception))
 
+    def test_dependency_graph_none(self):
+        """Tests that no issue is raised if dependency_graph is None"""
+        processing = Processing(
+            data_processes=[
+                DataProcess(
+                    start_date_time=datetime(2024, 10, 10, 1, 2, 3),
+                    end_date_time=datetime(2024, 10, 11, 1, 2, 3),
+                    process_type=ProcessName.COMPRESSION,
+                    experimenters=["AIND Scientific Computing"],
+                    stage=ProcessStage.PROCESSING,
+                    code=Code(
+                        url="www.example.com/ephys_compression",
+                    ),
+                ),
+                DataProcess(
+                    start_date_time=datetime(2024, 10, 10, 1, 2, 3),
+                    end_date_time=datetime(2024, 10, 11, 1, 2, 4),
+                    process_type=ProcessName.OTHER,
+                    experimenters=["AIND Scientific Computing"],
+                    stage=ProcessStage.PROCESSING,
+                    code=Code(url=""),
+                    notes="Data was copied.",
+                ),
+            ]
+        )
+        self.assertIsNone(processing.dependency_graph)
+
     def test_validate_pipeline_names(self):
         """Test the validate_pipeline_names method"""
 


### PR DESCRIPTION
Closes #1574

- Fixes a bug where the default `None` value for the Processing.dependency_graph field raises an error in a validator
- Running the linters introduced many changes across many files. I opened a ticket to suggest committing the linter changes whenever a PR is merged, but don't want to add these many changes directly to the main branch.