### PR TITLE
fix: pydantic 2.12 compatible model validators

### DIFF
--- a/src/aind_data_schema/base.py
+++ b/src/aind_data_schema/base.py
@@ -149,7 +149,7 @@ class DataModel(BaseModel):
         return first_part + second_part
 
     @model_validator(mode="after")
-    def unit_validator(cls, values):
+    def unit_validator(self):
         """Ensure that all fields matching the pattern variable_unit are set if
         they have a matching variable that is set (!= None)
 
@@ -157,6 +157,7 @@ class DataModel(BaseModel):
         if any of variable_* are set
         """
         # Accumulate a dictionary mapping variable : unit/unit_value
+        values = self.model_dump().items()
         for unit_name, unit_value in values:
             if "_unit" in unit_name and not unit_value:
                 var_name = unit_name.rsplit("_unit", 1)[0]
@@ -173,7 +174,7 @@ class DataModel(BaseModel):
                     if var_name is not unit_name:
                         if var_name in variable_name and variable_value:
                             raise ValueError(f"Unit {unit_name} is required when {variable_name} is set.")
-        return values
+        return self
 
 
 class DataCoreModel(DataModel):
@@ -254,9 +255,9 @@ class DataCoreModel(DataModel):
             logging.warning(f"File size exceeds {MAX_FILE_SIZE / 1024} KB: {filename}")
 
     @model_validator(mode="after")
-    def coordinate_system_validator(cls, data):
+    def coordinate_system_validator(self):
         """Validate that all coordinates match the defined coordinate system"""
 
-        recursive_coord_system_check(data, None, None)
+        recursive_coord_system_check(self, None, None)
 
-        return data
+        return self

--- a/src/aind_data_schema/components/configs.py
+++ b/src/aind_data_schema/components/configs.py
@@ -377,7 +377,7 @@ class LickSpoutConfig(DeviceConfig):
     notes: Optional[str] = Field(default=None, title="Notes", validate_default=True)
 
     @model_validator(mode="after")
-    def validate_other(cls, values):
+    def validate_other(values):
         """Validator for other/notes"""
 
         if values.solution == Liquid.OTHER and not values.notes:

--- a/src/aind_data_schema/components/devices.py
+++ b/src/aind_data_schema/components/devices.py
@@ -82,8 +82,7 @@ class Device(DataModel):
     notes: Optional[str] = Field(default=None, title="Notes")
 
     @model_validator(mode="after")
-    @classmethod
-    def validate_manufacturer_notes(cls, values):
+    def validate_manufacturer_notes(values):
         """Ensure that notes are not empty if manufacturer is 'other'"""
 
         if hasattr(values, "manufacturer") and values.manufacturer is not None:
@@ -110,8 +109,7 @@ class DevicePosition(DataModel):
     )
 
     @model_validator(mode="after")
-    @classmethod
-    def validate_transform_and_cs(cls, values):
+    def validate_transform_and_cs(values):
         """Ensure that transform and coordinate system are either both set or both unset"""
         transform = values.transform
         coordinate_system = values.coordinate_system

--- a/src/aind_data_schema/components/injection_procedures.py
+++ b/src/aind_data_schema/components/injection_procedures.py
@@ -95,7 +95,7 @@ class InjectionDynamics(DataModel):
     alternating_current: Optional[str] = Field(default=None, title="Alternating current")
 
     @model_validator(mode="after")
-    def check_volume_or_current(cls, values):
+    def check_volume_or_current(values):
         """Check that either volume or injection_current is provided"""
         if not values.volume and not values.injection_current:
             raise ValueError("Either volume or injection_current must be provided.")

--- a/src/aind_data_schema/components/specimen_procedures.py
+++ b/src/aind_data_schema/components/specimen_procedures.py
@@ -49,8 +49,7 @@ class Section(DataModel):
     )
 
     @model_validator(mode="after")
-    @classmethod
-    def check_one_of_end_thickness(cls, values):
+    def check_one_of_end_thickness(values):
         """Ensure that either end_coordinate or thickness is provided"""
 
         if not values.end_coordinate and not values.thickness:

--- a/src/aind_data_schema/components/surgery_procedures.py
+++ b/src/aind_data_schema/components/surgery_procedures.py
@@ -107,7 +107,7 @@ class Craniotomy(DataModel):
     dura_removed: Optional[bool] = Field(default=None, title="Dura removed")
 
     @model_validator(mode="after")
-    def check_system_if_position(cls, values):
+    def check_system_if_position(values):
         """Ensure that coordinate_system_name is provided if position is provided"""
 
         if values.position and not values.coordinate_system_name:
@@ -115,7 +115,7 @@ class Craniotomy(DataModel):
         return values
 
     @model_validator(mode="after")
-    def check_position(cls, values):
+    def check_position(values):
         """Ensure a position is provided for certain craniotomy types"""
 
         POS_REQUIRED = [CraniotomyType.CIRCLE, CraniotomyType.SQUARE, CraniotomyType.WHC]
@@ -125,7 +125,7 @@ class Craniotomy(DataModel):
         return values
 
     @model_validator(mode="after")
-    def validate_size(cls, values):
+    def validate_size(values):
         """Ensure that size is provided for certain craniotomy types"""
 
         SIZE_REQUIRED = [CraniotomyType.CIRCLE, CraniotomyType.SQUARE]

--- a/src/aind_data_schema/core/instrument.py
+++ b/src/aind_data_schema/core/instrument.py
@@ -213,7 +213,7 @@ class Instrument(DataCoreModel):
         return self
 
     @model_validator(mode="after")
-    def validate_modality_device_dependencies(cls, value):
+    def validate_modality_device_dependencies(value):
         """
         Validate that devices exist for the modalities specified.
 

--- a/src/aind_data_schema/core/metadata.py
+++ b/src/aind_data_schema/core/metadata.py
@@ -201,8 +201,7 @@ class Metadata(DataCoreModel):
         return self
 
     @model_validator(mode="after")
-    @classmethod
-    def validate_acquisition_active_devices(cls, values):
+    def validate_acquisition_active_devices(values):
         """Ensure that all Acquisition.data_streams.active_devices exist in either the instrument or procedures."""
 
         active_devices = []

--- a/src/aind_data_schema/core/processing.py
+++ b/src/aind_data_schema/core/processing.py
@@ -175,8 +175,7 @@ class Processing(DataCoreModel):
         return cls(dependency_graph=dependency_graph, data_processes=data_processes, **kwargs)
 
     @model_validator(mode="after")
-    @classmethod
-    def validate_process_graph(cls, values):
+    def validate_process_graph(values):
         """Check that the same processes are represented in data_processes and dependency_graph"""
 
         if not hasattr(values, "data_processes"):  # bypass for testing
@@ -205,8 +204,7 @@ class Processing(DataCoreModel):
         return values
 
     @model_validator(mode="after")
-    @classmethod
-    def validate_pipeline_names(cls, values):
+    def validate_pipeline_names(values):
         """Ensure that all pipeline names in the processes are in the pipelines list"""
 
         if not hasattr(values, "data_processes"):  # bypass for testing

--- a/src/aind_data_schema/core/quality_control.py
+++ b/src/aind_data_schema/core/quality_control.py
@@ -72,7 +72,7 @@ class QCMetric(DataModel):
         return self.status_history[-1]
 
     @model_validator(mode="after")
-    def validate_multi_asset(cls, v):
+    def validate_multi_asset(v):
         """Ensure that evaluated_assets is set correctly for multi-asset metrics"""
         if v.stage == Stage.MULTI_ASSET and (not v.evaluated_assets or len(v.evaluated_assets) == 0):
             raise ValueError(f"Metric '{v.name}' is a multi-asset metric and must have evaluated_assets set.")


### PR DESCRIPTION
Apparently "after" mode validators were unintentionally and silently being converted to classmethods, and that behavior was stopped in the latest pydantic release!
I made minimal changes, not renaming all args to the expected "self" so feel free to update that if desired.