### PR TITLE
fix: allow acquisition/procedures with None coordinate_system to merge

### DIFF
--- a/src/aind_data_schema/core/procedures.py
+++ b/src/aind_data_schema/core/procedures.py
@@ -14,7 +14,7 @@ from aind_data_schema.components.subject_procedures import (
     TrainingProtocol,
     WaterRestriction,
 )
-from aind_data_schema.utils.merge import merge_notes
+from aind_data_schema.utils.merge import merge_notes, merge_coordinate_systems
 from aind_data_schema.utils.validators import subject_specimen_id_compatibility
 
 
@@ -107,17 +107,12 @@ class Procedures(DataCoreModel):
         if not self.subject_id == other.subject_id:
             raise ValueError("Subject IDs must match to combine Procedures objects.")
 
-        # Check for incompatible coordinate systems
-        if self.coordinate_system != other.coordinate_system:
-            raise ValueError(
-                "Cannot combine Procedures objects with different coordinate systems: "
-                f"{self.coordinate_system} vs {other.coordinate_system}"
-            )
+        coordinate_system = merge_coordinate_systems(self.coordinate_system, other.coordinate_system)
 
         return Procedures(
             subject_id=self.subject_id,
             subject_procedures=self.subject_procedures + other.subject_procedures,
             specimen_procedures=self.specimen_procedures + other.specimen_procedures,
-            coordinate_system=self.coordinate_system,
+            coordinate_system=coordinate_system,
             notes=merge_notes(self.notes, other.notes),
         )

--- a/src/aind_data_schema/utils/merge.py
+++ b/src/aind_data_schema/utils/merge.py
@@ -30,3 +30,14 @@ def merge_notes(notes1: Optional[str], notes2: Optional[str]) -> Optional[str]:
     else:
         notes = notes1 if notes1 else notes2
     return notes
+
+
+def merge_coordinate_systems(cs1: Optional[Any], cs2: Optional[Any]) -> Optional[Any]:
+    """Merge two coordinate system strings"""
+
+    if cs1 and cs2:
+        if cs1 != cs2:
+            raise ValueError(f"Cannot merge differing coordinate systems: '{cs1.name}' and '{cs2.name}'")
+        return cs1
+    else:
+        return cs1 if cs1 else cs2

--- a/tests/test_procedures.py
+++ b/tests/test_procedures.py
@@ -736,7 +736,7 @@ class ProceduresTests(unittest.TestCase):
         with self.assertRaises(ValueError) as context:
             _ = p1 + p2
 
-        self.assertIn("Cannot combine Procedures objects with different coordinate systems", str(context.exception))
+        self.assertIn("Cannot merge differing coordinate systems", str(context.exception))
         self.assertIn("BREGMA_ARI", str(context.exception))
         self.assertIn("BREGMA_ARID", str(context.exception))
 

--- a/tests/test_utils_merge.py
+++ b/tests/test_utils_merge.py
@@ -2,7 +2,8 @@
 
 import unittest
 
-from aind_data_schema.utils.merge import merge_notes, merge_optional_list
+from aind_data_schema.components.coordinates import CoordinateSystemLibrary
+from aind_data_schema.utils.merge import merge_notes, merge_optional_list, merge_coordinate_systems
 
 
 class TestMergeNotes(unittest.TestCase):
@@ -110,6 +111,44 @@ class MergeOptionalListTests(unittest.TestCase):
     def test_both_non_empty(self):
         """Test when both inputs are non-empty lists"""
         self.assertEqual(merge_optional_list([1, 2], [3, 4]), [1, 2, 3, 4])
+
+
+class MergeCSTests(unittest.TestCase):
+    """Tests for merge_coordinate_systems"""
+
+    def setUp(self):
+        """Set up test cases"""
+        self.CSA = CoordinateSystemLibrary.BREGMA_ARI
+        self.CSB = CoordinateSystemLibrary.MPM_MANIP_RFB
+
+    def test_both_none(self):
+        """Test when both inputs are None"""
+
+        self.assertIsNone(merge_coordinate_systems(None, None))
+
+    def test_first_none(self):
+        """Test when first input is None"""
+
+        self.assertEqual(merge_coordinate_systems(None, self.CSA), self.CSA)
+
+    def test_second_none(self):
+        """Test when second input is None"""
+
+        self.assertEqual(merge_coordinate_systems(self.CSA, None), self.CSA)
+
+    def test_both_same(self):
+        """Test when both inputs are the same"""
+
+        self.assertEqual(
+            merge_coordinate_systems(self.CSA, self.CSA),
+            self.CSA,
+        )
+
+    def test_both_different(self):
+        """Test when both inputs are different"""
+
+        with self.assertRaises(ValueError):
+            merge_coordinate_systems(self.CSA, self.CSB)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR modifies the `__add__` logic in `Acquisition` and `Procedures` to properly merge the `.coordinate_system` field in situations where one file has a coordinate system set and the other one has `.coordinate_system=None`. 

This isn't possible in instrument because all instrument.json files are required to have a coordinate system set.