### PR TITLE
fix: reduce requirement for SLAP2 to just ImagingConfig

### DIFF
--- a/src/aind_data_schema/core/acquisition.py
+++ b/src/aind_data_schema/core/acquisition.py
@@ -50,7 +50,7 @@ CONFIG_REQUIREMENTS = {
     Modality.POPHYS: [[ImagingConfig]],
     Modality.MRI: [[MRIScan]],
     Modality.SPIM: [[ImagingConfig], [SampleChamberConfig]],
-    Modality.SLAP2: [[ImagingConfig], [SlapPlane]],
+    Modality.SLAP2: [[ImagingConfig]],
 }
 
 SPECIMEN_MODALITIES = [Modality.SPIM.abbreviation, Modality.CONFOCAL.abbreviation]


### PR DESCRIPTION
PR fixes a bug where including Modality.SLAP2 incorrectly required users to provide a standalone SlapPlane outside of an ImagingConfig.