### PR TITLE
feat: allow PlanarSectioning to accept Atlas coordinate systems

### DIFF
--- a/src/aind_data_schema/components/specimen_procedures.py
+++ b/src/aind_data_schema/components/specimen_procedures.py
@@ -11,7 +11,7 @@ from aind_data_schema_models.units import SizeUnit
 from pydantic import Field, model_validator
 
 from aind_data_schema.base import AwareDatetimeWithDefault, DataModel, DiscriminatedList
-from aind_data_schema.components.coordinates import CoordinateSystem, Translation
+from aind_data_schema.components.coordinates import Atlas, CoordinateSystem, Translation
 from aind_data_schema.components.reagent import (
     FluorescentStain,
     GeneProbeSet,
@@ -63,7 +63,7 @@ class Section(DataModel):
 class PlanarSectioning(DataModel):
     """Description of a sectioning procedure performed on the coronal, sagittal, or transverse/axial plane"""
 
-    coordinate_system: Optional[CoordinateSystem] = Field(
+    coordinate_system: Optional[CoordinateSystem | Atlas] = Field(
         default=None,
         title="Sectioning coordinate system",
         description="Only required if different from the Procedures.coordinate_system",


### PR DESCRIPTION
This PR allows BarSEQ sectioning procedures to specify where they start their sectioning using Atlas coordinates instead of using real brain coordinates. 