### PR TITLE
fix: recursive_get_all_names should only get names from DataModel objects

### DIFF
--- a/src/aind_data_schema/utils/validators.py
+++ b/src/aind_data_schema/utils/validators.py
@@ -238,7 +238,7 @@ def recursive_coord_system_check(data, coordinate_system_name: Optional[str], ax
 
 
 def recursive_get_all_names(obj: Any) -> List[str]:
-    """Recursively extract all 'name' fields from an object and its nested fields."""
+    """Recursively extract all 'name' fields from a DataModel object and its nested fields."""
     names = []
 
     if obj is None or isinstance(obj, Enum):  # Skip None and Enums
@@ -249,8 +249,13 @@ def recursive_get_all_names(obj: Any) -> List[str]:
             names.extend(recursive_get_all_names(item))
 
     elif hasattr(obj, "__dict__"):  # Handle objects (including Pydantic models)
+        if not hasattr(obj, "object_type"):
+            # All DataModel objects should have an object_type attribute
+            return names
         if hasattr(obj, "name") and isinstance(obj.name, str):  # Ensure name is a string
             names.append(obj.name)
+
+        # Continue recursion into fields
         for field_value in vars(obj).values():  # Use vars() for robustness
             names.extend(recursive_get_all_names(field_value))
 

--- a/tests/test_utils_validators.py
+++ b/tests/test_utils_validators.py
@@ -291,14 +291,14 @@ class MockEnum(Enum):
     VALUE2 = "value2"
 
 
-class NestedModel(BaseModel):
+class NestedModel(DataModel):
     """Nested model for testing"""
 
     name: str
     value: int
 
 
-class ComplexModel(BaseModel):
+class ComplexModel(DataModel):
     """Complex model for testing"""
 
     name: str
@@ -307,11 +307,25 @@ class ComplexModel(BaseModel):
     enum_field: MockEnum
 
 
-class ComplexParentModel(BaseModel):
+class ComplexParentModel(DataModel):
     """Multi-level model for testing"""
 
     name: str
     child: ComplexModel
+
+
+class NonDataModel(BaseModel):
+    """BaseModel (not DataModel) for testing that names are not extracted from non-DataModel objects"""
+
+    name: str
+    value: int
+
+
+class ModelWithNonDataModelChild(DataModel):
+    """DataModel containing a non-DataModel child"""
+
+    name: str
+    non_data_child: NonDataModel
 
 
 class TestRecursiveGetAllNames(unittest.TestCase):
@@ -379,6 +393,13 @@ class TestRecursiveGetAllNames(unittest.TestCase):
         parent_model = ComplexParentModel(name="parent_name", child=model)
         result = recursive_get_all_names(parent_model)
         self.assertEqual(result, ["parent_name", "complex_name", "nested_name"])
+
+    def test_non_data_model_child_ignored(self):
+        """Test that names from non-DataModel objects (without object_type) are not extracted"""
+        non_data_child = NonDataModel(name="should_be_ignored", value=42)
+        model = ModelWithNonDataModelChild(name="parent_name", non_data_child=non_data_child)
+        result = recursive_get_all_names(model)
+        self.assertEqual(result, ["parent_name"])
 
 
 class TestRecursiveCheckPaths(unittest.TestCase):


### PR DESCRIPTION
recursive_get_all_names currently pulls the "name" field from aind-data-schema-model objects like `ManufacturerModel`. This is a bug, we only intended it to pull names from things that are subclassed from `DataModel` like `Device` and subclasses of `Device`. There's no easy way to identify that something is a subclass of `Device` specifically, so taking names from anything built off of `DataModel` is close enough.