### PR TITLE
Removed reference to metadata app in instrument.md

### DIFF
--- a/docs/source/instrument.md
+++ b/docs/source/instrument.md
@@ -4,7 +4,7 @@
 
 The `instrument.json` collects the components, mostly hardware devices, used to collect data. In general, the instrument schema describes the static state of the data acquisition hardware across sessions. The [Acquisition](acquisition.md) is used to describe the configuration of components for a specific session.
 
-Instrument files are created manually, either through the [metadata-entry app](https://metadata-entry.allenneuraldynamics.org) or by writing python code that uses [aind-data-schema](https://github.com/allenNeuralDynamics/aind-data-schema). In general, your `instrument.json` file should be re-used across every session without changes until a device is added, removed, or moved, or maintenance is performed. The last change to an instrument should be timestamped in the `Instrument.modification_date` field.
+Instrument files are created manually by writing python code that uses [aind-data-schema](https://github.com/allenNeuralDynamics/aind-data-schema). In general, your `instrument.json` file should be re-used across every session without changes until a device is added, removed, or moved, or maintenance is performed. The last change to an instrument should be timestamped in the `Instrument.modification_date` field.
 
 ## Uniqueness
 


### PR DESCRIPTION
Removes the reference to the metadata app in instrument.md. It sounds like no one is using it and we'd rather push people to create instrument JSONs from reusable python scripts. Also, the app seems to be AIND-specific (is it even available off-prem?) and documentation should be more general.