### PR TITLE
hotfix: repair acquisition_start_tz

### DIFF
--- a/docs/source/acquisition.md
+++ b/docs/source/acquisition.md
@@ -80,7 +80,7 @@ while the StimulusEpoch represents all stimuli being presented.
 | `subject_id` | `str` | Subject ID (Unique identifier for the subject) |
 | `specimen_id` | `Optional[str]` | Specimen ID (Specimen ID is required for in vitro imaging modalities) |
 | `acquisition_start_time` | `datetime (timezone-aware)` | Acquisition start time (During validation, timezone information will be moved into the acquisition_start_tz field.) |
-| `acquisition_start_tz` | `Optional[pydantic_extra_types.timezone_name.TimeZoneName]` | Acquisition start timezone (Automatically populated by a validator based on acquisition_start_time.) |
+| `acquisition_start_tz` | `int or pydantic_extra_types.timezone_name.TimeZoneName or NoneType` | Acquisition start timezone (Automatically populated by a validator based on acquisition_start_time. Will be a TimeZoneName (IANA name) when the datetime uses a ZoneInfo timezone, or an integer UTC offset in hours for fixed-offset timezones. Use ZoneInfo (from the zoneinfo standard library) to preserve the named timezone.) |
 | `acquisition_end_time` | `datetime (timezone-aware)` | Acquisition end time  |
 | `experimenters` | `List[str]` | experimenter(s)  |
 | `protocol_id` | `Optional[List[str]]` | Protocol ID (DOI for protocols.io) |

--- a/docs/source/aind_data_schema_models/devices.md
+++ b/docs/source/aind_data_schema_models/devices.md
@@ -95,6 +95,7 @@ Detector type name
 |------|-------|
 | `CAMERA` | `Camera` |
 | `PMT` | `Photomultiplier Tube` |
+| `SiPM` | `Silicon Photomultiplier` |
 | `OTHER` | `Other` |
 
 

--- a/docs/source/aind_data_schema_models/organizations.md
+++ b/docs/source/aind_data_schema_models/organizations.md
@@ -9,97 +9,98 @@ Organization
 | Name | abbreviation | name | registry | registry_identifier |
 |------|------|------|------|------|
 | `AA_OPTO_ELECTRONIC` | `None` | `AA Opto Electronic` | `None` | `None` |
-| `ABCAM` | `None` | `Abcam` | `Registry.ROR` | `02e1wjw63` |
-| `ADDGENE` | `None` | `Addgene` | `Registry.ROR` | `01nn1pw54` |
-| `AI` | `AI` | `Allen Institute` | `Registry.ROR` | `03cpe7c52` |
-| `AIBS` | `AIBS` | `Allen Institute for Brain Science` | `Registry.ROR` | `00dcv1019` |
+| `ABCAM` | `None` | `Abcam` | `Research Organization Registry (ROR)` | `02e1wjw63` |
+| `ADDGENE` | `None` | `Addgene` | `Research Organization Registry (ROR)` | `01nn1pw54` |
+| `AI` | `AI` | `Allen Institute` | `Research Organization Registry (ROR)` | `03cpe7c52` |
+| `AIBS` | `AIBS` | `Allen Institute for Brain Science` | `Research Organization Registry (ROR)` | `00dcv1019` |
 | `AILIPU` | `Ailipu` | `Ailipu Technology Co` | `None` | `None` |
-| `AIND` | `AIND` | `Allen Institute for Neural Dynamics` | `Registry.ROR` | `04szwah67` |
-| `AMS_OSRAM` | `None` | `ams OSRAM` | `Registry.ROR` | `045d0h266` |
+| `AIND` | `AIND` | `Allen Institute for Neural Dynamics` | `Research Organization Registry (ROR)` | `04szwah67` |
+| `AMS_OSRAM` | `None` | `ams OSRAM` | `Research Organization Registry (ROR)` | `045d0h266` |
 | `ARDUINO` | `None` | `Arduino` | `None` | `None` |
 | `ARECONT_VISION_COSTAR` | `None` | `Arecont Vision Costar` | `None` | `None` |
 | `ASI` | `ASI` | `Applied Scientific Instrumentation` | `None` | `None` |
-| `ASUS` | `None` | `ASUS` | `Registry.ROR` | `00bxkz165` |
+| `ASUS` | `None` | `ASUS` | `Research Organization Registry (ROR)` | `00bxkz165` |
 | `BASLER` | `None` | `Basler` | `None` | `None` |
-| `BCM` | `BCM` | `Baylor College of Medicine` | `Registry.ROR` | `02pttbw34` |
-| `BU` | `BU` | `Boston University` | `Registry.ROR` | `05qwgg493` |
-| `CAJAL` | `Cajal` | `Cajal Neuroscience` | `Registry.ROR` | `05pdc0q70` |
+| `BCM` | `BCM` | `Baylor College of Medicine` | `Research Organization Registry (ROR)` | `02pttbw34` |
+| `BRUKER` | `None` | `Bruker` | `Research Organization Registry (ROR)` | `04r739x86` |
+| `BU` | `BU` | `Boston University` | `Research Organization Registry (ROR)` | `05qwgg493` |
+| `CAJAL` | `Cajal` | `Cajal Neuroscience` | `Research Organization Registry (ROR)` | `05pdc0q70` |
 | `CAMBRIDGE_TECHNOLOGY` | `None` | `Cambridge Technology` | `None` | `None` |
-| `CARL_ZEISS` | `None` | `Carl Zeiss` | `Registry.ROR` | `01xk5xs43` |
+| `CARL_ZEISS` | `None` | `Carl Zeiss` | `Research Organization Registry (ROR)` | `01xk5xs43` |
 | `CATHETER_IMPLANT_INSTITUTIONS` | `N/A` | `N/A` | `N/A` | `N/A` |
-| `CHAMPALIMAUD` | `Champalimaud` | `Champalimaud Foundation` | `Registry.ROR` | `03g001n57` |
+| `CHAMPALIMAUD` | `Champalimaud` | `Champalimaud Foundation` | `Research Organization Registry (ROR)` | `03g001n57` |
 | `CHROMA` | `None` | `Chroma` | `None` | `None` |
-| `COHERENT_SCIENTIFIC` | `None` | `Coherent Scientific` | `Registry.ROR` | `031tysd23` |
-| `COLUMBIA` | `Columbia` | `Columbia University` | `Registry.ROR` | `00hj8s172` |
+| `COHERENT_SCIENTIFIC` | `None` | `Coherent Scientific` | `Research Organization Registry (ROR)` | `031tysd23` |
+| `COLUMBIA` | `Columbia` | `Columbia University` | `Research Organization Registry (ROR)` | `00hj8s172` |
 | `COMPUTAR` | `None` | `Computar` | `None` | `None` |
 | `CONOPTICS` | `None` | `Conoptics` | `None` | `None` |
 | `CRESTOPTICS` | `None` | `CrestOptics` | `None` | `None` |
-| `CRL` | `CRL` | `Charles River Laboratories` | `Registry.ROR` | `03ndmsg87` |
+| `CRL` | `CRL` | `Charles River Laboratories` | `Research Organization Registry (ROR)` | `03ndmsg87` |
 | `CUSTOM` | `None` | `Custom` | `None` | `None` |
-| `CZI` | `CZI` | `Chan Zuckerberg Initiative` | `Registry.ROR` | `02qenvm24` |
+| `CZI` | `CZI` | `Chan Zuckerberg Initiative` | `Research Organization Registry (ROR)` | `02qenvm24` |
 | `DAQ_DEVICE_MANUFACTURERS` | `N/A` | `N/A` | `N/A` | `N/A` |
 | `DETECTOR_MANUFACTURERS` | `N/A` | `N/A` | `N/A` | `N/A` |
 | `DIGIKEY` | `None` | `DigiKey` | `None` | `None` |
 | `DODOTRONIC` | `None` | `Dodotronic` | `None` | `None` |
-| `DORIC` | `None` | `Doric` | `Registry.ROR` | `059n53q30` |
+| `DORIC` | `None` | `Doric` | `Research Organization Registry (ROR)` | `059n53q30` |
 | `EALING` | `None` | `Ealing` | `None` | `None` |
-| `EDMUND_OPTICS` | `None` | `Edmund Optics` | `Registry.ROR` | `01j1gwp17` |
-| `EMORY` | `Emory` | `Emory University` | `Registry.ROR` | `03czfpz43` |
+| `EDMUND_OPTICS` | `None` | `Edmund Optics` | `Research Organization Registry (ROR)` | `01j1gwp17` |
+| `EMORY` | `Emory` | `Emory University` | `Research Organization Registry (ROR)` | `03czfpz43` |
 | `EURESYS` | `None` | `Euresys` | `None` | `None` |
 | `FILTER_MANUFACTURERS` | `N/A` | `N/A` | `N/A` | `N/A` |
-| `FLIR` | `FLIR` | `Teledyne FLIR` | `Registry.ROR` | `01j1gwp17` |
+| `FLIR` | `FLIR` | `Teledyne FLIR` | `Research Organization Registry (ROR)` | `01j1gwp17` |
 | `FUJINON` | `None` | `Fujinon` | `None` | `None` |
 | `FUNDERS` | `N/A` | `N/A` | `N/A` | `N/A` |
-| `HAMAMATSU` | `None` | `Hamamatsu` | `Registry.ROR` | `03natb733` |
+| `HAMAMATSU` | `None` | `Hamamatsu` | `Research Organization Registry (ROR)` | `03natb733` |
 | `HAMILTON` | `None` | `Hamilton` | `None` | `None` |
-| `HUST` | `HUST` | `Huazhong University of Science and Technology` | `Registry.ROR` | `00p991c53` |
-| `IDT` | `IDT` | `Integrated DNA Technologies` | `Registry.ROR` | `009jvpf03` |
-| `IMEC` | `IMEC` | `Interuniversity Microelectronics Center` | `Registry.ROR` | `02kcbn207` |
+| `HUST` | `HUST` | `Huazhong University of Science and Technology` | `Research Organization Registry (ROR)` | `00p991c53` |
+| `IDT` | `IDT` | `Integrated DNA Technologies` | `Research Organization Registry (ROR)` | `009jvpf03` |
+| `IMEC` | `IMEC` | `Interuniversity Microelectronics Center` | `Research Organization Registry (ROR)` | `02kcbn207` |
 | `INFINITY_PHOTO_OPTICAL` | `None` | `Infinity Photo-Optical` | `None` | `None` |
-| `INVITROGEN` | `None` | `Invitrogen` | `Registry.ROR` | `03x1ewr52` |
+| `INVITROGEN` | `None` | `Invitrogen` | `Research Organization Registry (ROR)` | `03x1ewr52` |
 | `IR_ROBOT_CO` | `None` | `IR Robot Co` | `None` | `None` |
 | `ISL` | `ISL` | `ISL Products International` | `None` | `None` |
 | `ITEM` | `None` | `Item` | `None` | `None` |
-| `JANELIA` | `Janelia` | `Janelia Research Campus` | `Registry.ROR` | `013sk6x84` |
-| `JAX` | `JAX` | `Jackson Laboratory` | `Registry.ROR` | `021sy4w91` |
-| `JENOPTIK` | `None` | `Jenoptik` | `Registry.ROR` | `05g7t5c49` |
-| `JHU` | `JHU` | `Johns Hopkins University` | `Registry.ROR` | `00za53h95` |
+| `JANELIA` | `Janelia` | `Janelia Research Campus` | `Research Organization Registry (ROR)` | `013sk6x84` |
+| `JAX` | `JAX` | `Jackson Laboratory` | `Research Organization Registry (ROR)` | `021sy4w91` |
+| `JENOPTIK` | `None` | `Jenoptik` | `Research Organization Registry (ROR)` | `05g7t5c49` |
+| `JHU` | `JHU` | `Johns Hopkins University` | `Research Organization Registry (ROR)` | `00za53h95` |
 | `JULABO` | `None` | `Julabo` | `None` | `None` |
-| `KOWA` | `None` | `Kowa` | `Registry.ROR` | `03zbwg482` |
+| `KOWA` | `None` | `Kowa` | `Research Organization Registry (ROR)` | `03zbwg482` |
 | `LASER_MANUFACTURERS` | `N/A` | `N/A` | `N/A` | `N/A` |
 | `LASOS` | `LASOS` | `LASOS Lasertechnik` | `None` | `None` |
 | `LED_MANUFACTURERS` | `N/A` | `N/A` | `N/A` | `N/A` |
 | `LEICA` | `None` | `Leica` | `None` | `None` |
 | `LENS_MANUFACTURERS` | `N/A` | `N/A` | `N/A` | `N/A` |
-| `LG` | `None` | `LG` | `Registry.ROR` | `02b948n83` |
+| `LG` | `None` | `LG` | `Research Organization Registry (ROR)` | `02b948n83` |
 | `LIFECANVAS` | `None` | `LifeCanvas` | `None` | `None` |
 | `LUMENCOR` | `None` | `Lumencor` | `None` | `None` |
 | `LUMEN_DYNAMICS` | `None` | `Lumen Dynamics` | `None` | `None` |
 | `MANIPULATOR_MANUFACTURERS` | `N/A` | `N/A` | `N/A` | `N/A` |
-| `MBF` | `MBF` | `MBF Bioscience` | `Registry.ROR` | `02zynam48` |
-| `MEADOWLARK_OPTICS` | `None` | `Meadowlark Optics` | `Registry.ROR` | `00n8qbq54` |
-| `MIBR` | `MIBR` | `McGovern Institute for Brain Research` | `Registry.ROR` | `05ymca674` |
+| `MBF` | `MBF` | `MBF Bioscience` | `Research Organization Registry (ROR)` | `02zynam48` |
+| `MEADOWLARK_OPTICS` | `None` | `Meadowlark Optics` | `Research Organization Registry (ROR)` | `00n8qbq54` |
+| `MIBR` | `MIBR` | `McGovern Institute for Brain Research` | `Research Organization Registry (ROR)` | `05ymca674` |
 | `MIDOPT` | `MidOpt` | `Midwest Optical Systems, Inc.` | `None` | `None` |
-| `MIT` | `MIT` | `Massachusetts Institute of Technology` | `Registry.ROR` | `042nb2s44` |
+| `MIT` | `MIT` | `Massachusetts Institute of Technology` | `Research Organization Registry (ROR)` | `042nb2s44` |
 | `MITUTUYO` | `None` | `Mitutuyo` | `None` | `None` |
 | `MIT_BCS` | `MIT-BCS` | `MIT Department of Brain and Cognitive Sciences` | `None` | `None` |
-| `MJFF` | `MJFF` | `Michael J. Fox Foundation for Parkinson's Research` | `Registry.ROR` | `03arq3225` |
-| `MKS_NEWPORT` | `None` | `MKS Newport` | `Registry.ROR` | `00k17f049` |
+| `MJFF` | `MJFF` | `Michael J. Fox Foundation for Parkinson's Research` | `Research Organization Registry (ROR)` | `03arq3225` |
+| `MKS_NEWPORT` | `None` | `MKS Newport` | `Research Organization Registry (ROR)` | `00k17f049` |
 | `MONITOR_MANUFACTURERS` | `N/A` | `N/A` | `N/A` | `N/A` |
 | `MPI` | `MPI` | `MPI` | `None` | `None` |
-| `NATIONAL_INSTRUMENTS` | `None` | `National Instruments` | `Registry.ROR` | `026exqw73` |
+| `NATIONAL_INSTRUMENTS` | `None` | `National Instruments` | `Research Organization Registry (ROR)` | `026exqw73` |
 | `NAVITAR` | `None` | `Navitar` | `None` | `None` |
-| `NCCIH` | `NCCIH` | `National Center for Complementary and Integrative Health` | `Registry.ROR` | `00190t495` |
+| `NCCIH` | `NCCIH` | `National Center for Complementary and Integrative Health` | `Research Organization Registry (ROR)` | `00190t495` |
 | `NEURALYNX` | `None` | `NeuraLynx` | `None` | `None` |
 | `NEUROPHOTOMETRICS` | `None` | `Neurophotometrics` | `None` | `None` |
 | `NEW_SCALE_TECHNOLOGIES` | `None` | `New Scale Technologies` | `None` | `None` |
-| `NIKON` | `None` | `Nikon` | `Registry.ROR` | `0280y9h11` |
-| `NIMH` | `NIMH` | `National Institute of Mental Health` | `Registry.ROR` | `04xeg9z08` |
-| `NINDS` | `NINDS` | `National Institute of Neurological Disorders and Stroke` | `Registry.ROR` | `01s5ya894` |
+| `NIKON` | `None` | `Nikon` | `Research Organization Registry (ROR)` | `0280y9h11` |
+| `NIMH` | `NIMH` | `National Institute of Mental Health` | `Research Organization Registry (ROR)` | `04xeg9z08` |
+| `NINDS` | `NINDS` | `National Institute of Neurological Disorders and Stroke` | `Research Organization Registry (ROR)` | `01s5ya894` |
 | `NRESEARCH_INC` | `None` | `NResearch Inc` | `None` | `None` |
-| `NYU` | `NYU` | `New York University` | `Registry.ROR` | `0190ak572` |
-| `OEPS` | `OEPS` | `Open Ephys Production Site` | `Registry.ROR` | `007rkz355` |
-| `OLYMPUS` | `None` | `Olympus` | `Registry.ROR` | `02vcdte90` |
+| `NYU` | `NYU` | `New York University` | `Research Organization Registry (ROR)` | `0190ak572` |
+| `OEPS` | `OEPS` | `Open Ephys Production Site` | `Research Organization Registry (ROR)` | `007rkz355` |
+| `OLYMPUS` | `None` | `Olympus` | `Research Organization Registry (ROR)` | `02vcdte90` |
 | `OPTOTUNE` | `None` | `Optotune` | `None` | `None` |
 | `OTHER` | `None` | `Other` | `None` | `None` |
 | `OXXIUS` | `None` | `Oxxius` | `None` | `None` |
@@ -114,25 +115,25 @@ Organization
 | `SEMROCK` | `None` | `Semrock` | `None` | `None` |
 | `SICGEN` | `None` | `SICGEN` | `None` | `None` |
 | `SIGMA_ALDRICH` | `None` | `Sigma-Aldrich` | `None` | `None` |
-| `SIMONS_FOUNDATION` | `None` | `Simons Foundation` | `Registry.ROR` | `01cmst727` |
+| `SIMONS_FOUNDATION` | `None` | `Simons Foundation` | `Research Organization Registry (ROR)` | `01cmst727` |
 | `SPEAKER_MANUFACTURERS` | `N/A` | `N/A` | `N/A` | `N/A` |
-| `SPECTRA_PHYSICS` | `None` | `Spectra-Physics` | `Registry.ROR` | `02ad9kp97` |
+| `SPECTRA_PHYSICS` | `None` | `Spectra-Physics` | `Research Organization Registry (ROR)` | `02ad9kp97` |
 | `SPINNAKER` | `None` | `Spinnaker` | `None` | `None` |
 | `SUBJECT_SOURCES` | `N/A` | `N/A` | `N/A` | `N/A` |
 | `TAMRON` | `None` | `Tamron` | `None` | `None` |
 | `TELEDYNE_VISION_SOLUTIONS` | `None` | `Teledyne Vision Solutions` | `None` | `None` |
-| `TE_CONNECTIVITY` | `None` | `TE Connectivity` | `Registry.ROR` | `034frgp20` |
-| `THERMO_FISHER_SCIENTIFIC` | `None` | `Thermo Fisher Scientific` | `Registry.ROR` | `03x1ewr52` |
+| `TE_CONNECTIVITY` | `None` | `TE Connectivity` | `Research Organization Registry (ROR)` | `034frgp20` |
+| `THERMO_FISHER_SCIENTIFIC` | `None` | `Thermo Fisher Scientific` | `Research Organization Registry (ROR)` | `03x1ewr52` |
 | `THE_IMAGING_SOURCE` | `None` | `The Imaging Source` | `None` | `None` |
 | `THE_LEE_COMPANY` | `None` | `The Lee Company` | `None` | `None` |
-| `THORLABS` | `None` | `Thorlabs` | `Registry.ROR` | `04gsnvb07` |
+| `THORLABS` | `None` | `Thorlabs` | `Research Organization Registry (ROR)` | `04gsnvb07` |
 | `TMC` | `TMC` | `Technical Manufacturing Corporation` | `None` | `None` |
 | `TRANSDUCER_TECHNIQUES` | `None` | `Transducer Techniques` | `None` | `None` |
-| `TWCF` | `TWCF` | `Templeton World Charity Foundation` | `Registry.ROR` | `00x0z1472` |
+| `TWCF` | `TWCF` | `Templeton World Charity Foundation` | `Research Organization Registry (ROR)` | `00x0z1472` |
 | `TYMPHANY` | `None` | `Tymphany` | `None` | `None` |
-| `UCSD` | `UCSD` | `University of California, San Diego` | `Registry.ROR` | `0168r3w48` |
+| `UCSD` | `UCSD` | `University of California, San Diego` | `Research Organization Registry (ROR)` | `0168r3w48` |
 | `UNKNOWN` | `UNKNOWN` | `Unknown` | `None` | `None` |
-| `UPENN` | `UPENN` | `University of Pennsylvania` | `Registry.ROR` | `00b30xv10` |
+| `UPENN` | `UPENN` | `University of Pennsylvania` | `Research Organization Registry (ROR)` | `00b30xv10` |
 | `VIEWORKS` | `None` | `Vieworks` | `None` | `None` |
 | `VORTRAN` | `None` | `Vortran` | `None` | `None` |
 

--- a/docs/source/aind_data_schema_models/species.md
+++ b/docs/source/aind_data_schema_models/species.md
@@ -8,18 +8,18 @@ Species
 
 | Name | name | common_name | registry | registry_identifier |
 |------|------|------|------|------|
-| `ALPACA` | `Vicuna pacos` | `Alpaca` | `Registry.NCBI` | `NCBI:txid30538` |
-| `CHICKEN` | `Gallus gallus` | `Chicken` | `Registry.NCBI` | `NCBI:txid9031` |
-| `COMMON_MARMOSET` | `Callithrix jacchus` | `Common marmoset` | `Registry.NCBI` | `NCBI:txid9483` |
-| `DONKEY` | `Equus asinus` | `Donkey` | `Registry.NCBI` | `NCBI:txid9793` |
-| `EUROPEAN_RABBIT` | `Oryctolagus cuniculus` | `European rabbit` | `Registry.NCBI` | `NCBI:txid9986` |
-| `GOAT` | `Carpa hircus` | `Goat` | `Registry.NCBI` | `NCBI:txid9925` |
-| `GUINEA_PIG` | `Cavia porcellus` | `Guinea pig` | `Registry.NCBI` | `NCBI:txid10141` |
-| `HOUSE_MOUSE` | `Mus musculus` | `House mouse` | `Registry.NCBI` | `NCBI:txid10090` |
-| `HUMAN` | `Homo sapiens` | `Human` | `Registry.NCBI` | `NCBI:txid9606` |
-| `LLAMA` | `Lama glama` | `Llama` | `Registry.NCBI` | `NCBI:txid9844` |
-| `NORWAY_RAT` | `Rattus norvegicus` | `Norway rat` | `Registry.NCBI` | `NCBI:txid10116` |
-| `RHESUS_MACAQUE` | `Macaca mulatta` | `Rhesus macaque` | `Registry.NCBI` | `NCBI:txid9544` |
+| `ALPACA` | `Vicuna pacos` | `Alpaca` | `National Center for Biotechnology Information (NCBI)` | `NCBI:txid30538` |
+| `CHICKEN` | `Gallus gallus` | `Chicken` | `National Center for Biotechnology Information (NCBI)` | `NCBI:txid9031` |
+| `COMMON_MARMOSET` | `Callithrix jacchus` | `Common marmoset` | `National Center for Biotechnology Information (NCBI)` | `NCBI:txid9483` |
+| `DONKEY` | `Equus asinus` | `Donkey` | `National Center for Biotechnology Information (NCBI)` | `NCBI:txid9793` |
+| `EUROPEAN_RABBIT` | `Oryctolagus cuniculus` | `European rabbit` | `National Center for Biotechnology Information (NCBI)` | `NCBI:txid9986` |
+| `GOAT` | `Carpa hircus` | `Goat` | `National Center for Biotechnology Information (NCBI)` | `NCBI:txid9925` |
+| `GUINEA_PIG` | `Cavia porcellus` | `Guinea pig` | `National Center for Biotechnology Information (NCBI)` | `NCBI:txid10141` |
+| `HOUSE_MOUSE` | `Mus musculus` | `House mouse` | `National Center for Biotechnology Information (NCBI)` | `NCBI:txid10090` |
+| `HUMAN` | `Homo sapiens` | `Human` | `National Center for Biotechnology Information (NCBI)` | `NCBI:txid9606` |
+| `LLAMA` | `Lama glama` | `Llama` | `National Center for Biotechnology Information (NCBI)` | `NCBI:txid9844` |
+| `NORWAY_RAT` | `Rattus norvegicus` | `Norway rat` | `National Center for Biotechnology Information (NCBI)` | `NCBI:txid10116` |
+| `RHESUS_MACAQUE` | `Macaca mulatta` | `Rhesus macaque` | `National Center for Biotechnology Information (NCBI)` | `NCBI:txid9544` |
 
 
 ### Strain
@@ -28,8 +28,8 @@ Strain
 
 | Name | name | species | registry | registry_identifier |
 |------|------|------|------|------|
-| `BALB_C` | `BALB/c` | `Mus musculus` | `Registry.MGI` | `MGI:2159737` |
-| `C57BL_6J` | `C57BL/6J` | `Mus musculus` | `Registry.MGI` | `MGI:3028467` |
+| `BALB_C` | `BALB/c` | `Mus musculus` | `Mouse Genome Informatics (MGI)` | `MGI:2159737` |
+| `C57BL_6J` | `C57BL/6J` | `Mus musculus` | `Mouse Genome Informatics (MGI)` | `MGI:3028467` |
 | `UNKNOWN` | `Unknown` | `Mus musculus` | `None` | `None` |
 
 

--- a/docs/source/components/devices.md
+++ b/docs/source/components/devices.md
@@ -376,17 +376,6 @@ Module for inserted fiber photometry recording
 | `fibers` | List[[FiberProbe](#fiberprobe)] | Probes that are held by this module  |
 
 
-### PatchClampEphysAssembly
-
-Assembly combining a manipulator and headstage used for Patch clamp ephys
-
-| Field | Type | Title (Description) |
-|-------|------|-------------|
-| `name` | `str` | Patch clamp assembly name  |
-| `manipulator` | [Manipulator](#manipulator) | Manipulator  |
-| `headstage` | [Device](#device) | Headstage |
-
-
 ### FiberPatchCord
 
 Description of a patch cord
@@ -792,7 +781,7 @@ Multichannel electrophysiology DAQ
 | Field | Type | Title (Description) |
 |-------|------|-------------|
 | `ports` | List[[ProbePort](#probeport)] | Acquisition board ports  |
-| `data_interface` | `"DataInterface.USB"` |   |
+| `data_interface` | `"USB"` |   |
 | `manufacturer` | [Organization](../aind_data_schema_models/organizations.md#organization) |   |
 | `channels` | List[[DAQChannel](#daqchannel)] | DAQ channels  |
 | `firmware_version` | `Optional[str]` | Firmware version  |
@@ -802,6 +791,17 @@ Multichannel electrophysiology DAQ
 | `model` | `Optional[str]` | Model  |
 | `additional_settings` | `Optional[dict]` | Additional parameters  |
 | `notes` | `Optional[str]` | Notes  |
+
+
+### PatchClampEphysAssembly
+
+Assembly combining a manipulator and headstage used for Patch clamp ephys
+
+| Field | Type | Title (Description) |
+|-------|------|-------------|
+| `name` | `str` | Patch clamp Assembly Name  |
+| `manipulator` | [Manipulator](#manipulator) | Manipulator  |
+| `headstage` | [Device](#device) | Headstage  |
 
 
 ### PockelsCell

--- a/docs/source/components/identifiers.md
+++ b/docs/source/components/identifiers.md
@@ -12,7 +12,7 @@ Code or script identifier
 | `name` | `Optional[str]` | Name  |
 | `version` | `Optional[str]` | Code version  |
 | `container` | Optional[[Container](#container)] | Container  |
-| `run_script` | `Optional[pathlib._local.Path]` | Run script (Path to run script) |
+| `run_script` | `Optional[pathlib.Path]` | Run script (Path to run script) |
 | `language` | `Optional[str]` | Programming language (Programming language used) |
 | `language_version` | `Optional[str]` | Programming language version  |
 | `input_data` | Optional[List[[DataAsset](#dataasset) or [CombinedData](#combineddata)]] | Input data (Input data used in the code or script) |

--- a/docs/source/instrument.md
+++ b/docs/source/instrument.md
@@ -4,7 +4,7 @@
 
 The `instrument.json` collects the components, mostly hardware devices, used to collect data. In general, the instrument schema describes the static state of the data acquisition hardware across sessions. The [Acquisition](acquisition.md) is used to describe the configuration of components for a specific session.
 
-Instrument files are created manually by writing python code that uses [aind-data-schema](https://github.com/allenNeuralDynamics/aind-data-schema). In general, your `instrument.json` file should be re-used across every session without changes until a device is added, removed, or moved, or maintenance is performed. The last change to an instrument should be timestamped in the `Instrument.modification_date` field.
+Instrument files are created manually, either through the [metadata-entry app](https://metadata-entry.allenneuraldynamics.org) or by writing python code that uses [aind-data-schema](https://github.com/allenNeuralDynamics/aind-data-schema). In general, your `instrument.json` file should be re-used across every session without changes until a device is added, removed, or moved, or maintenance is performed. The last change to an instrument should be timestamped in the `Instrument.modification_date` field.
 
 ## Uniqueness
 

--- a/examples/bergamo_ophys_acquisition.py
+++ b/examples/bergamo_ophys_acquisition.py
@@ -1,7 +1,8 @@
 """ example Bergamo ophys acquisition """
 
 import argparse
-from datetime import datetime, timezone
+from datetime import datetime
+from zoneinfo import ZoneInfo
 
 from aind_data_schema_models.modalities import Modality
 from aind_data_schema_models.units import FrequencyUnit
@@ -29,7 +30,7 @@ from aind_data_schema_models.stimulus_modality import StimulusModality
 
 # If a timezone isn't specified, the timezone of the computer running this
 # script will be used as default
-t = datetime(2022, 7, 12, 7, 00, 00, tzinfo=timezone.utc)
+t = datetime(2022, 7, 12, 7, 00, 00, tzinfo=ZoneInfo("America/Los_Angeles"))
 
 laser_config_a = LaserConfig(
     device_name="Laser A",

--- a/examples/ephys_acquisition.py
+++ b/examples/ephys_acquisition.py
@@ -100,8 +100,12 @@ ephys_assembly_b_config = EphysAssemblyConfig(
 acquisition = Acquisition(
     experimenters=["John Smith"],
     subject_id="664484",
-    acquisition_start_time=datetime(year=2023, month=4, day=25, hour=2, minute=35, second=0, tzinfo=ZoneInfo("America/Los_Angeles")),
-    acquisition_end_time=datetime(year=2023, month=4, day=25, hour=3, minute=16, second=0, tzinfo=ZoneInfo("America/Los_Angeles")),
+    acquisition_start_time=datetime(
+        year=2023, month=4, day=25, hour=2, minute=35, second=0, tzinfo=ZoneInfo("America/Los_Angeles")
+    ),
+    acquisition_end_time=datetime(
+        year=2023, month=4, day=25, hour=3, minute=16, second=0, tzinfo=ZoneInfo("America/Los_Angeles")
+    ),
     acquisition_type="Receptive field mapping",
     instrument_id="EPHYS1",
     ethics_review_id=["2109"],
@@ -113,8 +117,12 @@ acquisition = Acquisition(
         StimulusEpoch(
             stimulus_name="Visual Stimulation",
             stimulus_modalities=[StimulusModality.VISUAL],
-            stimulus_start_time=datetime(year=2023, month=4, day=25, hour=2, minute=45, second=0, tzinfo=ZoneInfo("America/Los_Angeles")),
-            stimulus_end_time=datetime(year=2023, month=4, day=25, hour=3, minute=10, second=0, tzinfo=ZoneInfo("America/Los_Angeles")),
+            stimulus_start_time=datetime(
+                year=2023, month=4, day=25, hour=2, minute=45, second=0, tzinfo=ZoneInfo("America/Los_Angeles")
+            ),
+            stimulus_end_time=datetime(
+                year=2023, month=4, day=25, hour=3, minute=10, second=0, tzinfo=ZoneInfo("America/Los_Angeles")
+            ),
             code=Code(
                 url="https://github.com/fakeorg/GratingAndFlashes/gratings_and_flashes.bonsai",
                 core_dependency=bonsai_software,
@@ -132,8 +140,12 @@ acquisition = Acquisition(
         StimulusEpoch(
             stimulus_name="Visual Stimulation",
             stimulus_modalities=[StimulusModality.VISUAL],
-            stimulus_start_time=datetime(year=2023, month=4, day=25, hour=3, minute=10, second=0, tzinfo=ZoneInfo("America/Los_Angeles")),
-            stimulus_end_time=datetime(year=2023, month=4, day=25, hour=3, minute=16, second=0, tzinfo=ZoneInfo("America/Los_Angeles")),
+            stimulus_start_time=datetime(
+                year=2023, month=4, day=25, hour=3, minute=10, second=0, tzinfo=ZoneInfo("America/Los_Angeles")
+            ),
+            stimulus_end_time=datetime(
+                year=2023, month=4, day=25, hour=3, minute=16, second=0, tzinfo=ZoneInfo("America/Los_Angeles")
+            ),
             active_devices=["Stimulus Screen"],
             code=Code(
                 url="https://github.com/fakeorg/GratingAndFlashes/gratings_and_flashes.bonsai",
@@ -152,8 +164,12 @@ acquisition = Acquisition(
     ],
     data_streams=[
         DataStream(
-            stream_start_time=datetime(year=2023, month=4, day=25, hour=2, minute=45, second=0, tzinfo=ZoneInfo("America/Los_Angeles")),
-            stream_end_time=datetime(year=2023, month=4, day=25, hour=3, minute=16, second=0, tzinfo=ZoneInfo("America/Los_Angeles")),
+            stream_start_time=datetime(
+                year=2023, month=4, day=25, hour=2, minute=45, second=0, tzinfo=ZoneInfo("America/Los_Angeles")
+            ),
+            stream_end_time=datetime(
+                year=2023, month=4, day=25, hour=3, minute=16, second=0, tzinfo=ZoneInfo("America/Los_Angeles")
+            ),
             modalities=[Modality.ECEPHYS],
             active_devices=[
                 "Basestation Slot 3",
@@ -166,8 +182,12 @@ acquisition = Acquisition(
             ],
         ),
         DataStream(
-            stream_start_time=datetime(year=2023, month=4, day=25, hour=2, minute=35, second=0, tzinfo=ZoneInfo("America/Los_Angeles")),
-            stream_end_time=datetime(year=2023, month=4, day=25, hour=2, minute=45, second=0, tzinfo=ZoneInfo("America/Los_Angeles")),
+            stream_start_time=datetime(
+                year=2023, month=4, day=25, hour=2, minute=35, second=0, tzinfo=ZoneInfo("America/Los_Angeles")
+            ),
+            stream_end_time=datetime(
+                year=2023, month=4, day=25, hour=2, minute=45, second=0, tzinfo=ZoneInfo("America/Los_Angeles")
+            ),
             modalities=[Modality.ECEPHYS],
             notes="664484_2023-04-24_20-06-37; Surface Finding",
             active_devices=[

--- a/examples/ephys_acquisition.py
+++ b/examples/ephys_acquisition.py
@@ -1,7 +1,8 @@
 """Generates an example JSON file for an ephys acquisition"""
 
 import argparse
-from datetime import datetime, timezone
+from datetime import datetime
+from zoneinfo import ZoneInfo
 
 from aind_data_schema_models.modalities import Modality
 
@@ -99,8 +100,8 @@ ephys_assembly_b_config = EphysAssemblyConfig(
 acquisition = Acquisition(
     experimenters=["John Smith"],
     subject_id="664484",
-    acquisition_start_time=datetime(year=2023, month=4, day=25, hour=2, minute=35, second=0, tzinfo=timezone.utc),
-    acquisition_end_time=datetime(year=2023, month=4, day=25, hour=3, minute=16, second=0, tzinfo=timezone.utc),
+    acquisition_start_time=datetime(year=2023, month=4, day=25, hour=2, minute=35, second=0, tzinfo=ZoneInfo("America/Los_Angeles")),
+    acquisition_end_time=datetime(year=2023, month=4, day=25, hour=3, minute=16, second=0, tzinfo=ZoneInfo("America/Los_Angeles")),
     acquisition_type="Receptive field mapping",
     instrument_id="EPHYS1",
     ethics_review_id=["2109"],
@@ -112,8 +113,8 @@ acquisition = Acquisition(
         StimulusEpoch(
             stimulus_name="Visual Stimulation",
             stimulus_modalities=[StimulusModality.VISUAL],
-            stimulus_start_time=datetime(year=2023, month=4, day=25, hour=2, minute=45, second=0, tzinfo=timezone.utc),
-            stimulus_end_time=datetime(year=2023, month=4, day=25, hour=3, minute=10, second=0, tzinfo=timezone.utc),
+            stimulus_start_time=datetime(year=2023, month=4, day=25, hour=2, minute=45, second=0, tzinfo=ZoneInfo("America/Los_Angeles")),
+            stimulus_end_time=datetime(year=2023, month=4, day=25, hour=3, minute=10, second=0, tzinfo=ZoneInfo("America/Los_Angeles")),
             code=Code(
                 url="https://github.com/fakeorg/GratingAndFlashes/gratings_and_flashes.bonsai",
                 core_dependency=bonsai_software,
@@ -131,8 +132,8 @@ acquisition = Acquisition(
         StimulusEpoch(
             stimulus_name="Visual Stimulation",
             stimulus_modalities=[StimulusModality.VISUAL],
-            stimulus_start_time=datetime(year=2023, month=4, day=25, hour=3, minute=10, second=0, tzinfo=timezone.utc),
-            stimulus_end_time=datetime(year=2023, month=4, day=25, hour=3, minute=16, second=0, tzinfo=timezone.utc),
+            stimulus_start_time=datetime(year=2023, month=4, day=25, hour=3, minute=10, second=0, tzinfo=ZoneInfo("America/Los_Angeles")),
+            stimulus_end_time=datetime(year=2023, month=4, day=25, hour=3, minute=16, second=0, tzinfo=ZoneInfo("America/Los_Angeles")),
             active_devices=["Stimulus Screen"],
             code=Code(
                 url="https://github.com/fakeorg/GratingAndFlashes/gratings_and_flashes.bonsai",
@@ -151,8 +152,8 @@ acquisition = Acquisition(
     ],
     data_streams=[
         DataStream(
-            stream_start_time=datetime(year=2023, month=4, day=25, hour=2, minute=45, second=0, tzinfo=timezone.utc),
-            stream_end_time=datetime(year=2023, month=4, day=25, hour=3, minute=16, second=0, tzinfo=timezone.utc),
+            stream_start_time=datetime(year=2023, month=4, day=25, hour=2, minute=45, second=0, tzinfo=ZoneInfo("America/Los_Angeles")),
+            stream_end_time=datetime(year=2023, month=4, day=25, hour=3, minute=16, second=0, tzinfo=ZoneInfo("America/Los_Angeles")),
             modalities=[Modality.ECEPHYS],
             active_devices=[
                 "Basestation Slot 3",
@@ -165,8 +166,8 @@ acquisition = Acquisition(
             ],
         ),
         DataStream(
-            stream_start_time=datetime(year=2023, month=4, day=25, hour=2, minute=35, second=0, tzinfo=timezone.utc),
-            stream_end_time=datetime(year=2023, month=4, day=25, hour=2, minute=45, second=0, tzinfo=timezone.utc),
+            stream_start_time=datetime(year=2023, month=4, day=25, hour=2, minute=35, second=0, tzinfo=ZoneInfo("America/Los_Angeles")),
+            stream_end_time=datetime(year=2023, month=4, day=25, hour=2, minute=45, second=0, tzinfo=ZoneInfo("America/Los_Angeles")),
             modalities=[Modality.ECEPHYS],
             notes="664484_2023-04-24_20-06-37; Surface Finding",
             active_devices=[

--- a/examples/exaspim_acquisition.py
+++ b/examples/exaspim_acquisition.py
@@ -1,6 +1,7 @@
 """ example ExaSPIM acquisition """
 
-from datetime import datetime, timezone
+from datetime import datetime
+from zoneinfo import ZoneInfo
 import argparse
 
 from aind_data_schema_models.organizations import Organization
@@ -27,7 +28,7 @@ from aind_data_schema.components.measurements import Calibration, Maintenance
 
 # If a timezone isn't specified, the timezone of the computer running this
 # script will be used as default
-t = datetime(2022, 11, 22, 8, 43, 00, tzinfo=timezone.utc)
+t = datetime(2022, 11, 22, 8, 43, 00, tzinfo=ZoneInfo("America/Los_Angeles"))
 
 tile_scale = Scale(
     scale=[0.748, 0.748, 1],

--- a/examples/fip_ophys_acquisition.py
+++ b/examples/fip_ophys_acquisition.py
@@ -1,7 +1,8 @@
 """ example FIP ophys acquisition """
 
 import argparse
-from datetime import datetime, timezone
+from datetime import datetime
+from zoneinfo import ZoneInfo
 from decimal import Decimal
 
 from aind_data_schema_models.modalities import Modality
@@ -28,7 +29,7 @@ from aind_data_schema.components.identifiers import Code
 from aind_data_schema_models.stimulus_modality import StimulusModality
 
 # The session date from the JSON file is 2024-01-15 with timezone -08:00
-t_start = datetime(2024, 1, 15, 15, 56, 28, tzinfo=timezone.utc)
+t_start = datetime(2024, 1, 15, 15, 56, 28, tzinfo=ZoneInfo("America/Los_Angeles"))
 t_end = t_start  # Set end time same as start since it's not specified in the JSON
 
 # Define detector configurations

--- a/examples/mri_acquisition.py
+++ b/examples/mri_acquisition.py
@@ -1,7 +1,8 @@
 """example MRIAcquisition and MRIScan"""
 
 import argparse
-from datetime import datetime, timezone
+from datetime import datetime
+from zoneinfo import ZoneInfo
 from decimal import Decimal
 
 from aind_data_schema_models.modalities import Modality
@@ -68,8 +69,8 @@ scan2 = MRIScan(
 )
 
 stream = DataStream(
-    stream_start_time=datetime(2024, 3, 12, 16, 27, 55, 584892, tzinfo=timezone.utc),
-    stream_end_time=datetime(2024, 3, 12, 16, 27, 55, 584892, tzinfo=timezone.utc),
+    stream_start_time=datetime(2024, 3, 12, 16, 27, 55, 584892, tzinfo=ZoneInfo("America/Los_Angeles")),
+    stream_end_time=datetime(2024, 3, 12, 16, 27, 55, 584892, tzinfo=ZoneInfo("America/Los_Angeles")),
     active_devices=["Scanner 72"],
     configurations=[scan1, scan2],
     modalities=[Modality.MRI],
@@ -77,8 +78,8 @@ stream = DataStream(
 
 acquisition = Acquisition(
     subject_id="123456",
-    acquisition_start_time=datetime(2024, 3, 12, 16, 27, 55, 584892, tzinfo=timezone.utc),
-    acquisition_end_time=datetime(2024, 3, 12, 16, 27, 55, 584892, tzinfo=timezone.utc),
+    acquisition_start_time=datetime(2024, 3, 12, 16, 27, 55, 584892, tzinfo=ZoneInfo("America/Los_Angeles")),
+    acquisition_end_time=datetime(2024, 3, 12, 16, 27, 55, 584892, tzinfo=ZoneInfo("America/Los_Angeles")),
     experimenters=["John Smith"],
     protocol_id=["dx.doi.org/10.57824/protocols.io.bh7kl4n6"],
     ethics_review_id=["1234"],

--- a/examples/multiplane_ophys_acquisition.py
+++ b/examples/multiplane_ophys_acquisition.py
@@ -1,7 +1,8 @@
 """ example fiber photometry acquisition """
 
 import argparse
-from datetime import datetime, timezone
+from datetime import datetime
+from zoneinfo import ZoneInfo
 
 from aind_data_schema_models.modalities import Modality
 from aind_data_schema_models.units import PowerUnit, SizeUnit, FrequencyUnit, VolumeUnit
@@ -30,7 +31,7 @@ from aind_data_schema_models.brain_atlas import CCFv3
 
 # If a timezone isn't specified, the timezone of the computer running this
 # script will be used as default
-t = datetime(2022, 7, 12, 7, 00, 00, tzinfo=timezone.utc)
+t = datetime(2022, 7, 12, 7, 00, 00, tzinfo=ZoneInfo("America/Los_Angeles"))
 
 # Define the sampling strategy
 sampling_strategy = SamplingStrategy(

--- a/examples/ophys_acquisition.py
+++ b/examples/ophys_acquisition.py
@@ -1,7 +1,8 @@
 """ example fiber photometry acquisition """
 
 import argparse
-from datetime import datetime, timezone
+from datetime import datetime
+from zoneinfo import ZoneInfo
 
 from aind_data_schema_models.modalities import Modality
 
@@ -13,7 +14,7 @@ from aind_data_schema.core.acquisition import (
 from aind_data_schema.components.connections import Connection
 from aind_data_schema.components.configs import Channel, DetectorConfig, PatchCordConfig, LaserConfig
 
-t = datetime(2022, 7, 12, 7, 00, 00, tzinfo=timezone.utc)
+t = datetime(2022, 7, 12, 7, 00, 00, tzinfo=ZoneInfo("America/Los_Angeles"))
 
 connections = [
     Connection(

--- a/src/aind_data_schema/core/acquisition.py
+++ b/src/aind_data_schema/core/acquisition.py
@@ -1,8 +1,10 @@
 """Schema describing data acquisition metadata and configurations"""
 
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 import logging
-from typing import Annotated, List, Literal, Optional
+from typing import Annotated, List, Literal, Optional, Union
+from zoneinfo import ZoneInfo
 
 from aind_data_schema_models.modalities import Modality
 from aind_data_schema_models.stimulus_modality import StimulusModality
@@ -342,10 +344,15 @@ class Acquisition(DataCoreModel):
         title="Acquisition start time",
         description="During validation, timezone information will be moved into the acquisition_start_tz field.",
     )
-    acquisition_start_tz: Optional[TimeZoneName] = Field(
+    acquisition_start_tz: Optional[Union[int, TimeZoneName]] = Field(
         default=None,
         title="Acquisition start timezone",
-        description="Automatically populated by a validator based on acquisition_start_time.",
+        description=(
+            "Automatically populated by a validator based on acquisition_start_time. "
+            "Will be a TimeZoneName (IANA name) when the datetime uses a ZoneInfo timezone, "
+            "or an integer UTC offset in minutes for fixed-offset timezones. "
+            "Use ZoneInfo (from the zoneinfo standard library) to preserve the named timezone."
+        ),
     )
     acquisition_end_time: AwareDatetimeWithDefault = Field(..., title="Acquisition end time")
     experimenters: List[str] = Field(
@@ -406,6 +413,23 @@ class Acquisition(DataCoreModel):
         default=[], title="Manipulations", description="Procedures performed during the acquisition."
     )
     subject_details: Optional[AcquisitionSubjectDetails] = Field(default=None, title="Subject details")
+
+    @property
+    def acquisition_start_time_local(self) -> datetime:
+        """Return acquisition_start_time converted to the timezone stored in acquisition_start_tz.
+
+        If acquisition_start_tz is a TimeZoneName (IANA name), uses ZoneInfo to construct the timezone.
+        If acquisition_start_tz is an int (UTC offset in minutes), uses a fixed-offset timezone.
+        If acquisition_start_tz is None, returns acquisition_start_time as-is.
+        """
+        if self.acquisition_start_tz is None:
+            return self.acquisition_start_time
+        if isinstance(self.acquisition_start_tz, int):
+            tz = timezone(timedelta(minutes=self.acquisition_start_tz))
+        else:
+            tz = ZoneInfo(str(self.acquisition_start_tz))
+        return self.acquisition_start_time.astimezone(tz)
+
 
     @model_validator(mode="after")
     def extract_timezone(self):

--- a/src/aind_data_schema/core/acquisition.py
+++ b/src/aind_data_schema/core/acquisition.py
@@ -3,6 +3,7 @@
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 import logging
+import re
 from typing import Annotated, List, Literal, Optional, Union
 from zoneinfo import ZoneInfo
 
@@ -10,7 +11,7 @@ from aind_data_schema_models.modalities import Modality
 from aind_data_schema_models.stimulus_modality import StimulusModality
 from aind_data_schema_models.units import MassUnit, VolumeUnit
 from aind_data_schema.utils.validators import TimeValidation
-from pydantic import Field, SkipValidation, model_validator
+from pydantic import Field, SkipValidation, field_validator, model_validator
 from pydantic_extra_types.timezone_name import TimeZoneName
 
 from aind_data_schema.base import AwareDatetimeWithDefault, DataCoreModel, DataModel, DiscriminatedList, GenericModel
@@ -350,11 +351,23 @@ class Acquisition(DataCoreModel):
         description=(
             "Automatically populated by a validator based on acquisition_start_time. "
             "Will be a TimeZoneName (IANA name) when the datetime uses a ZoneInfo timezone, "
-            "or an integer UTC offset in minutes for fixed-offset timezones. "
+            "or an integer UTC offset in hours for fixed-offset timezones. "
             "Use ZoneInfo (from the zoneinfo standard library) to preserve the named timezone."
         ),
     )
     acquisition_end_time: AwareDatetimeWithDefault = Field(..., title="Acquisition end time")
+
+    @field_validator("acquisition_start_tz", mode="before")
+    @classmethod
+    def coerce_fixed_offset_tz_string(cls, v):
+        """Convert legacy fixed-offset strings like '-07:00' or '+05:30' to integer minutes."""
+        if isinstance(v, str):
+            m = re.fullmatch(r"([+-]?)(\d{2}):(\d{2})", v)
+            if m:
+                sign = -1 if m.group(1) == "-" else 1
+                return sign * (int(m.group(2)) * 60 + int(m.group(3))) // 60
+        return v
+
     experimenters: List[str] = Field(
         default=[],
         title="experimenter(s)",
@@ -419,13 +432,13 @@ class Acquisition(DataCoreModel):
         """Return acquisition_start_time converted to the timezone stored in acquisition_start_tz.
 
         If acquisition_start_tz is a TimeZoneName (IANA name), uses ZoneInfo to construct the timezone.
-        If acquisition_start_tz is an int (UTC offset in minutes), uses a fixed-offset timezone.
+        If acquisition_start_tz is an int (UTC offset in hours), uses a fixed-offset timezone.
         If acquisition_start_tz is None, returns acquisition_start_time as-is.
         """
         if self.acquisition_start_tz is None:
             return self.acquisition_start_time
         if isinstance(self.acquisition_start_tz, int):
-            tz = timezone(timedelta(minutes=self.acquisition_start_tz))
+            tz = timezone(timedelta(hours=self.acquisition_start_tz))
         else:
             tz = ZoneInfo(str(self.acquisition_start_tz))
         return self.acquisition_start_time.astimezone(tz)

--- a/src/aind_data_schema/core/acquisition.py
+++ b/src/aind_data_schema/core/acquisition.py
@@ -430,7 +430,6 @@ class Acquisition(DataCoreModel):
             tz = ZoneInfo(str(self.acquisition_start_tz))
         return self.acquisition_start_time.astimezone(tz)
 
-
     @model_validator(mode="after")
     def extract_timezone(self):
         """Extract timezone information from acquisition_start_time and set acquisition_start_tz"""

--- a/src/aind_data_schema/utils/validators.py
+++ b/src/aind_data_schema/utils/validators.py
@@ -339,8 +339,8 @@ def validate_creation_time_after_midnight(
         )
 
 
-def extract_timezone_from_datetime(dt: datetime) -> TimeZoneName:
-    """Extract timezone information from a datetime object and return as TimeZoneName.
+def extract_timezone_from_datetime(dt: datetime) -> Union[int, TimeZoneName]:
+    """Extract timezone information from a datetime object.
 
     Parameters
     ----------
@@ -349,8 +349,10 @@ def extract_timezone_from_datetime(dt: datetime) -> TimeZoneName:
 
     Returns
     -------
-    TimeZoneName
-        The timezone name extracted from the datetime
+    Union[int, TimeZoneName]
+        A TimeZoneName (IANA name string) if the tzinfo is a ZoneInfo-backed timezone,
+        or an integer representing the UTC offset in minutes for fixed-offset timezones
+        such as datetime.timezone.utc or datetime.timezone(timedelta(...)).
 
     Raises
     ------
@@ -359,10 +361,19 @@ def extract_timezone_from_datetime(dt: datetime) -> TimeZoneName:
 
     Notes
     -----
-    When used with AwareDatetimeWithDefault fields in mode='after' validators,
-    the datetime will already be timezone-aware (naive datetimes are automatically
-    converted by the field validator).
+    Prefer using ZoneInfo (from the zoneinfo standard library) when constructing
+    timezone-aware datetimes so that the IANA timezone name is preserved.
+    Fixed-offset timezones (e.g. timezone.utc, timezone(timedelta(hours=-7))) will
+    be stored as integer UTC offsets in minutes and lose their named identity.
     """
     if not hasattr(dt, "tzinfo") or dt.tzinfo is None:
         raise ValueError("datetime must be timezone-aware")
-    return TimeZoneName(dt.tzinfo)
+
+    key = getattr(dt.tzinfo, "key", None)
+    if key is not None:
+        return TimeZoneName(key)
+
+    offset = dt.utcoffset()
+    if offset is None:
+        raise ValueError("datetime must be timezone-aware")
+    return int(offset.total_seconds() // 60)

--- a/src/aind_data_schema/utils/validators.py
+++ b/src/aind_data_schema/utils/validators.py
@@ -374,6 +374,4 @@ def extract_timezone_from_datetime(dt: datetime) -> Union[int, TimeZoneName]:
         return TimeZoneName(key)
 
     offset = dt.utcoffset()
-    if offset is None:
-        raise ValueError("datetime must be timezone-aware")
     return int(offset.total_seconds() // 60)

--- a/src/aind_data_schema/utils/validators.py
+++ b/src/aind_data_schema/utils/validators.py
@@ -351,7 +351,7 @@ def extract_timezone_from_datetime(dt: datetime) -> Union[int, TimeZoneName]:
     -------
     Union[int, TimeZoneName]
         A TimeZoneName (IANA name string) if the tzinfo is a ZoneInfo-backed timezone,
-        or an integer representing the UTC offset in minutes for fixed-offset timezones
+        or an integer representing the UTC offset in hours for fixed-offset timezones
         such as datetime.timezone.utc or datetime.timezone(timedelta(...)).
 
     Raises
@@ -364,7 +364,7 @@ def extract_timezone_from_datetime(dt: datetime) -> Union[int, TimeZoneName]:
     Prefer using ZoneInfo (from the zoneinfo standard library) when constructing
     timezone-aware datetimes so that the IANA timezone name is preserved.
     Fixed-offset timezones (e.g. timezone.utc, timezone(timedelta(hours=-7))) will
-    be stored as integer UTC offsets in minutes and lose their named identity.
+    be stored as integer UTC offsets in hours and lose their named identity.
     """
     if not hasattr(dt, "tzinfo") or dt.tzinfo is None:
         raise ValueError("datetime must be timezone-aware")
@@ -374,4 +374,4 @@ def extract_timezone_from_datetime(dt: datetime) -> Union[int, TimeZoneName]:
         return TimeZoneName(key)
 
     offset = dt.utcoffset()
-    return int(offset.total_seconds() // 60)
+    return int(offset.total_seconds() // 3600)

--- a/tests/test_composability_merge.py
+++ b/tests/test_composability_merge.py
@@ -2,6 +2,7 @@
 
 import unittest
 from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
 
 from aind_data_schema_models.modalities import Modality
 
@@ -135,7 +136,7 @@ class TestComposability(unittest.TestCase):
     def test_merge_acquisition(self):
         """Test merging two Acquisition objects"""
 
-        t = datetime(2022, 11, 22, 8, 43, 00, tzinfo=timezone.utc)
+        t = datetime(2022, 11, 22, 8, 43, 00, tzinfo=ZoneInfo("America/Los_Angeles"))
 
         acq1 = self.exaspim_acquisition.model_copy()
         acq2 = self.exaspim_acquisition.model_copy()

--- a/tests/test_utils_validators.py
+++ b/tests/test_utils_validators.py
@@ -800,18 +800,18 @@ class TestExtractTimezoneFromDatetime(unittest.TestCase):
         self.assertEqual(result, 0)
 
     def test_negative_fixed_offset_returns_int(self):
-        """Test that a negative fixed-offset timezone returns the offset in minutes"""
+        """Test that a negative fixed-offset timezone returns the offset in hours"""
         dt = datetime(2023, 1, 1, 7, 0, 0, tzinfo=timezone(timedelta(hours=-7)))
         result = extract_timezone_from_datetime(dt)
         self.assertIsInstance(result, int)
-        self.assertEqual(result, -420)
+        self.assertEqual(result, -7)
 
     def test_positive_fixed_offset_returns_int(self):
-        """Test that a positive fixed-offset timezone returns the offset in minutes"""
+        """Test that a positive fixed-offset timezone returns the offset in hours"""
         dt = datetime(2023, 1, 1, 17, 30, 0, tzinfo=timezone(timedelta(hours=5, minutes=30)))
         result = extract_timezone_from_datetime(dt)
         self.assertIsInstance(result, int)
-        self.assertEqual(result, 330)
+        self.assertEqual(result, 5)
 
     def test_local_timezone_from_astimezone_returns_int_or_timezone_name(self):
         """Test that a datetime from astimezone() returns either int or TimeZoneName"""


### PR DESCRIPTION
This PR allows for offset timezones like UTC, -07:00, etc, to be stored as integer offsets in the `Acquisition.acquisition_start_tz` field. It also adds support for a property `Acquisition.acquisition_start_time_local` that reconstructs the original datetime object from the combined contents of the start time and the start tz. 

This is a hotfix to repair a bug in v2.5.0 that causes ALL assets to fail validation after serialization and de-serialization.