### PR TITLE
fix: remove behavior modality requirement for a LickSpoutAssembly

### DIFF
--- a/src/aind_data_schema/core/instrument.py
+++ b/src/aind_data_schema/core/instrument.py
@@ -65,7 +65,6 @@ DEVICES_REQUIRED = {
     Modality.POPHYS.abbreviation: [[Laser], [Detector], [Objective]],
     Modality.SLAP2.abbreviation: [[Laser], [Detector], [Objective], [DigitalMicromirrorDevice], [Microscope]],
     Modality.BEHAVIOR_VIDEOS.abbreviation: [CameraAssembly],
-    Modality.BEHAVIOR.abbreviation: [[LickSpoutAssembly]],
     Modality.SPIM.abbreviation: [[Laser], [Objective], [ScanningStage]],
 }
 


### PR DESCRIPTION
Removes the requirement that behavior assets include a LickSpoutAssembly