### PR TITLE
Allow specimen_id to be a list

### DIFF
--- a/docs/source/acquisition.md
+++ b/docs/source/acquisition.md
@@ -78,7 +78,7 @@ while the StimulusEpoch represents all stimuli being presented.
 | Field | Type | Title (Description) |
 |-------|------|-------------|
 | `subject_id` | `str` | Subject ID (Unique identifier for the subject) |
-| `specimen_id` | `Optional[str]` | Specimen ID (Specimen ID is required for in vitro imaging modalities) |
+| `specimen_id` | `str or List[str] or NoneType` | Specimen ID (Specimen ID is required for in vitro imaging modalities) |
 | `acquisition_start_time` | `datetime (timezone-aware)` | Acquisition start time (During validation, timezone information will be moved into the acquisition_start_tz field.) |
 | `acquisition_start_tz` | `int or pydantic_extra_types.timezone_name.TimeZoneName or NoneType` | Acquisition start timezone (Automatically populated by a validator based on acquisition_start_time. Will be a TimeZoneName (IANA name) when the datetime uses a ZoneInfo timezone, or an integer UTC offset in hours for fixed-offset timezones. Use ZoneInfo (from the zoneinfo standard library) to preserve the named timezone.) |
 | `acquisition_end_time` | `datetime (timezone-aware)` | Acquisition end time  |

--- a/src/aind_data_schema/core/acquisition.py
+++ b/src/aind_data_schema/core/acquisition.py
@@ -329,11 +329,11 @@ class Acquisition(DataCoreModel):
     # Meta metadata
     _DESCRIBED_BY_URL = DataCoreModel._DESCRIBED_BY_BASE_URL.default + "aind_data_schema/core/acquisition.py"
     describedBy: str = Field(default=_DESCRIBED_BY_URL, json_schema_extra={"const": _DESCRIBED_BY_URL})
-    schema_version: SkipValidation[Literal["2.4.0"]] = Field(default="2.4.0")
+    schema_version: SkipValidation[Literal["2.5.0"]] = Field(default="2.5.0")
 
     # ID
     subject_id: str = Field(default=..., title="Subject ID", description="Unique identifier for the subject")
-    specimen_id: Optional[str] = Field(
+    specimen_id: Optional[Union[str, List[str]]] = Field(
         default=None, title="Specimen ID", description="Specimen ID is required for in vitro imaging modalities"
     )
 
@@ -452,8 +452,10 @@ class Acquisition(DataCoreModel):
     def check_subject_specimen_id(self):
         """Check that the subject and specimen IDs match"""
         if self.specimen_id and self.subject_id:
-            if not subject_specimen_id_compatibility(self.subject_id, self.specimen_id):
-                raise ValueError(f"Expected {self.subject_id} to appear in {self.specimen_id}")
+            ids = self.specimen_id if isinstance(self.specimen_id, list) else [self.specimen_id]
+            for sid in ids:
+                if not subject_specimen_id_compatibility(self.subject_id, sid):
+                    raise ValueError(f"Expected {self.subject_id} to appear in {sid}")
 
         return self
 

--- a/src/aind_data_schema/core/acquisition.py
+++ b/src/aind_data_schema/core/acquisition.py
@@ -334,7 +334,7 @@ class Acquisition(DataCoreModel):
     # ID
     subject_id: str = Field(default=..., title="Subject ID", description="Unique identifier for the subject")
     specimen_id: Optional[Union[str, List[str]]] = Field(
-        default=None, title="Specimen ID", description="Specimen ID is required for in vitro imaging modalities"
+        default=None, title="Specimen ID", description="Specimen ID(s) used in this acquisition. Required for in vitro imaging modalities."
     )
 
     # Acquisition metadata

--- a/src/aind_data_schema/core/acquisition.py
+++ b/src/aind_data_schema/core/acquisition.py
@@ -334,7 +334,9 @@ class Acquisition(DataCoreModel):
     # ID
     subject_id: str = Field(default=..., title="Subject ID", description="Unique identifier for the subject")
     specimen_id: Optional[Union[str, List[str]]] = Field(
-        default=None, title="Specimen ID", description="Specimen ID(s) used in this acquisition. Required for in vitro imaging modalities."
+        default=None,
+        title="Specimen ID",
+        description="Specimen ID(s) used in this acquisition. Required for in vitro imaging modalities.",
     )
 
     # Acquisition metadata

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -78,13 +78,6 @@ class AcquisitionTest(unittest.TestCase):
             Acquisition.model_validate_json(acq.model_dump_json())
         self.assertIn("Expected 123456 to appear in SP654321_slide2", str(context.exception))
 
-    def test_specimen_id_none(self):
-        """Test that specimen_id=None is valid for non-specimen modalities"""
-        acq = ephys_acquisition.model_copy()
-        acq.specimen_id = None
-        validated = Acquisition.model_validate_json(acq.model_dump_json())
-        self.assertIsNone(validated.specimen_id)
-
     def test_specimen_required(self):
         """Test that specimen ID is required for in vitro imaging modalities"""
         with self.assertRaises(ValueError):

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -63,6 +63,28 @@ class AcquisitionTest(unittest.TestCase):
 
         self.assertIn("Expected 123456 to appear in 654321", str(context.exception))
 
+    def test_specimen_id_list_valid(self):
+        """Test that specimen_id accepts a list of strings when all contain subject_id"""
+        acq = exaspim_acquisition.model_copy()
+        acq.specimen_id = ["SP123456_slide1", "SP123456_slide2"]
+        validated = Acquisition.model_validate_json(acq.model_dump_json())
+        self.assertEqual(validated.specimen_id, ["SP123456_slide1", "SP123456_slide2"])
+
+    def test_specimen_id_list_invalid(self):
+        """Test that specimen_id list raises ValueError if any entry does not contain subject_id"""
+        with self.assertRaises(ValueError) as context:
+            acq = exaspim_acquisition.model_copy()
+            acq.specimen_id = ["SP123456_slide1", "SP654321_slide2"]
+            Acquisition.model_validate_json(acq.model_dump_json())
+        self.assertIn("Expected 123456 to appear in SP654321_slide2", str(context.exception))
+
+    def test_specimen_id_none(self):
+        """Test that specimen_id=None is valid for non-specimen modalities"""
+        acq = ephys_acquisition.model_copy()
+        acq.specimen_id = None
+        validated = Acquisition.model_validate_json(acq.model_dump_json())
+        self.assertIsNone(validated.specimen_id)
+
     def test_specimen_required(self):
         """Test that specimen ID is required for in vitro imaging modalities"""
         with self.assertRaises(ValueError):

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -66,17 +66,17 @@ class AcquisitionTest(unittest.TestCase):
     def test_specimen_id_list_valid(self):
         """Test that specimen_id accepts a list of strings when all contain subject_id"""
         acq = exaspim_acquisition.model_copy()
-        acq.specimen_id = ["SP123456_slide1", "SP123456_slide2"]
+        acq.specimen_id = ["123456_slide1", "123456_slide2"]
         validated = Acquisition.model_validate_json(acq.model_dump_json())
-        self.assertEqual(validated.specimen_id, ["SP123456_slide1", "SP123456_slide2"])
+        self.assertEqual(validated.specimen_id, ["123456_slide1", "123456_slide2"])
 
     def test_specimen_id_list_invalid(self):
         """Test that specimen_id list raises ValueError if any entry does not contain subject_id"""
         with self.assertRaises(ValueError) as context:
             acq = exaspim_acquisition.model_copy()
-            acq.specimen_id = ["SP123456_slide1", "SP654321_slide2"]
+            acq.specimen_id = ["123456_slide1", "654321_slide2"]
             Acquisition.model_validate_json(acq.model_dump_json())
-        self.assertIn("Expected 123456 to appear in SP654321_slide2", str(context.exception))
+        self.assertIn("Expected 123456 to appear in 654321_slide2", str(context.exception))
 
     def test_specimen_required(self):
         """Test that specimen ID is required for in vitro imaging modalities"""


### PR DESCRIPTION
Changes acquisition.specimen_id type to be a union of `str` and `list[str]`. This allows us to pass multiple specimen_ids, as would be the case when acquisitions are derived from imaging multiple brain slices.