### PR TITLE
docs: rebuild docs

### DIFF
--- a/docs/base/core/acquisition.md
+++ b/docs/base/core/acquisition.md
@@ -19,9 +19,9 @@ Because the start and stop times are independent for data streams and stimulus e
 
 ## Uniqueness
 
-You can uniquely identify acquisition sessions (and therefore a specific data asset) by their acquisition datetime (`Acquisition.acquisition_end_time`). In addition, the `Acquisition.acquisition_type` is an open `str` field where you can put conceptual information that groups similar acquisitions together. This should not be completely redundant with project names, modalities, stimulus names, or any other fields in the metadata.
+You can uniquely identify acquisition sessions (and therefore a specific data asset) by their acquisition datetime (`Acquisition.acquisition_start_time`). In addition, the `Acquisition.acquisition_type` is an open `str` field where you can put conceptual information that groups similar acquisitions together. This should not be completely redundant with project names, modalities, stimulus names, or any other fields in the metadata.
 
-For example, in the `"Brain Computer Interface"` project name, good acquisition types would be strings like: `"BCI: Single neuron stim"` and `"BCI: Group neuron stim"`. These phrases clearly identify what part of a project these acquisitions belong to, without being overly redundant with controlled fields in the metadata.
+For example, in the `"Brain Computer Interface"` project name, good acquisition types would be strings like: `"Single neuron stim"` and `"Group neuron stim"`. These phrases clearly identify what part of a project these acquisitions belong to, without being overly redundant with controlled fields in the metadata.
 
 ## Stimulus parameters
 

--- a/docs/base/core/quality_control.md
+++ b/docs/base/core/quality_control.md
@@ -26,7 +26,7 @@ If you find yourself computing a value for something smaller than an entire moda
 
 `tags` are groups of descriptors that define how metrics are organized hierarchically, making it easier to visualize metrics. Good tag keys (groups) are things like "probe" and good tag values are things like "Probe A" or just "A".
 
-```{python}
+```python
 # For an electrophysiology metric
 tags = {
     "probe": "A",

--- a/docs/source/acquisition.md
+++ b/docs/source/acquisition.md
@@ -19,9 +19,9 @@ Because the start and stop times are independent for data streams and stimulus e
 
 ## Uniqueness
 
-You can uniquely identify acquisition sessions (and therefore a specific data asset) by their acquisition datetime (`Acquisition.acquisition_end_time`). In addition, the `Acquisition.acquisition_type` is an open `str` field where you can put conceptual information that groups similar acquisitions together. This should not be completely redundant with project names, modalities, stimulus names, or any other fields in the metadata.
+You can uniquely identify acquisition sessions (and therefore a specific data asset) by their acquisition datetime (`Acquisition.acquisition_start_time`). In addition, the `Acquisition.acquisition_type` is an open `str` field where you can put conceptual information that groups similar acquisitions together. This should not be completely redundant with project names, modalities, stimulus names, or any other fields in the metadata.
 
-For example, in the `"Brain Computer Interface"` project name, good acquisition types would be strings like: `"BCI: Single neuron stim"` and `"BCI: Group neuron stim"`. These phrases clearly identify what part of a project these acquisitions belong to, without being overly redundant with controlled fields in the metadata.
+For example, in the `"Brain Computer Interface"` project name, good acquisition types would be strings like: `"Single neuron stim"` and `"Group neuron stim"`. These phrases clearly identify what part of a project these acquisitions belong to, without being overly redundant with controlled fields in the metadata.
 
 ## Stimulus parameters
 

--- a/docs/source/aind_data_schema_models/devices.md
+++ b/docs/source/aind_data_schema_models/devices.md
@@ -95,7 +95,6 @@ Detector type name
 |------|-------|
 | `CAMERA` | `Camera` |
 | `PMT` | `Photomultiplier Tube` |
-| `SiPM` | `Silicon Photomultiplier` |
 | `OTHER` | `Other` |
 
 

--- a/docs/source/aind_data_schema_models/organizations.md
+++ b/docs/source/aind_data_schema_models/organizations.md
@@ -9,98 +9,97 @@ Organization
 | Name | abbreviation | name | registry | registry_identifier |
 |------|------|------|------|------|
 | `AA_OPTO_ELECTRONIC` | `None` | `AA Opto Electronic` | `None` | `None` |
-| `ABCAM` | `None` | `Abcam` | `Research Organization Registry (ROR)` | `02e1wjw63` |
-| `ADDGENE` | `None` | `Addgene` | `Research Organization Registry (ROR)` | `01nn1pw54` |
-| `AI` | `AI` | `Allen Institute` | `Research Organization Registry (ROR)` | `03cpe7c52` |
-| `AIBS` | `AIBS` | `Allen Institute for Brain Science` | `Research Organization Registry (ROR)` | `00dcv1019` |
+| `ABCAM` | `None` | `Abcam` | `Registry.ROR` | `02e1wjw63` |
+| `ADDGENE` | `None` | `Addgene` | `Registry.ROR` | `01nn1pw54` |
+| `AI` | `AI` | `Allen Institute` | `Registry.ROR` | `03cpe7c52` |
+| `AIBS` | `AIBS` | `Allen Institute for Brain Science` | `Registry.ROR` | `00dcv1019` |
 | `AILIPU` | `Ailipu` | `Ailipu Technology Co` | `None` | `None` |
-| `AIND` | `AIND` | `Allen Institute for Neural Dynamics` | `Research Organization Registry (ROR)` | `04szwah67` |
-| `AMS_OSRAM` | `None` | `ams OSRAM` | `Research Organization Registry (ROR)` | `045d0h266` |
+| `AIND` | `AIND` | `Allen Institute for Neural Dynamics` | `Registry.ROR` | `04szwah67` |
+| `AMS_OSRAM` | `None` | `ams OSRAM` | `Registry.ROR` | `045d0h266` |
 | `ARDUINO` | `None` | `Arduino` | `None` | `None` |
 | `ARECONT_VISION_COSTAR` | `None` | `Arecont Vision Costar` | `None` | `None` |
 | `ASI` | `ASI` | `Applied Scientific Instrumentation` | `None` | `None` |
-| `ASUS` | `None` | `ASUS` | `Research Organization Registry (ROR)` | `00bxkz165` |
+| `ASUS` | `None` | `ASUS` | `Registry.ROR` | `00bxkz165` |
 | `BASLER` | `None` | `Basler` | `None` | `None` |
-| `BCM` | `BCM` | `Baylor College of Medicine` | `Research Organization Registry (ROR)` | `02pttbw34` |
-| `BRUKER` | `None` | `Bruker` | `Research Organization Registry (ROR)` | `04r739x86` |
-| `BU` | `BU` | `Boston University` | `Research Organization Registry (ROR)` | `05qwgg493` |
-| `CAJAL` | `Cajal` | `Cajal Neuroscience` | `Research Organization Registry (ROR)` | `05pdc0q70` |
+| `BCM` | `BCM` | `Baylor College of Medicine` | `Registry.ROR` | `02pttbw34` |
+| `BU` | `BU` | `Boston University` | `Registry.ROR` | `05qwgg493` |
+| `CAJAL` | `Cajal` | `Cajal Neuroscience` | `Registry.ROR` | `05pdc0q70` |
 | `CAMBRIDGE_TECHNOLOGY` | `None` | `Cambridge Technology` | `None` | `None` |
-| `CARL_ZEISS` | `None` | `Carl Zeiss` | `Research Organization Registry (ROR)` | `01xk5xs43` |
+| `CARL_ZEISS` | `None` | `Carl Zeiss` | `Registry.ROR` | `01xk5xs43` |
 | `CATHETER_IMPLANT_INSTITUTIONS` | `N/A` | `N/A` | `N/A` | `N/A` |
-| `CHAMPALIMAUD` | `Champalimaud` | `Champalimaud Foundation` | `Research Organization Registry (ROR)` | `03g001n57` |
+| `CHAMPALIMAUD` | `Champalimaud` | `Champalimaud Foundation` | `Registry.ROR` | `03g001n57` |
 | `CHROMA` | `None` | `Chroma` | `None` | `None` |
-| `COHERENT_SCIENTIFIC` | `None` | `Coherent Scientific` | `Research Organization Registry (ROR)` | `031tysd23` |
-| `COLUMBIA` | `Columbia` | `Columbia University` | `Research Organization Registry (ROR)` | `00hj8s172` |
+| `COHERENT_SCIENTIFIC` | `None` | `Coherent Scientific` | `Registry.ROR` | `031tysd23` |
+| `COLUMBIA` | `Columbia` | `Columbia University` | `Registry.ROR` | `00hj8s172` |
 | `COMPUTAR` | `None` | `Computar` | `None` | `None` |
 | `CONOPTICS` | `None` | `Conoptics` | `None` | `None` |
 | `CRESTOPTICS` | `None` | `CrestOptics` | `None` | `None` |
-| `CRL` | `CRL` | `Charles River Laboratories` | `Research Organization Registry (ROR)` | `03ndmsg87` |
+| `CRL` | `CRL` | `Charles River Laboratories` | `Registry.ROR` | `03ndmsg87` |
 | `CUSTOM` | `None` | `Custom` | `None` | `None` |
-| `CZI` | `CZI` | `Chan Zuckerberg Initiative` | `Research Organization Registry (ROR)` | `02qenvm24` |
+| `CZI` | `CZI` | `Chan Zuckerberg Initiative` | `Registry.ROR` | `02qenvm24` |
 | `DAQ_DEVICE_MANUFACTURERS` | `N/A` | `N/A` | `N/A` | `N/A` |
 | `DETECTOR_MANUFACTURERS` | `N/A` | `N/A` | `N/A` | `N/A` |
 | `DIGIKEY` | `None` | `DigiKey` | `None` | `None` |
 | `DODOTRONIC` | `None` | `Dodotronic` | `None` | `None` |
-| `DORIC` | `None` | `Doric` | `Research Organization Registry (ROR)` | `059n53q30` |
+| `DORIC` | `None` | `Doric` | `Registry.ROR` | `059n53q30` |
 | `EALING` | `None` | `Ealing` | `None` | `None` |
-| `EDMUND_OPTICS` | `None` | `Edmund Optics` | `Research Organization Registry (ROR)` | `01j1gwp17` |
-| `EMORY` | `Emory` | `Emory University` | `Research Organization Registry (ROR)` | `03czfpz43` |
+| `EDMUND_OPTICS` | `None` | `Edmund Optics` | `Registry.ROR` | `01j1gwp17` |
+| `EMORY` | `Emory` | `Emory University` | `Registry.ROR` | `03czfpz43` |
 | `EURESYS` | `None` | `Euresys` | `None` | `None` |
 | `FILTER_MANUFACTURERS` | `N/A` | `N/A` | `N/A` | `N/A` |
-| `FLIR` | `FLIR` | `Teledyne FLIR` | `Research Organization Registry (ROR)` | `01j1gwp17` |
+| `FLIR` | `FLIR` | `Teledyne FLIR` | `Registry.ROR` | `01j1gwp17` |
 | `FUJINON` | `None` | `Fujinon` | `None` | `None` |
 | `FUNDERS` | `N/A` | `N/A` | `N/A` | `N/A` |
-| `HAMAMATSU` | `None` | `Hamamatsu` | `Research Organization Registry (ROR)` | `03natb733` |
+| `HAMAMATSU` | `None` | `Hamamatsu` | `Registry.ROR` | `03natb733` |
 | `HAMILTON` | `None` | `Hamilton` | `None` | `None` |
-| `HUST` | `HUST` | `Huazhong University of Science and Technology` | `Research Organization Registry (ROR)` | `00p991c53` |
-| `IDT` | `IDT` | `Integrated DNA Technologies` | `Research Organization Registry (ROR)` | `009jvpf03` |
-| `IMEC` | `IMEC` | `Interuniversity Microelectronics Center` | `Research Organization Registry (ROR)` | `02kcbn207` |
+| `HUST` | `HUST` | `Huazhong University of Science and Technology` | `Registry.ROR` | `00p991c53` |
+| `IDT` | `IDT` | `Integrated DNA Technologies` | `Registry.ROR` | `009jvpf03` |
+| `IMEC` | `IMEC` | `Interuniversity Microelectronics Center` | `Registry.ROR` | `02kcbn207` |
 | `INFINITY_PHOTO_OPTICAL` | `None` | `Infinity Photo-Optical` | `None` | `None` |
-| `INVITROGEN` | `None` | `Invitrogen` | `Research Organization Registry (ROR)` | `03x1ewr52` |
+| `INVITROGEN` | `None` | `Invitrogen` | `Registry.ROR` | `03x1ewr52` |
 | `IR_ROBOT_CO` | `None` | `IR Robot Co` | `None` | `None` |
 | `ISL` | `ISL` | `ISL Products International` | `None` | `None` |
 | `ITEM` | `None` | `Item` | `None` | `None` |
-| `JANELIA` | `Janelia` | `Janelia Research Campus` | `Research Organization Registry (ROR)` | `013sk6x84` |
-| `JAX` | `JAX` | `Jackson Laboratory` | `Research Organization Registry (ROR)` | `021sy4w91` |
-| `JENOPTIK` | `None` | `Jenoptik` | `Research Organization Registry (ROR)` | `05g7t5c49` |
-| `JHU` | `JHU` | `Johns Hopkins University` | `Research Organization Registry (ROR)` | `00za53h95` |
+| `JANELIA` | `Janelia` | `Janelia Research Campus` | `Registry.ROR` | `013sk6x84` |
+| `JAX` | `JAX` | `Jackson Laboratory` | `Registry.ROR` | `021sy4w91` |
+| `JENOPTIK` | `None` | `Jenoptik` | `Registry.ROR` | `05g7t5c49` |
+| `JHU` | `JHU` | `Johns Hopkins University` | `Registry.ROR` | `00za53h95` |
 | `JULABO` | `None` | `Julabo` | `None` | `None` |
-| `KOWA` | `None` | `Kowa` | `Research Organization Registry (ROR)` | `03zbwg482` |
+| `KOWA` | `None` | `Kowa` | `Registry.ROR` | `03zbwg482` |
 | `LASER_MANUFACTURERS` | `N/A` | `N/A` | `N/A` | `N/A` |
 | `LASOS` | `LASOS` | `LASOS Lasertechnik` | `None` | `None` |
 | `LED_MANUFACTURERS` | `N/A` | `N/A` | `N/A` | `N/A` |
 | `LEICA` | `None` | `Leica` | `None` | `None` |
 | `LENS_MANUFACTURERS` | `N/A` | `N/A` | `N/A` | `N/A` |
-| `LG` | `None` | `LG` | `Research Organization Registry (ROR)` | `02b948n83` |
+| `LG` | `None` | `LG` | `Registry.ROR` | `02b948n83` |
 | `LIFECANVAS` | `None` | `LifeCanvas` | `None` | `None` |
 | `LUMENCOR` | `None` | `Lumencor` | `None` | `None` |
 | `LUMEN_DYNAMICS` | `None` | `Lumen Dynamics` | `None` | `None` |
 | `MANIPULATOR_MANUFACTURERS` | `N/A` | `N/A` | `N/A` | `N/A` |
-| `MBF` | `MBF` | `MBF Bioscience` | `Research Organization Registry (ROR)` | `02zynam48` |
-| `MEADOWLARK_OPTICS` | `None` | `Meadowlark Optics` | `Research Organization Registry (ROR)` | `00n8qbq54` |
-| `MIBR` | `MIBR` | `McGovern Institute for Brain Research` | `Research Organization Registry (ROR)` | `05ymca674` |
+| `MBF` | `MBF` | `MBF Bioscience` | `Registry.ROR` | `02zynam48` |
+| `MEADOWLARK_OPTICS` | `None` | `Meadowlark Optics` | `Registry.ROR` | `00n8qbq54` |
+| `MIBR` | `MIBR` | `McGovern Institute for Brain Research` | `Registry.ROR` | `05ymca674` |
 | `MIDOPT` | `MidOpt` | `Midwest Optical Systems, Inc.` | `None` | `None` |
-| `MIT` | `MIT` | `Massachusetts Institute of Technology` | `Research Organization Registry (ROR)` | `042nb2s44` |
+| `MIT` | `MIT` | `Massachusetts Institute of Technology` | `Registry.ROR` | `042nb2s44` |
 | `MITUTUYO` | `None` | `Mitutuyo` | `None` | `None` |
 | `MIT_BCS` | `MIT-BCS` | `MIT Department of Brain and Cognitive Sciences` | `None` | `None` |
-| `MJFF` | `MJFF` | `Michael J. Fox Foundation for Parkinson's Research` | `Research Organization Registry (ROR)` | `03arq3225` |
-| `MKS_NEWPORT` | `None` | `MKS Newport` | `Research Organization Registry (ROR)` | `00k17f049` |
+| `MJFF` | `MJFF` | `Michael J. Fox Foundation for Parkinson's Research` | `Registry.ROR` | `03arq3225` |
+| `MKS_NEWPORT` | `None` | `MKS Newport` | `Registry.ROR` | `00k17f049` |
 | `MONITOR_MANUFACTURERS` | `N/A` | `N/A` | `N/A` | `N/A` |
 | `MPI` | `MPI` | `MPI` | `None` | `None` |
-| `NATIONAL_INSTRUMENTS` | `None` | `National Instruments` | `Research Organization Registry (ROR)` | `026exqw73` |
+| `NATIONAL_INSTRUMENTS` | `None` | `National Instruments` | `Registry.ROR` | `026exqw73` |
 | `NAVITAR` | `None` | `Navitar` | `None` | `None` |
-| `NCCIH` | `NCCIH` | `National Center for Complementary and Integrative Health` | `Research Organization Registry (ROR)` | `00190t495` |
+| `NCCIH` | `NCCIH` | `National Center for Complementary and Integrative Health` | `Registry.ROR` | `00190t495` |
 | `NEURALYNX` | `None` | `NeuraLynx` | `None` | `None` |
 | `NEUROPHOTOMETRICS` | `None` | `Neurophotometrics` | `None` | `None` |
 | `NEW_SCALE_TECHNOLOGIES` | `None` | `New Scale Technologies` | `None` | `None` |
-| `NIKON` | `None` | `Nikon` | `Research Organization Registry (ROR)` | `0280y9h11` |
-| `NIMH` | `NIMH` | `National Institute of Mental Health` | `Research Organization Registry (ROR)` | `04xeg9z08` |
-| `NINDS` | `NINDS` | `National Institute of Neurological Disorders and Stroke` | `Research Organization Registry (ROR)` | `01s5ya894` |
+| `NIKON` | `None` | `Nikon` | `Registry.ROR` | `0280y9h11` |
+| `NIMH` | `NIMH` | `National Institute of Mental Health` | `Registry.ROR` | `04xeg9z08` |
+| `NINDS` | `NINDS` | `National Institute of Neurological Disorders and Stroke` | `Registry.ROR` | `01s5ya894` |
 | `NRESEARCH_INC` | `None` | `NResearch Inc` | `None` | `None` |
-| `NYU` | `NYU` | `New York University` | `Research Organization Registry (ROR)` | `0190ak572` |
-| `OEPS` | `OEPS` | `Open Ephys Production Site` | `Research Organization Registry (ROR)` | `007rkz355` |
-| `OLYMPUS` | `None` | `Olympus` | `Research Organization Registry (ROR)` | `02vcdte90` |
+| `NYU` | `NYU` | `New York University` | `Registry.ROR` | `0190ak572` |
+| `OEPS` | `OEPS` | `Open Ephys Production Site` | `Registry.ROR` | `007rkz355` |
+| `OLYMPUS` | `None` | `Olympus` | `Registry.ROR` | `02vcdte90` |
 | `OPTOTUNE` | `None` | `Optotune` | `None` | `None` |
 | `OTHER` | `None` | `Other` | `None` | `None` |
 | `OXXIUS` | `None` | `Oxxius` | `None` | `None` |
@@ -115,25 +114,25 @@ Organization
 | `SEMROCK` | `None` | `Semrock` | `None` | `None` |
 | `SICGEN` | `None` | `SICGEN` | `None` | `None` |
 | `SIGMA_ALDRICH` | `None` | `Sigma-Aldrich` | `None` | `None` |
-| `SIMONS_FOUNDATION` | `None` | `Simons Foundation` | `Research Organization Registry (ROR)` | `01cmst727` |
+| `SIMONS_FOUNDATION` | `None` | `Simons Foundation` | `Registry.ROR` | `01cmst727` |
 | `SPEAKER_MANUFACTURERS` | `N/A` | `N/A` | `N/A` | `N/A` |
-| `SPECTRA_PHYSICS` | `None` | `Spectra-Physics` | `Research Organization Registry (ROR)` | `02ad9kp97` |
+| `SPECTRA_PHYSICS` | `None` | `Spectra-Physics` | `Registry.ROR` | `02ad9kp97` |
 | `SPINNAKER` | `None` | `Spinnaker` | `None` | `None` |
 | `SUBJECT_SOURCES` | `N/A` | `N/A` | `N/A` | `N/A` |
 | `TAMRON` | `None` | `Tamron` | `None` | `None` |
 | `TELEDYNE_VISION_SOLUTIONS` | `None` | `Teledyne Vision Solutions` | `None` | `None` |
-| `TE_CONNECTIVITY` | `None` | `TE Connectivity` | `Research Organization Registry (ROR)` | `034frgp20` |
-| `THERMO_FISHER_SCIENTIFIC` | `None` | `Thermo Fisher Scientific` | `Research Organization Registry (ROR)` | `03x1ewr52` |
+| `TE_CONNECTIVITY` | `None` | `TE Connectivity` | `Registry.ROR` | `034frgp20` |
+| `THERMO_FISHER_SCIENTIFIC` | `None` | `Thermo Fisher Scientific` | `Registry.ROR` | `03x1ewr52` |
 | `THE_IMAGING_SOURCE` | `None` | `The Imaging Source` | `None` | `None` |
 | `THE_LEE_COMPANY` | `None` | `The Lee Company` | `None` | `None` |
-| `THORLABS` | `None` | `Thorlabs` | `Research Organization Registry (ROR)` | `04gsnvb07` |
+| `THORLABS` | `None` | `Thorlabs` | `Registry.ROR` | `04gsnvb07` |
 | `TMC` | `TMC` | `Technical Manufacturing Corporation` | `None` | `None` |
 | `TRANSDUCER_TECHNIQUES` | `None` | `Transducer Techniques` | `None` | `None` |
-| `TWCF` | `TWCF` | `Templeton World Charity Foundation` | `Research Organization Registry (ROR)` | `00x0z1472` |
+| `TWCF` | `TWCF` | `Templeton World Charity Foundation` | `Registry.ROR` | `00x0z1472` |
 | `TYMPHANY` | `None` | `Tymphany` | `None` | `None` |
-| `UCSD` | `UCSD` | `University of California, San Diego` | `Research Organization Registry (ROR)` | `0168r3w48` |
+| `UCSD` | `UCSD` | `University of California, San Diego` | `Registry.ROR` | `0168r3w48` |
 | `UNKNOWN` | `UNKNOWN` | `Unknown` | `None` | `None` |
-| `UPENN` | `UPENN` | `University of Pennsylvania` | `Research Organization Registry (ROR)` | `00b30xv10` |
+| `UPENN` | `UPENN` | `University of Pennsylvania` | `Registry.ROR` | `00b30xv10` |
 | `VIEWORKS` | `None` | `Vieworks` | `None` | `None` |
 | `VORTRAN` | `None` | `Vortran` | `None` | `None` |
 

--- a/docs/source/aind_data_schema_models/species.md
+++ b/docs/source/aind_data_schema_models/species.md
@@ -8,18 +8,18 @@ Species
 
 | Name | name | common_name | registry | registry_identifier |
 |------|------|------|------|------|
-| `ALPACA` | `Vicuna pacos` | `Alpaca` | `National Center for Biotechnology Information (NCBI)` | `NCBI:txid30538` |
-| `CHICKEN` | `Gallus gallus` | `Chicken` | `National Center for Biotechnology Information (NCBI)` | `NCBI:txid9031` |
-| `COMMON_MARMOSET` | `Callithrix jacchus` | `Common marmoset` | `National Center for Biotechnology Information (NCBI)` | `NCBI:txid9483` |
-| `DONKEY` | `Equus asinus` | `Donkey` | `National Center for Biotechnology Information (NCBI)` | `NCBI:txid9793` |
-| `EUROPEAN_RABBIT` | `Oryctolagus cuniculus` | `European rabbit` | `National Center for Biotechnology Information (NCBI)` | `NCBI:txid9986` |
-| `GOAT` | `Carpa hircus` | `Goat` | `National Center for Biotechnology Information (NCBI)` | `NCBI:txid9925` |
-| `GUINEA_PIG` | `Cavia porcellus` | `Guinea pig` | `National Center for Biotechnology Information (NCBI)` | `NCBI:txid10141` |
-| `HOUSE_MOUSE` | `Mus musculus` | `House mouse` | `National Center for Biotechnology Information (NCBI)` | `NCBI:txid10090` |
-| `HUMAN` | `Homo sapiens` | `Human` | `National Center for Biotechnology Information (NCBI)` | `NCBI:txid9606` |
-| `LLAMA` | `Lama glama` | `Llama` | `National Center for Biotechnology Information (NCBI)` | `NCBI:txid9844` |
-| `NORWAY_RAT` | `Rattus norvegicus` | `Norway rat` | `National Center for Biotechnology Information (NCBI)` | `NCBI:txid10116` |
-| `RHESUS_MACAQUE` | `Macaca mulatta` | `Rhesus macaque` | `National Center for Biotechnology Information (NCBI)` | `NCBI:txid9544` |
+| `ALPACA` | `Vicuna pacos` | `Alpaca` | `Registry.NCBI` | `NCBI:txid30538` |
+| `CHICKEN` | `Gallus gallus` | `Chicken` | `Registry.NCBI` | `NCBI:txid9031` |
+| `COMMON_MARMOSET` | `Callithrix jacchus` | `Common marmoset` | `Registry.NCBI` | `NCBI:txid9483` |
+| `DONKEY` | `Equus asinus` | `Donkey` | `Registry.NCBI` | `NCBI:txid9793` |
+| `EUROPEAN_RABBIT` | `Oryctolagus cuniculus` | `European rabbit` | `Registry.NCBI` | `NCBI:txid9986` |
+| `GOAT` | `Carpa hircus` | `Goat` | `Registry.NCBI` | `NCBI:txid9925` |
+| `GUINEA_PIG` | `Cavia porcellus` | `Guinea pig` | `Registry.NCBI` | `NCBI:txid10141` |
+| `HOUSE_MOUSE` | `Mus musculus` | `House mouse` | `Registry.NCBI` | `NCBI:txid10090` |
+| `HUMAN` | `Homo sapiens` | `Human` | `Registry.NCBI` | `NCBI:txid9606` |
+| `LLAMA` | `Lama glama` | `Llama` | `Registry.NCBI` | `NCBI:txid9844` |
+| `NORWAY_RAT` | `Rattus norvegicus` | `Norway rat` | `Registry.NCBI` | `NCBI:txid10116` |
+| `RHESUS_MACAQUE` | `Macaca mulatta` | `Rhesus macaque` | `Registry.NCBI` | `NCBI:txid9544` |
 
 
 ### Strain
@@ -28,8 +28,8 @@ Strain
 
 | Name | name | species | registry | registry_identifier |
 |------|------|------|------|------|
-| `BALB_C` | `BALB/c` | `Mus musculus` | `Mouse Genome Informatics (MGI)` | `MGI:2159737` |
-| `C57BL_6J` | `C57BL/6J` | `Mus musculus` | `Mouse Genome Informatics (MGI)` | `MGI:3028467` |
+| `BALB_C` | `BALB/c` | `Mus musculus` | `Registry.MGI` | `MGI:2159737` |
+| `C57BL_6J` | `C57BL/6J` | `Mus musculus` | `Registry.MGI` | `MGI:3028467` |
 | `UNKNOWN` | `Unknown` | `Mus musculus` | `None` | `None` |
 
 

--- a/docs/source/components/configs.md
+++ b/docs/source/components/configs.md
@@ -476,7 +476,6 @@ Configuration of a SLAP2 imaging plane (all imaging ROIs of a specific acquisiti
 | `specimen_id` | `Optional[str]` | Specimen ID (Unique index identifying the cell being imaged: <subject_id>_###) |
 | `fov_index` | `Optional[int]` | Field of view index (For FOVs that are imaged multiple times, assign a shared index to each instance of the FOV) |
 | `structure_types` | Optional[List[[NeuronStructure](#neuronstructure)]] | Structure type  |
-| `target_name` | `Optional[str]` | Name of imaged target  |
 | `y_dilations` | `List[int]` | Unique Y dilations  |
 | `y_dilations_unit` | [SizeUnit](../aind_data_schema_models/units.md#sizeunit) | Dilation unit  |
 | `frame_rates` | `List[float]` | Unique frame rates  |

--- a/docs/source/components/devices.md
+++ b/docs/source/components/devices.md
@@ -777,7 +777,7 @@ Multichannel electrophysiology DAQ
 | Field | Type | Title (Description) |
 |-------|------|-------------|
 | `ports` | List[[ProbePort](#probeport)] | Acquisition board ports  |
-| `data_interface` | `"USB"` |   |
+| `data_interface` | `"DataInterface.USB"` |   |
 | `manufacturer` | [Organization](../aind_data_schema_models/organizations.md#organization) |   |
 | `channels` | List[[DAQChannel](#daqchannel)] | DAQ channels  |
 | `firmware_version` | `Optional[str]` | Firmware version  |

--- a/docs/source/components/identifiers.md
+++ b/docs/source/components/identifiers.md
@@ -12,7 +12,7 @@ Code or script identifier
 | `name` | `Optional[str]` | Name  |
 | `version` | `Optional[str]` | Code version  |
 | `container` | Optional[[Container](#container)] | Container  |
-| `run_script` | `Optional[pathlib.Path]` | Run script (Path to run script) |
+| `run_script` | `Optional[pathlib._local.Path]` | Run script (Path to run script) |
 | `language` | `Optional[str]` | Programming language (Programming language used) |
 | `language_version` | `Optional[str]` | Programming language version  |
 | `input_data` | Optional[List[[DataAsset](#dataasset) or [CombinedData](#combineddata)]] | Input data (Input data used in the code or script) |

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -33,7 +33,6 @@ I want to...
 ------------
 
 - :doc:`Create metadata for my data assets <example_workflow/example_workflow>`. 
-- :doc:`Create metadata using the AIND metadata-mapper <todo>`. 
 - :doc:`Learn about the philosophy behind aind-data-schema<general>`.
 - :doc:`Learn about how coordinate systems work<coordinate_systems>`.
 - `Report an issue or request an addition to the metadata schema <https://github.com/AllenNeuralDynamics/aind-data-schema/issues>`_.

--- a/docs/source/quality_control.md
+++ b/docs/source/quality_control.md
@@ -26,7 +26,7 @@ If you find yourself computing a value for something smaller than an entire moda
 
 `tags` are groups of descriptors that define how metrics are organized hierarchically, making it easier to visualize metrics. Good tag keys (groups) are things like "probe" and good tag values are things like "Probe A" or just "A".
 
-```{python}
+```python
 # For an electrophysiology metric
 tags = {
     "probe": "A",

--- a/docs/source/validation.md
+++ b/docs/source/validation.md
@@ -14,7 +14,7 @@ The following consistency rules are enforced:
 
 Construct it as follows:
 
-```{python}
+```python
 from aind_data_schema.utils.compatibility_check import InstrumentAcquisitionCompatibility
 
 # Construct your Instrument and Acquisition objects


### PR DESCRIPTION
A few minor changes:

1. Removed bad {python} directives
2. Removed a link that was related to aind-metadata-mapper (not allowed in this repo)
3. Fixed a reference to acquisition_end_time which should have been pointing to the start_time
4. Re-built all docs