### PR TITLE
fix: throw warnings when users put identical Device.names

### DIFF
--- a/examples/ephys_instrument.py
+++ b/examples/ephys_instrument.py
@@ -204,14 +204,12 @@ probe_camera_4 = Camera(
     chroma="Color",
 )
 
-stick_lens = Lens(name="Probe lens", manufacturer=Organization.EDMUND_OPTICS)
-
 microscope_1 = CameraAssembly(
     name="Stick_assembly_1",
     target=CameraTarget.BRAIN,
     relative_position=[AnatomicalRelative.SUPERIOR],
     camera=probe_camera_1,
-    lens=stick_lens,
+    lens=Lens(name="Probe lens 1", manufacturer=Organization.EDMUND_OPTICS),
 )
 
 microscope_2 = CameraAssembly(
@@ -219,7 +217,7 @@ microscope_2 = CameraAssembly(
     target=CameraTarget.BRAIN,
     relative_position=[AnatomicalRelative.SUPERIOR],
     camera=probe_camera_2,
-    lens=stick_lens,
+    lens=Lens(name="Probe lens 2", manufacturer=Organization.EDMUND_OPTICS),
 )
 
 microscope_3 = CameraAssembly(
@@ -227,7 +225,7 @@ microscope_3 = CameraAssembly(
     target=CameraTarget.BRAIN,
     relative_position=[AnatomicalRelative.SUPERIOR],
     camera=probe_camera_3,
-    lens=stick_lens,
+    lens=Lens(name="Probe lens 3", manufacturer=Organization.EDMUND_OPTICS),
 )
 
 microscope_4 = CameraAssembly(
@@ -235,7 +233,7 @@ microscope_4 = CameraAssembly(
     target=CameraTarget.BRAIN,
     relative_position=[AnatomicalRelative.SUPERIOR],
     camera=probe_camera_4,
-    lens=stick_lens,
+    lens=Lens(name="Probe lens 4", manufacturer=Organization.EDMUND_OPTICS),
 )
 
 probeA = EphysProbe(name="Probe A", serial_number="9291019", probe_model="Neuropixels 1.0")
@@ -258,19 +256,6 @@ ephys_assemblyB = EphysAssembly(
     probes=[probeB],
 )
 
-filt = Filter(
-    name="LP filter",
-    filter_type="Long pass",
-    manufacturer=Organization.THORLABS,
-    cut_on_wavelength=850,
-    wavelength_unit=SizeUnit.NM,
-)
-
-lens = Lens(
-    name="Camera lens",
-    manufacturer=Organization.EDMUND_OPTICS,
-)
-
 face_camera = Camera(
     name="Face Camera",
     detector_type="Camera",
@@ -290,8 +275,14 @@ camassm1 = CameraAssembly(
     camera=face_camera,
     target=CameraTarget.FACE,
     relative_position=[AnatomicalRelative.LEFT],
-    filter=filt,
-    lens=lens,
+    filter=Filter(
+        name="LP filter face",
+        filter_type="Long pass",
+        manufacturer=Organization.THORLABS,
+        cut_on_wavelength=850,
+        wavelength_unit=SizeUnit.NM,
+    ),
+    lens=Lens(name="Camera lens face", manufacturer=Organization.EDMUND_OPTICS),
 )
 
 body_camera = Camera(
@@ -313,8 +304,14 @@ camassm2 = CameraAssembly(
     target=CameraTarget.BODY,
     relative_position=[AnatomicalRelative.SUPERIOR],
     camera=body_camera,
-    filter=filt,
-    lens=lens,
+    filter=Filter(
+        name="LP filter body",
+        filter_type="Long pass",
+        manufacturer=Organization.THORLABS,
+        cut_on_wavelength=850,
+        wavelength_unit=SizeUnit.NM,
+    ),
+    lens=Lens(name="Camera lens body", manufacturer=Organization.EDMUND_OPTICS),
 )
 
 monitor = Monitor(

--- a/src/aind_data_schema/core/instrument.py
+++ b/src/aind_data_schema/core/instrument.py
@@ -199,6 +199,20 @@ class Instrument(DataCoreModel):
         return self
 
     @model_validator(mode="after")
+    def validate_unique_component_names(self):
+        """Warn if any component names are duplicated"""
+        names = self.get_component_names()
+        if len(set(names)) != len(names):
+            seen = set()
+            duplicates = set()
+            for name in names:
+                if name in seen:
+                    duplicates.add(name)
+                seen.add(name)
+            logging.warning(f"Duplicate component names found: {sorted(duplicates)}")
+        return self
+
+    @model_validator(mode="after")
     def validate_connections(self):
         """validate that all connections map between devices that actually exist"""
         device_names = self.get_component_names()

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -824,6 +824,39 @@ class InstrumentTests(unittest.TestCase):
 
         self.assertEqual(len(combined.components), 3)
 
+    def test_validate_unique_component_names(self):
+        """Test that duplicate component names log a warning"""
+        duplicate_component = ephys_instrument.components[0].model_copy(deep=True)
+        inst_with_dup = Instrument.model_construct(
+            instrument_id=ephys_instrument.instrument_id,
+            modification_date=ephys_instrument.modification_date,
+            modalities=ephys_instrument.modalities,
+            coordinate_system=ephys_instrument.coordinate_system,
+            components=list(ephys_instrument.components) + [duplicate_component],
+            connections=ephys_instrument.connections or [],
+            calibrations=ephys_instrument.calibrations,
+        )
+
+        with patch("aind_data_schema.core.instrument.logging") as mock_logging:
+            inst_with_dup.validate_unique_component_names()
+            mock_logging.warning.assert_called_once()
+            warning_msg = mock_logging.warning.call_args[0][0]
+            self.assertIn(duplicate_component.name, warning_msg)
+
+        inst_no_dup = Instrument.model_construct(
+            instrument_id=ephys_instrument.instrument_id,
+            modification_date=ephys_instrument.modification_date,
+            modalities=ephys_instrument.modalities,
+            coordinate_system=ephys_instrument.coordinate_system,
+            components=list(ephys_instrument.components),
+            connections=ephys_instrument.connections or [],
+            calibrations=ephys_instrument.calibrations,
+        )
+
+        with patch("aind_data_schema.core.instrument.logging") as mock_logging:
+            inst_no_dup.validate_unique_component_names()
+            mock_logging.warning.assert_not_called()
+
 
 class ConnectionTest(unittest.TestCase):
     """Test the Connection schema"""


### PR DESCRIPTION
This PR adds a validator that throws warnings when it runs into repeated names in the `Instrument.get_component_names()` output. In V3 we'll upgrade these to validation errors.