### PR TITLE
fix: validate modalities

### DIFF
--- a/src/aind_data_schema/core/metadata.py
+++ b/src/aind_data_schema/core/metadata.py
@@ -373,7 +373,9 @@ class Metadata(DataCoreModel):
                 parts.append(f"in acquisition but not data_description: {acq_modalities - dd_modalities}")
             if dd_modalities - acq_modalities:
                 parts.append(f"in data_description but not acquisition: {dd_modalities - acq_modalities}")
-            warnings.warn(f"Modality mismatch between acquisition.data_streams and data_description. {'; '.join(parts)}")
+            warnings.warn(
+                f"Modality mismatch between acquisition.data_streams and data_description. {'; '.join(parts)}"
+            )
 
     def _check_instrument_modalities(self, dd_modalities):
         """Warn if instrument modalities are not a superset of data_description modalities."""

--- a/src/aind_data_schema/core/metadata.py
+++ b/src/aind_data_schema/core/metadata.py
@@ -361,6 +361,48 @@ class Metadata(DataCoreModel):
         return self
 
     @model_validator(mode="after")
+    def validate_modality_consistency(self):
+        """Validate that modalities are consistent across core files relative to data_description"""
+
+        if not self.data_description or not hasattr(self.data_description, "modalities"):
+            return self
+
+        dd_modalities = set(self.data_description.modalities)
+
+        if self.acquisition and self.acquisition.data_streams:
+            acq_modalities = set()
+            for data_stream in self.acquisition.data_streams:
+                acq_modalities.update(data_stream.modalities)
+            if acq_modalities != dd_modalities:
+                missing_from_dd = acq_modalities - dd_modalities
+                missing_from_acq = dd_modalities - acq_modalities
+                parts = []
+                if missing_from_dd:
+                    parts.append(f"in acquisition but not data_description: {missing_from_dd}")
+                if missing_from_acq:
+                    parts.append(f"in data_description but not acquisition: {missing_from_acq}")
+                warnings.warn(f"Modality mismatch between acquisition.data_streams and data_description. {'; '.join(parts)}")
+
+        if self.instrument and hasattr(self.instrument, "modalities"):
+            inst_modalities = set(self.instrument.modalities)
+            if not inst_modalities.issuperset(dd_modalities):
+                missing = dd_modalities - inst_modalities
+                warnings.warn(
+                    f"Instrument modalities are not a superset of data_description modalities. "
+                    f"Missing from instrument: {missing}"
+                )
+
+        if self.quality_control and hasattr(self.quality_control, "modalities"):
+            qc_modalities = set(self.quality_control.modalities)
+            if not qc_modalities.issubset(dd_modalities):
+                extra = qc_modalities - dd_modalities
+                warnings.warn(
+                    f"QualityControl metric modalities {extra} are not present in data_description modalities {dd_modalities}"
+                )
+
+        return self
+
+    @model_validator(mode="after")
     def validate_data_description_name_time_consistency(self):
         """Validate that the creation_time from data_description.name is on or after midnight
         on the same day as acquisition.acquisition_end_time"""

--- a/src/aind_data_schema/core/metadata.py
+++ b/src/aind_data_schema/core/metadata.py
@@ -360,46 +360,52 @@ class Metadata(DataCoreModel):
 
         return self
 
+    def _check_acquisition_modalities(self, dd_modalities):
+        """Warn if acquisition.data_streams modalities do not exactly match data_description modalities."""
+        if not (self.acquisition and self.acquisition.data_streams):
+            return
+        acq_modalities = set()
+        for data_stream in self.acquisition.data_streams:
+            acq_modalities.update(data_stream.modalities)
+        if acq_modalities != dd_modalities:
+            parts = []
+            if acq_modalities - dd_modalities:
+                parts.append(f"in acquisition but not data_description: {acq_modalities - dd_modalities}")
+            if dd_modalities - acq_modalities:
+                parts.append(f"in data_description but not acquisition: {dd_modalities - acq_modalities}")
+            warnings.warn(f"Modality mismatch between acquisition.data_streams and data_description. {'; '.join(parts)}")
+
+    def _check_instrument_modalities(self, dd_modalities):
+        """Warn if instrument modalities are not a superset of data_description modalities."""
+        if not (self.instrument and hasattr(self.instrument, "modalities")):
+            return
+        missing = dd_modalities - set(self.instrument.modalities)
+        if missing:
+            warnings.warn(
+                f"Instrument modalities are not a superset of data_description modalities. "
+                f"Missing from instrument: {missing}"
+            )
+
+    def _check_quality_control_modalities(self, dd_modalities):
+        """Warn if any QualityControl metric modalities are not present in data_description modalities."""
+        if not (self.quality_control and hasattr(self.quality_control, "modalities")):
+            return
+        extra = set(self.quality_control.modalities) - dd_modalities
+        if extra:
+            warnings.warn(
+                f"QualityControl metric modalities {extra} are not present"
+                f" in data_description modalities {dd_modalities}"
+            )
+
     @model_validator(mode="after")
     def validate_modality_consistency(self):
         """Validate that modalities are consistent across core files relative to data_description"""
-
         if not self.data_description or not hasattr(self.data_description, "modalities"):
             return self
-
         dd_modalities = set(self.data_description.modalities)
-
-        if self.acquisition and self.acquisition.data_streams:
-            acq_modalities = set()
-            for data_stream in self.acquisition.data_streams:
-                acq_modalities.update(data_stream.modalities)
-            if acq_modalities != dd_modalities:
-                missing_from_dd = acq_modalities - dd_modalities
-                missing_from_acq = dd_modalities - acq_modalities
-                parts = []
-                if missing_from_dd:
-                    parts.append(f"in acquisition but not data_description: {missing_from_dd}")
-                if missing_from_acq:
-                    parts.append(f"in data_description but not acquisition: {missing_from_acq}")
-                warnings.warn(f"Modality mismatch between acquisition.data_streams and data_description. {'; '.join(parts)}")
-
-        if self.instrument and hasattr(self.instrument, "modalities"):
-            inst_modalities = set(self.instrument.modalities)
-            if not inst_modalities.issuperset(dd_modalities):
-                missing = dd_modalities - inst_modalities
-                warnings.warn(
-                    f"Instrument modalities are not a superset of data_description modalities. "
-                    f"Missing from instrument: {missing}"
-                )
-
-        if self.quality_control and hasattr(self.quality_control, "modalities"):
-            qc_modalities = set(self.quality_control.modalities)
-            if not qc_modalities.issubset(dd_modalities):
-                extra = qc_modalities - dd_modalities
-                warnings.warn(
-                    f"QualityControl metric modalities {extra} are not present in data_description modalities {dd_modalities}"
-                )
-
+        self._check_acquisition_modalities(dd_modalities)
+        self._check_instrument_modalities(dd_modalities)
+        self._check_quality_control_modalities(dd_modalities)
         return self
 
     @model_validator(mode="after")

--- a/src/aind_data_schema/utils/validators.py
+++ b/src/aind_data_schema/utils/validators.py
@@ -83,10 +83,10 @@ def _validate_time_constraint(field_value, time_validation, start_time, end_time
                 f"Field '{field_name}' with value {field_value} must be between {start_time} and {end_time}"
             )
     elif time_validation == TimeValidation.AFTER:
-        if comparable_field_value <= start_time:
+        if comparable_field_value < start_time:
             raise ValueError(f"Field '{field_name}' with value {field_value} must be after {start_time}")
     elif time_validation == TimeValidation.BEFORE:
-        if comparable_field_value >= end_time:
+        if comparable_field_value > end_time:
             raise ValueError(f"Field '{field_name}' with value {field_value} must be before {end_time}")
 
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -34,7 +34,6 @@ from examples.subject import s as subject
 from examples.exaspim_acquisition import acq as exaspim_acq
 from examples.exaspim_instrument import inst as exaspim_inst
 from examples.exaspim_quality_control import quality_control as exaspim_qc
-from examples.ephys_acquisition import acquisition as ephys_acq
 
 ephys_assembly = EphysAssembly(
     probes=[EphysProbe(probe_model="Neuropixels 1.0", name="Probe A")],
@@ -954,13 +953,10 @@ class TestMetadata(unittest.TestCase):
         """Tests that modality consistency validator issues correct warnings."""
         import warnings as warnings_module
 
-        dd_ecephys = data_description.model_copy(update={"modalities": [Modality.ECEPHYS]})
         dd_spim = data_description.model_copy(update={"modalities": [Modality.SPIM]})
-        dd_ecephys_spim = data_description.model_copy(update={"modalities": [Modality.ECEPHYS, Modality.SPIM]})
-        dd_ecephys_bv = data_description.model_copy(
-            update={"modalities": [Modality.ECEPHYS, Modality.BEHAVIOR_VIDEOS]}
-        )
-        inst_no_cal = ephys_inst.model_copy(update={"calibrations": None})
+        dd_ecephys = data_description.model_copy(update={"modalities": [Modality.ECEPHYS]})
+        dd_spim_ecephys = data_description.model_copy(update={"modalities": [Modality.SPIM, Modality.ECEPHYS]})
+        inst_no_cal = exaspim_inst.model_copy(update={"calibrations": None})
 
         # Case 1: acquisition modalities match data_description - no warning
         with warnings_module.catch_warnings(record=True) as w:
@@ -969,9 +965,9 @@ class TestMetadata(unittest.TestCase):
                 name="Test",
                 location="loc",
                 subject=subject,
-                data_description=dd_ecephys,
+                data_description=dd_spim,
                 instrument=inst_no_cal,
-                acquisition=ephys_acq,
+                acquisition=exaspim_acq,
             )
         modality_warnings = [str(x.message) for x in w if "Modality mismatch" in str(x.message)]
         self.assertEqual([], modality_warnings)
@@ -982,9 +978,9 @@ class TestMetadata(unittest.TestCase):
                 name="Test",
                 location="loc",
                 subject=subject,
-                data_description=dd_spim,
+                data_description=dd_ecephys,
                 instrument=inst_no_cal,
-                acquisition=ephys_acq,
+                acquisition=exaspim_acq,
             )
         warning_messages = [str(x.message) for x in w.warnings]
         self.assertTrue(any("Modality mismatch" in m for m in warning_messages))
@@ -996,9 +992,9 @@ class TestMetadata(unittest.TestCase):
                 name="Test",
                 location="loc",
                 subject=subject,
-                data_description=dd_ecephys_spim,
+                data_description=dd_spim_ecephys,
                 instrument=inst_no_cal,
-                acquisition=ephys_acq,
+                acquisition=exaspim_acq,
             )
         warning_messages = [str(x.message) for x in w.warnings]
         self.assertTrue(any("Modality mismatch" in m for m in warning_messages))
@@ -1011,8 +1007,8 @@ class TestMetadata(unittest.TestCase):
                 name="Test",
                 location="loc",
                 subject=subject,
-                data_description=dd_ecephys,
-                instrument=ephys_inst,
+                data_description=dd_spim,
+                instrument=exaspim_inst,
             )
         inst_warnings = [str(x.message) for x in w if "superset" in str(x.message)]
         self.assertEqual([], inst_warnings)
@@ -1023,8 +1019,8 @@ class TestMetadata(unittest.TestCase):
                 name="Test",
                 location="loc",
                 subject=subject,
-                data_description=dd_spim,
-                instrument=ephys_inst,
+                data_description=dd_spim_ecephys,
+                instrument=exaspim_inst,
             )
         warning_messages = [str(x.message) for x in w.warnings]
         self.assertTrue(any("superset" in m for m in warning_messages))

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -31,6 +31,10 @@ from aind_data_schema.core.acquisition import StimulusEpoch
 
 from examples.data_description import d as data_description
 from examples.subject import s as subject
+from examples.exaspim_acquisition import acq as exaspim_acq
+from examples.exaspim_instrument import inst as exaspim_inst
+from examples.exaspim_quality_control import quality_control as exaspim_qc
+from examples.ephys_acquisition import acquisition as ephys_acq
 
 ephys_assembly = EphysAssembly(
     probes=[EphysProbe(probe_model="Neuropixels 1.0", name="Probe A")],
@@ -945,6 +949,124 @@ class TestMetadata(unittest.TestCase):
                 acquisition=acquisition_missing_both,
             )
         self.assertIn("Acquisition.subject_details are required for in vivo experiments", str(context.exception))
+
+    def test_validate_modality_consistency(self):
+        """Tests that modality consistency validator issues correct warnings."""
+        import warnings as warnings_module
+
+        dd_ecephys = data_description.model_copy(update={"modalities": [Modality.ECEPHYS]})
+        dd_spim = data_description.model_copy(update={"modalities": [Modality.SPIM]})
+        dd_ecephys_spim = data_description.model_copy(update={"modalities": [Modality.ECEPHYS, Modality.SPIM]})
+        dd_ecephys_bv = data_description.model_copy(
+            update={"modalities": [Modality.ECEPHYS, Modality.BEHAVIOR_VIDEOS]}
+        )
+        inst_no_cal = ephys_inst.model_copy(update={"calibrations": None})
+
+        # Case 1: acquisition modalities match data_description - no warning
+        with warnings_module.catch_warnings(record=True) as w:
+            warnings_module.simplefilter("always")
+            Metadata(
+                name="Test",
+                location="loc",
+                subject=subject,
+                data_description=dd_ecephys,
+                instrument=inst_no_cal,
+                acquisition=ephys_acq,
+            )
+        modality_warnings = [str(x.message) for x in w if "Modality mismatch" in str(x.message)]
+        self.assertEqual([], modality_warnings)
+
+        # Case 2: acquisition has modality not in data_description - warns
+        with self.assertWarns(UserWarning) as w:
+            Metadata(
+                name="Test",
+                location="loc",
+                subject=subject,
+                data_description=dd_spim,
+                instrument=inst_no_cal,
+                acquisition=ephys_acq,
+            )
+        warning_messages = [str(x.message) for x in w.warnings]
+        self.assertTrue(any("Modality mismatch" in m for m in warning_messages))
+        self.assertTrue(any("in acquisition but not data_description" in m for m in warning_messages))
+
+        # Case 3: data_description has modality not in acquisition - warns
+        with self.assertWarns(UserWarning) as w:
+            Metadata(
+                name="Test",
+                location="loc",
+                subject=subject,
+                data_description=dd_ecephys_spim,
+                instrument=inst_no_cal,
+                acquisition=ephys_acq,
+            )
+        warning_messages = [str(x.message) for x in w.warnings]
+        self.assertTrue(any("Modality mismatch" in m for m in warning_messages))
+        self.assertTrue(any("in data_description but not acquisition" in m for m in warning_messages))
+
+        # Case 4: instrument modalities are a superset of data_description - no warning
+        with warnings_module.catch_warnings(record=True) as w:
+            warnings_module.simplefilter("always")
+            Metadata(
+                name="Test",
+                location="loc",
+                subject=subject,
+                data_description=dd_ecephys,
+                instrument=ephys_inst,
+            )
+        inst_warnings = [str(x.message) for x in w if "superset" in str(x.message)]
+        self.assertEqual([], inst_warnings)
+
+        # Case 5: instrument modalities missing a modality from data_description - warns
+        with self.assertWarns(UserWarning) as w:
+            Metadata(
+                name="Test",
+                location="loc",
+                subject=subject,
+                data_description=dd_spim,
+                instrument=ephys_inst,
+            )
+        warning_messages = [str(x.message) for x in w.warnings]
+        self.assertTrue(any("superset" in m for m in warning_messages))
+
+        # Case 6: QC modalities are a subset of data_description - no warning
+        with warnings_module.catch_warnings(record=True) as w:
+            warnings_module.simplefilter("always")
+            Metadata(
+                name="Test",
+                location="loc",
+                subject=subject,
+                data_description=dd_spim,
+                quality_control=exaspim_qc,
+            )
+        qc_warnings = [str(x.message) for x in w if "QualityControl" in str(x.message)]
+        self.assertEqual([], qc_warnings)
+
+        # Case 7: QC has modality not in data_description - warns
+        with self.assertWarns(UserWarning) as w:
+            Metadata(
+                name="Test",
+                location="loc",
+                subject=subject,
+                data_description=dd_ecephys,
+                quality_control=exaspim_qc,
+            )
+        warning_messages = [str(x.message) for x in w.warnings]
+        self.assertTrue(any("QualityControl" in m for m in warning_messages))
+
+        # Case 8: no data_description - no modality warnings
+        with warnings_module.catch_warnings(record=True) as w:
+            warnings_module.simplefilter("always")
+            Metadata(
+                name="Test",
+                location="loc",
+                subject=subject,
+            )
+        modality_warnings = [
+            str(x.message) for x in w
+            if any(kw in str(x.message) for kw in ["Modality mismatch", "superset", "QualityControl metric"])
+        ]
+        self.assertEqual([], modality_warnings)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR validates modalities between:

- data_description and acquisition.data_streams/stimulus_epochs. I.e. all data_description modalities must appear in the acquisition streams or epochs and vice versa
- data_description and instrument, i.e. instrument must be a superset of data_description
- data_description and quality_control, i.e. QC must be a subset of data_description

Errors are raised as warnings. In V3 we will uplevel to validation errors.

While writing tests I also fixed a bug where the "BEFORE" and "AFTER" time validators weren't allowing identical times. This causes problems when people put in their instrument a calibration that occurred at the same time as the acquisition_start_time. I think it's fine for them to be equal since people are just using the start time as a short-hand for "happened as part of this acquisition".