### PR TITLE
fix: allow both planar and regular sectioning in sectioning procedures

### DIFF
--- a/src/aind_data_schema/components/specimen_procedures.py
+++ b/src/aind_data_schema/components/specimen_procedures.py
@@ -197,7 +197,10 @@ class SpecimenProcedure(DataModel):
         has_hcr_series = any(isinstance(detail, HCRSeries) for detail in self.procedure_details)
         has_fluorescent_stain = any(isinstance(detail, FluorescentStain) for detail in self.procedure_details)
         has_protein_probe = any(isinstance(detail, ProbeReagent) for detail in self.procedure_details)
-        has_sectioning = any(isinstance(detail, PlanarSectioning) for detail in self.procedure_details)
+        has_sectioning = any(
+            (isinstance(detail, PlanarSectioning) or isinstance(detail, Sectioning))
+            for detail in self.procedure_details
+        )
         has_geneprobeset = any(isinstance(detail, GeneProbeSet) for detail in self.procedure_details)
 
         if has_hcr_series + has_fluorescent_stain + has_sectioning + has_geneprobeset + has_protein_probe > 1:


### PR DESCRIPTION
PR fixes a validator that enforces that Sectioning and PlanarSectioning show up on their own in procedures, separate from other kinds of procedures like HCRSeries, etc.