### PR TITLE
1792 quality control validator has a bug at line 307 where it fails to check metrics before doing metrics0

### DIFF
--- a/src/aind_data_schema/core/quality_control.py
+++ b/src/aind_data_schema/core/quality_control.py
@@ -304,7 +304,7 @@ class QualityControl(DataCoreModel):
         if "default_grouping" not in value:
             return value
 
-        if all(isinstance(item, str) for item in value["default_grouping"]):
+        if all(isinstance(item, str) for item in value["default_grouping"]) and value.get("metrics"):
             first_metric = value["metrics"][0]
             if isinstance(first_metric, dict) and "tags" in first_metric:
                 if isinstance(first_metric["tags"], list):

--- a/src/aind_data_schema/core/quality_control.py
+++ b/src/aind_data_schema/core/quality_control.py
@@ -301,10 +301,10 @@ class QualityControl(DataCoreModel):
         This function is for backwards compatibility with v2.2.X where default_grouping was stored as a list of strings.
         Remove this function in aind-data-schema v3.X
         """
-        if "default_grouping" not in value:
+        if "default_grouping" not in value or "metrics" not in value or len(value["metrics"]) == 0:
             return value
 
-        if all(isinstance(item, str) for item in value["default_grouping"]) and value.get("metrics"):
+        if all(isinstance(item, str) for item in value["default_grouping"]):
             first_metric = value["metrics"][0]
             if isinstance(first_metric, dict) and "tags" in first_metric:
                 if isinstance(first_metric["tags"], list):

--- a/tests/test_quality_control.py
+++ b/tests/test_quality_control.py
@@ -869,6 +869,18 @@ class QualityControlTests(unittest.TestCase):
         # Tags should remain as dict
         self.assertEqual(qc_new.metrics[0].tags, {"group": "test_group", "probe": "probeA", "shank": "shank1"})
 
+    def test_empty_metrics_does_not_convert_default_grouping(self):
+        """Test that fix_default_grouping_list does not alter default_grouping when metrics is empty"""
+
+        empty_metrics_dict = {
+            "metrics": [],
+            "default_grouping": ["group1", "group2"],
+        }
+
+        qc = QualityControl.model_validate(empty_metrics_dict)
+
+        self.assertEqual(qc.default_grouping, ["group1", "group2"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
It was possible to accidentally trigger a call to `metrics[0]` when the metrics list was empty, crashing the validator. This fix prevents that and adds test coverage for this unlikely condition.