### PR TITLE
refactor: remove all Organization.X groups

### DIFF
--- a/docs/source/aind_data_schema_models/process_names.md
+++ b/docs/source/aind_data_schema_models/process_names.md
@@ -37,6 +37,7 @@ Process names
 | `IMAGE_TILE_ALIGNMENT` | `Image tile alignment` |
 | `IMAGE_TILE_FUSING` | `Image tile fusing` |
 | `IMAGE_TILE_PROJECTION` | `Image tile projection` |
+| `MANUAL_CURATION` | `Manual curation` |
 | `MODEL_EVALUATION` | `Model evaluation` |
 | `MODEL_TRAINING` | `Model training` |
 | `NEURON_SKELETON_PROCESSING` | `Neuron skeleton processing` |

--- a/docs/source/components/devices.md
+++ b/docs/source/components/devices.md
@@ -57,7 +57,6 @@ Camera Detector
 | Field | Type | Title (Description) |
 |-------|------|-------------|
 | `detector_type` | [DetectorType](../aind_data_schema_models/devices.md#detectortype) |   |
-| `manufacturer` | [Organization](../aind_data_schema_models/organizations.md#organization) |   |
 | `data_interface` | [DataInterface](../aind_data_schema_models/devices.md#datainterface) | Data interface  |
 | `cooling` | [Cooling](../aind_data_schema_models/devices.md#cooling) | Cooling  |
 | `frame_rate` | `Optional[decimal.Decimal]` | Frame rate (Hz) (Frame rate being used) |
@@ -85,6 +84,7 @@ Camera Detector
 | `driver_version` | `Optional[str]` | Driver version  |
 | `name` | `str` | Device name  |
 | `serial_number` | `Optional[str]` | Serial number  |
+| `manufacturer` | Optional[[Organization](../aind_data_schema_models/organizations.md#organization)] | Manufacturer  |
 | `model` | `Optional[str]` | Model  |
 | `additional_settings` | `Optional[dict]` | Additional parameters  |
 | `notes` | `Optional[str]` | Notes  |
@@ -192,12 +192,12 @@ Data acquisition device containing multiple I/O channels
 | Field | Type | Title (Description) |
 |-------|------|-------------|
 | `data_interface` | [DataInterface](../aind_data_schema_models/devices.md#datainterface) | Type of connection to PC  |
-| `manufacturer` | [Organization](../aind_data_schema_models/organizations.md#organization) |   |
 | `channels` | List[[DAQChannel](#daqchannel)] | DAQ channels  |
 | `firmware_version` | `Optional[str]` | Firmware version  |
 | `hardware_version` | `Optional[str]` | Hardware version  |
 | `name` | `str` | Device name  |
 | `serial_number` | `Optional[str]` | Serial number  |
+| `manufacturer` | Optional[[Organization](../aind_data_schema_models/organizations.md#organization)] | Manufacturer  |
 | `model` | `Optional[str]` | Model  |
 | `additional_settings` | `Optional[dict]` | Additional parameters  |
 | `notes` | `Optional[str]` | Notes  |
@@ -210,7 +210,6 @@ Description of a generic detector
 | Field | Type | Title (Description) |
 |-------|------|-------------|
 | `detector_type` | [DetectorType](../aind_data_schema_models/devices.md#detectortype) | Detector Type  |
-| `manufacturer` | [Organization](../aind_data_schema_models/organizations.md#organization) |   |
 | `data_interface` | [DataInterface](../aind_data_schema_models/devices.md#datainterface) | Data interface  |
 | `cooling` | [Cooling](../aind_data_schema_models/devices.md#cooling) | Cooling  |
 | `frame_rate` | `Optional[decimal.Decimal]` | Frame rate (Hz) (Frame rate being used) |
@@ -238,6 +237,7 @@ Description of a generic detector
 | `driver_version` | `Optional[str]` | Driver version  |
 | `name` | `str` | Device name  |
 | `serial_number` | `Optional[str]` | Serial number  |
+| `manufacturer` | Optional[[Organization](../aind_data_schema_models/organizations.md#organization)] | Manufacturer  |
 | `model` | `Optional[str]` | Model  |
 | `additional_settings` | `Optional[dict]` | Additional parameters  |
 | `notes` | `Optional[str]` | Notes  |
@@ -417,13 +417,13 @@ Filter used in a light path
 | Field | Type | Title (Description) |
 |-------|------|-------------|
 | `filter_type` | [FilterType](../aind_data_schema_models/devices.md#filtertype) | Type of filter  |
-| `manufacturer` | [Organization](../aind_data_schema_models/organizations.md#organization) |   |
 | `cut_off_wavelength` | `Optional[int]` | Cut-off wavelength (nm)  |
 | `cut_on_wavelength` | `Optional[int]` | Cut-on wavelength (nm)  |
 | `center_wavelength` | `int or List[int] or NoneType` | Center wavelength (nm) (Single wavelength or list of wavelengths for MULTIBAND or MULTI_NOTCH filters) |
 | `wavelength_unit` | [SizeUnit](../aind_data_schema_models/units.md#sizeunit) | Wavelength unit  |
 | `name` | `str` | Device name  |
 | `serial_number` | `Optional[str]` | Serial number  |
+| `manufacturer` | Optional[[Organization](../aind_data_schema_models/organizations.md#organization)] | Manufacturer  |
 | `model` | `Optional[str]` | Model  |
 | `additional_settings` | `Optional[dict]` | Additional parameters  |
 | `notes` | `Optional[str]` | Notes  |
@@ -435,7 +435,6 @@ DAQ that uses the Harp protocol for synchronization and data transmission
 
 | Field | Type | Title (Description) |
 |-------|------|-------------|
-| `manufacturer` | [Organization](../aind_data_schema_models/organizations.md#organization) |   |
 | `harp_device_type` | [HarpDeviceType](../aind_data_schema_models/harp_types.md#harpdevicetype) | Type of Harp device  |
 | `core_version` | `Optional[str]` | Core version  |
 | `tag_version` | `Optional[str]` | Tag version  |
@@ -446,6 +445,7 @@ DAQ that uses the Harp protocol for synchronization and data transmission
 | `hardware_version` | `Optional[str]` | Hardware version  |
 | `name` | `str` | Device name  |
 | `serial_number` | `Optional[str]` | Serial number  |
+| `manufacturer` | Optional[[Organization](../aind_data_schema_models/organizations.md#organization)] | Manufacturer  |
 | `model` | `Optional[str]` | Model  |
 | `additional_settings` | `Optional[dict]` | Additional parameters  |
 | `notes` | `Optional[str]` | Notes  |
@@ -476,7 +476,6 @@ Laser module with a specific wavelength (may be a sub-component of a larger asse
 
 | Field | Type | Title (Description) |
 |-------|------|-------------|
-| `manufacturer` | [Organization](../aind_data_schema_models/organizations.md#organization) |   |
 | `wavelength` | `int` | Wavelength (nm)  |
 | `wavelength_unit` | [SizeUnit](../aind_data_schema_models/units.md#sizeunit) | Wavelength unit  |
 | `coupling` | Optional[[Coupling](../aind_data_schema_models/devices.md#coupling)] | Coupling  |
@@ -484,6 +483,7 @@ Laser module with a specific wavelength (may be a sub-component of a larger asse
 | `coupling_efficiency_unit` | `"percent"` | Coupling efficiency unit  |
 | `name` | `str` | Device name  |
 | `serial_number` | `Optional[str]` | Serial number  |
+| `manufacturer` | Optional[[Organization](../aind_data_schema_models/organizations.md#organization)] | Manufacturer  |
 | `model` | `Optional[str]` | Model  |
 | `additional_settings` | `Optional[dict]` | Additional parameters  |
 | `notes` | `Optional[str]` | Notes  |
@@ -508,9 +508,9 @@ Lens
 
 | Field | Type | Title (Description) |
 |-------|------|-------------|
-| `manufacturer` | [Organization](../aind_data_schema_models/organizations.md#organization) |   |
 | `name` | `str` | Device name  |
 | `serial_number` | `Optional[str]` | Serial number  |
+| `manufacturer` | Optional[[Organization](../aind_data_schema_models/organizations.md#organization)] | Manufacturer  |
 | `model` | `Optional[str]` | Model  |
 | `additional_settings` | `Optional[dict]` | Additional parameters  |
 | `notes` | `Optional[str]` | Notes  |
@@ -564,13 +564,13 @@ Description of a Light Emitting Diode (LED) device
 
 | Field | Type | Title (Description) |
 |-------|------|-------------|
-| `manufacturer` | [Organization](../aind_data_schema_models/organizations.md#organization) |   |
 | `wavelength` | `int` | Wavelength (nm)  |
 | `wavelength_unit` | [SizeUnit](../aind_data_schema_models/units.md#sizeunit) | Wavelength unit  |
 | `bandwidth` | `Optional[int]` | Bandwidth (FWHM)  |
 | `bandwidth_unit` | Optional[[SizeUnit](../aind_data_schema_models/units.md#sizeunit)] | Bandwidth unit  |
 | `name` | `str` | Device name  |
 | `serial_number` | `Optional[str]` | Serial number  |
+| `manufacturer` | Optional[[Organization](../aind_data_schema_models/organizations.md#organization)] | Manufacturer  |
 | `model` | `Optional[str]` | Model  |
 | `additional_settings` | `Optional[dict]` | Additional parameters  |
 | `notes` | `Optional[str]` | Notes  |
@@ -582,9 +582,9 @@ Manipulator used on a dome module
 
 | Field | Type | Title (Description) |
 |-------|------|-------------|
-| `manufacturer` | [Organization](../aind_data_schema_models/organizations.md#organization) |   |
 | `name` | `str` | Device name  |
 | `serial_number` | `Optional[str]` | Serial number  |
+| `manufacturer` | Optional[[Organization](../aind_data_schema_models/organizations.md#organization)] | Manufacturer  |
 | `model` | `Optional[str]` | Model  |
 | `additional_settings` | `Optional[dict]` | Additional parameters  |
 | `notes` | `Optional[str]` | Notes  |
@@ -610,7 +610,6 @@ Description of visual display for visual stimuli
 
 | Field | Type | Title (Description) |
 |-------|------|-------------|
-| `manufacturer` | [Organization](../aind_data_schema_models/organizations.md#organization) |   |
 | `refresh_rate` | `int` | Refresh rate (Hz)  |
 | `width` | `int` | Width (pixels)  |
 | `height` | `int` | Height (pixels)  |
@@ -623,6 +622,7 @@ Description of visual display for visual stimuli
 | `brightness_unit` | Optional[[UnitlessUnit](../aind_data_schema_models/units.md#unitlessunit)] | Brightness unit  |
 | `name` | `str` | Device name  |
 | `serial_number` | `Optional[str]` | Serial number  |
+| `manufacturer` | Optional[[Organization](../aind_data_schema_models/organizations.md#organization)] | Manufacturer  |
 | `model` | `Optional[str]` | Model  |
 | `additional_settings` | `Optional[dict]` | Additional parameters  |
 | `notes` | `Optional[str]` | Notes  |
@@ -732,7 +732,6 @@ Description of an olfactometer for odor stimuli
 
 | Field | Type | Title (Description) |
 |-------|------|-------------|
-| `manufacturer` | [Organization](../aind_data_schema_models/organizations.md#organization) |   |
 | `harp_device_type` | [HarpDeviceType](../aind_data_schema_models/harp_types.md#harpdevicetype) | Type of Harp device  |
 | `channels` | List[[OlfactometerChannel](#olfactometerchannel)] |   |
 | `core_version` | `Optional[str]` | Core version  |
@@ -743,6 +742,7 @@ Description of an olfactometer for odor stimuli
 | `hardware_version` | `Optional[str]` | Hardware version  |
 | `name` | `str` | Device name  |
 | `serial_number` | `Optional[str]` | Serial number  |
+| `manufacturer` | Optional[[Organization](../aind_data_schema_models/organizations.md#organization)] | Manufacturer  |
 | `model` | `Optional[str]` | Model  |
 | `additional_settings` | `Optional[dict]` | Additional parameters  |
 | `notes` | `Optional[str]` | Notes  |
@@ -888,9 +888,9 @@ Description of a speaker for auditory stimuli
 
 | Field | Type | Title (Description) |
 |-------|------|-------------|
-| `manufacturer` | [Organization](../aind_data_schema_models/organizations.md#organization) |   |
 | `name` | `str` | Device name  |
 | `serial_number` | `Optional[str]` | Serial number  |
+| `manufacturer` | Optional[[Organization](../aind_data_schema_models/organizations.md#organization)] | Manufacturer  |
 | `model` | `Optional[str]` | Model  |
 | `additional_settings` | `Optional[dict]` | Additional parameters  |
 | `notes` | `Optional[str]` | Notes  |

--- a/docs/source/components/devices.md
+++ b/docs/source/components/devices.md
@@ -57,6 +57,7 @@ Camera Detector
 | Field | Type | Title (Description) |
 |-------|------|-------------|
 | `detector_type` | [DetectorType](../aind_data_schema_models/devices.md#detectortype) |   |
+| `manufacturer` | [Organization](../aind_data_schema_models/organizations.md#organization) | Manufacturer  |
 | `data_interface` | [DataInterface](../aind_data_schema_models/devices.md#datainterface) | Data interface  |
 | `cooling` | [Cooling](../aind_data_schema_models/devices.md#cooling) | Cooling  |
 | `frame_rate` | `Optional[decimal.Decimal]` | Frame rate (Hz) (Frame rate being used) |
@@ -84,7 +85,6 @@ Camera Detector
 | `driver_version` | `Optional[str]` | Driver version  |
 | `name` | `str` | Device name  |
 | `serial_number` | `Optional[str]` | Serial number  |
-| `manufacturer` | Optional[[Organization](../aind_data_schema_models/organizations.md#organization)] | Manufacturer  |
 | `model` | `Optional[str]` | Model  |
 | `additional_settings` | `Optional[dict]` | Additional parameters  |
 | `notes` | `Optional[str]` | Notes  |
@@ -192,12 +192,12 @@ Data acquisition device containing multiple I/O channels
 | Field | Type | Title (Description) |
 |-------|------|-------------|
 | `data_interface` | [DataInterface](../aind_data_schema_models/devices.md#datainterface) | Type of connection to PC  |
+| `manufacturer` | [Organization](../aind_data_schema_models/organizations.md#organization) | Manufacturer  |
 | `channels` | List[[DAQChannel](#daqchannel)] | DAQ channels  |
 | `firmware_version` | `Optional[str]` | Firmware version  |
 | `hardware_version` | `Optional[str]` | Hardware version  |
 | `name` | `str` | Device name  |
 | `serial_number` | `Optional[str]` | Serial number  |
-| `manufacturer` | Optional[[Organization](../aind_data_schema_models/organizations.md#organization)] | Manufacturer  |
 | `model` | `Optional[str]` | Model  |
 | `additional_settings` | `Optional[dict]` | Additional parameters  |
 | `notes` | `Optional[str]` | Notes  |
@@ -210,6 +210,7 @@ Description of a generic detector
 | Field | Type | Title (Description) |
 |-------|------|-------------|
 | `detector_type` | [DetectorType](../aind_data_schema_models/devices.md#detectortype) | Detector Type  |
+| `manufacturer` | [Organization](../aind_data_schema_models/organizations.md#organization) | Manufacturer  |
 | `data_interface` | [DataInterface](../aind_data_schema_models/devices.md#datainterface) | Data interface  |
 | `cooling` | [Cooling](../aind_data_schema_models/devices.md#cooling) | Cooling  |
 | `frame_rate` | `Optional[decimal.Decimal]` | Frame rate (Hz) (Frame rate being used) |
@@ -237,7 +238,6 @@ Description of a generic detector
 | `driver_version` | `Optional[str]` | Driver version  |
 | `name` | `str` | Device name  |
 | `serial_number` | `Optional[str]` | Serial number  |
-| `manufacturer` | Optional[[Organization](../aind_data_schema_models/organizations.md#organization)] | Manufacturer  |
 | `model` | `Optional[str]` | Model  |
 | `additional_settings` | `Optional[dict]` | Additional parameters  |
 | `notes` | `Optional[str]` | Notes  |
@@ -417,13 +417,13 @@ Filter used in a light path
 | Field | Type | Title (Description) |
 |-------|------|-------------|
 | `filter_type` | [FilterType](../aind_data_schema_models/devices.md#filtertype) | Type of filter  |
+| `manufacturer` | [Organization](../aind_data_schema_models/organizations.md#organization) | Manufacturer  |
 | `cut_off_wavelength` | `Optional[int]` | Cut-off wavelength (nm)  |
 | `cut_on_wavelength` | `Optional[int]` | Cut-on wavelength (nm)  |
 | `center_wavelength` | `int or List[int] or NoneType` | Center wavelength (nm) (Single wavelength or list of wavelengths for MULTIBAND or MULTI_NOTCH filters) |
 | `wavelength_unit` | [SizeUnit](../aind_data_schema_models/units.md#sizeunit) | Wavelength unit  |
 | `name` | `str` | Device name  |
 | `serial_number` | `Optional[str]` | Serial number  |
-| `manufacturer` | Optional[[Organization](../aind_data_schema_models/organizations.md#organization)] | Manufacturer  |
 | `model` | `Optional[str]` | Model  |
 | `additional_settings` | `Optional[dict]` | Additional parameters  |
 | `notes` | `Optional[str]` | Notes  |
@@ -435,6 +435,7 @@ DAQ that uses the Harp protocol for synchronization and data transmission
 
 | Field | Type | Title (Description) |
 |-------|------|-------------|
+| `manufacturer` | [Organization](../aind_data_schema_models/organizations.md#organization) | Manufacturer  |
 | `harp_device_type` | [HarpDeviceType](../aind_data_schema_models/harp_types.md#harpdevicetype) | Type of Harp device  |
 | `core_version` | `Optional[str]` | Core version  |
 | `tag_version` | `Optional[str]` | Tag version  |
@@ -445,7 +446,6 @@ DAQ that uses the Harp protocol for synchronization and data transmission
 | `hardware_version` | `Optional[str]` | Hardware version  |
 | `name` | `str` | Device name  |
 | `serial_number` | `Optional[str]` | Serial number  |
-| `manufacturer` | Optional[[Organization](../aind_data_schema_models/organizations.md#organization)] | Manufacturer  |
 | `model` | `Optional[str]` | Model  |
 | `additional_settings` | `Optional[dict]` | Additional parameters  |
 | `notes` | `Optional[str]` | Notes  |
@@ -476,6 +476,7 @@ Laser module with a specific wavelength (may be a sub-component of a larger asse
 
 | Field | Type | Title (Description) |
 |-------|------|-------------|
+| `manufacturer` | [Organization](../aind_data_schema_models/organizations.md#organization) | Manufacturer  |
 | `wavelength` | `int` | Wavelength (nm)  |
 | `wavelength_unit` | [SizeUnit](../aind_data_schema_models/units.md#sizeunit) | Wavelength unit  |
 | `coupling` | Optional[[Coupling](../aind_data_schema_models/devices.md#coupling)] | Coupling  |
@@ -483,7 +484,6 @@ Laser module with a specific wavelength (may be a sub-component of a larger asse
 | `coupling_efficiency_unit` | `"percent"` | Coupling efficiency unit  |
 | `name` | `str` | Device name  |
 | `serial_number` | `Optional[str]` | Serial number  |
-| `manufacturer` | Optional[[Organization](../aind_data_schema_models/organizations.md#organization)] | Manufacturer  |
 | `model` | `Optional[str]` | Model  |
 | `additional_settings` | `Optional[dict]` | Additional parameters  |
 | `notes` | `Optional[str]` | Notes  |
@@ -508,9 +508,9 @@ Lens
 
 | Field | Type | Title (Description) |
 |-------|------|-------------|
+| `manufacturer` | [Organization](../aind_data_schema_models/organizations.md#organization) | Manufacturer  |
 | `name` | `str` | Device name  |
 | `serial_number` | `Optional[str]` | Serial number  |
-| `manufacturer` | Optional[[Organization](../aind_data_schema_models/organizations.md#organization)] | Manufacturer  |
 | `model` | `Optional[str]` | Model  |
 | `additional_settings` | `Optional[dict]` | Additional parameters  |
 | `notes` | `Optional[str]` | Notes  |
@@ -582,9 +582,9 @@ Manipulator used on a dome module
 
 | Field | Type | Title (Description) |
 |-------|------|-------------|
+| `manufacturer` | [Organization](../aind_data_schema_models/organizations.md#organization) | Manufacturer  |
 | `name` | `str` | Device name  |
 | `serial_number` | `Optional[str]` | Serial number  |
-| `manufacturer` | Optional[[Organization](../aind_data_schema_models/organizations.md#organization)] | Manufacturer  |
 | `model` | `Optional[str]` | Model  |
 | `additional_settings` | `Optional[dict]` | Additional parameters  |
 | `notes` | `Optional[str]` | Notes  |
@@ -732,6 +732,7 @@ Description of an olfactometer for odor stimuli
 
 | Field | Type | Title (Description) |
 |-------|------|-------------|
+| `manufacturer` | [Organization](../aind_data_schema_models/organizations.md#organization) | Manufacturer  |
 | `harp_device_type` | [HarpDeviceType](../aind_data_schema_models/harp_types.md#harpdevicetype) | Type of Harp device  |
 | `channels` | List[[OlfactometerChannel](#olfactometerchannel)] |   |
 | `core_version` | `Optional[str]` | Core version  |
@@ -742,7 +743,6 @@ Description of an olfactometer for odor stimuli
 | `hardware_version` | `Optional[str]` | Hardware version  |
 | `name` | `str` | Device name  |
 | `serial_number` | `Optional[str]` | Serial number  |
-| `manufacturer` | Optional[[Organization](../aind_data_schema_models/organizations.md#organization)] | Manufacturer  |
 | `model` | `Optional[str]` | Model  |
 | `additional_settings` | `Optional[dict]` | Additional parameters  |
 | `notes` | `Optional[str]` | Notes  |
@@ -888,9 +888,9 @@ Description of a speaker for auditory stimuli
 
 | Field | Type | Title (Description) |
 |-------|------|-------------|
+| `manufacturer` | [Organization](../aind_data_schema_models/organizations.md#organization) | Manufacturer  |
 | `name` | `str` | Device name  |
 | `serial_number` | `Optional[str]` | Serial number  |
-| `manufacturer` | Optional[[Organization](../aind_data_schema_models/organizations.md#organization)] | Manufacturer  |
 | `model` | `Optional[str]` | Model  |
 | `additional_settings` | `Optional[dict]` | Additional parameters  |
 | `notes` | `Optional[str]` | Notes  |

--- a/docs/source/components/devices.md
+++ b/docs/source/components/devices.md
@@ -564,13 +564,13 @@ Description of a Light Emitting Diode (LED) device
 
 | Field | Type | Title (Description) |
 |-------|------|-------------|
+| `manufacturer` | [Organization](../aind_data_schema_models/organizations.md#organization) | Manufacturer  |
 | `wavelength` | `int` | Wavelength (nm)  |
 | `wavelength_unit` | [SizeUnit](../aind_data_schema_models/units.md#sizeunit) | Wavelength unit  |
 | `bandwidth` | `Optional[int]` | Bandwidth (FWHM)  |
 | `bandwidth_unit` | Optional[[SizeUnit](../aind_data_schema_models/units.md#sizeunit)] | Bandwidth unit  |
 | `name` | `str` | Device name  |
 | `serial_number` | `Optional[str]` | Serial number  |
-| `manufacturer` | Optional[[Organization](../aind_data_schema_models/organizations.md#organization)] | Manufacturer  |
 | `model` | `Optional[str]` | Model  |
 | `additional_settings` | `Optional[dict]` | Additional parameters  |
 | `notes` | `Optional[str]` | Notes  |
@@ -610,6 +610,7 @@ Description of visual display for visual stimuli
 
 | Field | Type | Title (Description) |
 |-------|------|-------------|
+| `manufacturer` | [Organization](../aind_data_schema_models/organizations.md#organization) | Manufacturer  |
 | `refresh_rate` | `int` | Refresh rate (Hz)  |
 | `width` | `int` | Width (pixels)  |
 | `height` | `int` | Height (pixels)  |
@@ -622,7 +623,6 @@ Description of visual display for visual stimuli
 | `brightness_unit` | Optional[[UnitlessUnit](../aind_data_schema_models/units.md#unitlessunit)] | Brightness unit  |
 | `name` | `str` | Device name  |
 | `serial_number` | `Optional[str]` | Serial number  |
-| `manufacturer` | Optional[[Organization](../aind_data_schema_models/organizations.md#organization)] | Manufacturer  |
 | `model` | `Optional[str]` | Model  |
 | `additional_settings` | `Optional[dict]` | Additional parameters  |
 | `notes` | `Optional[str]` | Notes  |

--- a/src/aind_data_schema/components/devices.py
+++ b/src/aind_data_schema/components/devices.py
@@ -662,7 +662,6 @@ class Speaker(Device, DevicePosition):
     """Description of a speaker for auditory stimuli"""
 
 
-
 class OlfactometerChannelType(Enum):
     """Olfactometer channel types"""
 

--- a/src/aind_data_schema/components/devices.py
+++ b/src/aind_data_schema/components/devices.py
@@ -144,7 +144,6 @@ class Detector(Device):
     """Description of a generic detector"""
 
     detector_type: DetectorType = Field(..., title="Detector Type")
-    manufacturer: Organization.DETECTOR_MANUFACTURERS
     data_interface: DataInterface = Field(..., title="Data interface")
     cooling: Cooling = Field(default=Cooling.NO_COOLING, title="Cooling")
     frame_rate: Optional[Decimal] = Field(default=None, title="Frame rate (Hz)", description="Frame rate being used")
@@ -206,7 +205,6 @@ class Filter(Device):
 
     # required fields
     filter_type: FilterType = Field(..., title="Type of filter")
-    manufacturer: Organization.FILTER_MANUFACTURERS
 
     # optional fields
     cut_off_wavelength: Optional[int] = Field(default=None, title="Cut-off wavelength (nm)")
@@ -238,9 +236,6 @@ class Filter(Device):
 
 class Lens(Device):
     """Lens"""
-
-    # required fields
-    manufacturer: Organization.LENS_MANUFACTURERS
 
 
 class MotorizedStage(Device):
@@ -316,7 +311,6 @@ class DAQDevice(Device):
 
     # required fields
     data_interface: DataInterface = Field(..., title="Type of connection to PC")
-    manufacturer: Organization.DAQ_DEVICE_MANUFACTURERS
 
     # optional fields
     channels: List[DAQChannel] = Field(default=[], title="DAQ channels")
@@ -328,7 +322,6 @@ class HarpDevice(DAQDevice):
     """DAQ that uses the Harp protocol for synchronization and data transmission"""
 
     # required fields
-    manufacturer: Organization.ONE_OF = Field(default=Organization.OEPS)
     harp_device_type: HarpDeviceType.ONE_OF = Field(..., title="Type of Harp device")
     core_version: Optional[str] = Field(default=None, title="Core version")
     tag_version: Optional[str] = Field(default=None, title="Tag version")
@@ -351,7 +344,6 @@ class Laser(Device):
     """Laser module with a specific wavelength (may be a sub-component of a larger assembly)"""
 
     # required fields
-    manufacturer: Organization.LASER_MANUFACTURERS
     wavelength: int = Field(..., title="Wavelength (nm)")
     wavelength_unit: SizeUnit = Field(default=SizeUnit.NM, title="Wavelength unit")
 
@@ -369,7 +361,6 @@ class Laser(Device):
 class LightEmittingDiode(Device):
     """Description of a Light Emitting Diode (LED) device"""
 
-    manufacturer: Organization.LED_MANUFACTURERS
     wavelength: int = Field(..., title="Wavelength (nm)")
     wavelength_unit: SizeUnit = Field(default=SizeUnit.NM, title="Wavelength unit")
     bandwidth: Optional[int] = Field(default=None, title="Bandwidth (FWHM)")
@@ -416,7 +407,7 @@ class NeuropixelsBasestation(DAQDevice):
 
     # fixed values
     data_interface: DataInterface = DataInterface.PXI
-    manufacturer: Organization.DAQ_DEVICE_MANUFACTURERS = Organization.IMEC
+    manufacturer: Organization.ONE_OF = Organization.IMEC
 
 
 class OpenEphysAcquisitionBoard(DAQDevice):
@@ -427,13 +418,11 @@ class OpenEphysAcquisitionBoard(DAQDevice):
 
     # fixed values
     data_interface: Literal[DataInterface.USB] = DataInterface.USB
-    manufacturer: Organization.DAQ_DEVICE_MANUFACTURERS = Field(default=Organization.OEPS)
+    manufacturer: Organization.ONE_OF = Field(default=Organization.OEPS)
 
 
 class Manipulator(Device):
     """Manipulator used on a dome module"""
-
-    manufacturer: Organization.MANIPULATOR_MANUFACTURERS
 
 
 class FiberPatchCord(Device):
@@ -600,7 +589,6 @@ class Arena(Device):
 class Monitor(Device, DevicePosition):
     """Description of visual display for visual stimuli"""
 
-    manufacturer: Organization.MONITOR_MANUFACTURERS
     refresh_rate: int = Field(..., title="Refresh rate (Hz)", ge=60)
     width: int = Field(..., title="Width (pixels)")
     height: int = Field(..., title="Height (pixels)")
@@ -673,7 +661,6 @@ class AirPuffDevice(Device):
 class Speaker(Device, DevicePosition):
     """Description of a speaker for auditory stimuli"""
 
-    manufacturer: Organization.SPEAKER_MANUFACTURERS
 
 
 class OlfactometerChannelType(Enum):
@@ -694,8 +681,6 @@ class OlfactometerChannel(DataModel):
 
 class Olfactometer(HarpDevice):
     """Description of an olfactometer for odor stimuli"""
-
-    manufacturer: Organization.DAQ_DEVICE_MANUFACTURERS = Field(default=Organization.CHAMPALIMAUD)
 
     harp_device_type: HarpDeviceType.ONE_OF = Field(
         HarpDeviceType.OLFACTOMETER, frozen=True, title="Type of Harp device"

--- a/src/aind_data_schema/components/devices.py
+++ b/src/aind_data_schema/components/devices.py
@@ -368,6 +368,7 @@ class Laser(Device):
 class LightEmittingDiode(Device):
     """Description of a Light Emitting Diode (LED) device"""
 
+    manufacturer: Organization.ONE_OF = Field(..., title="Manufacturer")
     wavelength: int = Field(..., title="Wavelength (nm)")
     wavelength_unit: SizeUnit = Field(default=SizeUnit.NM, title="Wavelength unit")
     bandwidth: Optional[int] = Field(default=None, title="Bandwidth (FWHM)")

--- a/src/aind_data_schema/components/devices.py
+++ b/src/aind_data_schema/components/devices.py
@@ -144,6 +144,7 @@ class Detector(Device):
     """Description of a generic detector"""
 
     detector_type: DetectorType = Field(..., title="Detector Type")
+    manufacturer: Organization.ONE_OF = Field(..., title="Manufacturer")
     data_interface: DataInterface = Field(..., title="Data interface")
     cooling: Cooling = Field(default=Cooling.NO_COOLING, title="Cooling")
     frame_rate: Optional[Decimal] = Field(default=None, title="Frame rate (Hz)", description="Frame rate being used")
@@ -205,6 +206,7 @@ class Filter(Device):
 
     # required fields
     filter_type: FilterType = Field(..., title="Type of filter")
+    manufacturer: Organization.ONE_OF = Field(..., title="Manufacturer")
 
     # optional fields
     cut_off_wavelength: Optional[int] = Field(default=None, title="Cut-off wavelength (nm)")
@@ -236,6 +238,8 @@ class Filter(Device):
 
 class Lens(Device):
     """Lens"""
+
+    manufacturer: Organization.ONE_OF = Field(..., title="Manufacturer")
 
 
 class MotorizedStage(Device):
@@ -311,6 +315,7 @@ class DAQDevice(Device):
 
     # required fields
     data_interface: DataInterface = Field(..., title="Type of connection to PC")
+    manufacturer: Organization.ONE_OF = Field(..., title="Manufacturer")
 
     # optional fields
     channels: List[DAQChannel] = Field(default=[], title="DAQ channels")
@@ -322,6 +327,7 @@ class HarpDevice(DAQDevice):
     """DAQ that uses the Harp protocol for synchronization and data transmission"""
 
     # required fields
+    manufacturer: Organization.ONE_OF = Field(default=Organization.OEPS, title="Manufacturer")
     harp_device_type: HarpDeviceType.ONE_OF = Field(..., title="Type of Harp device")
     core_version: Optional[str] = Field(default=None, title="Core version")
     tag_version: Optional[str] = Field(default=None, title="Tag version")
@@ -344,6 +350,7 @@ class Laser(Device):
     """Laser module with a specific wavelength (may be a sub-component of a larger assembly)"""
 
     # required fields
+    manufacturer: Organization.ONE_OF = Field(..., title="Manufacturer")
     wavelength: int = Field(..., title="Wavelength (nm)")
     wavelength_unit: SizeUnit = Field(default=SizeUnit.NM, title="Wavelength unit")
 
@@ -424,6 +431,7 @@ class OpenEphysAcquisitionBoard(DAQDevice):
 class Manipulator(Device):
     """Manipulator used on a dome module"""
 
+    manufacturer: Organization.ONE_OF = Field(..., title="Manufacturer")
 
 class FiberPatchCord(Device):
     """Description of a patch cord"""
@@ -661,6 +669,8 @@ class AirPuffDevice(Device):
 class Speaker(Device, DevicePosition):
     """Description of a speaker for auditory stimuli"""
 
+    manufacturer: Organization.ONE_OF = Field(..., title="Manufacturer")
+
 
 class OlfactometerChannelType(Enum):
     """Olfactometer channel types"""
@@ -681,6 +691,7 @@ class OlfactometerChannel(DataModel):
 class Olfactometer(HarpDevice):
     """Description of an olfactometer for odor stimuli"""
 
+    manufacturer: Organization.ONE_OF = Field(..., title="Manufacturer")
     harp_device_type: HarpDeviceType.ONE_OF = Field(
         HarpDeviceType.OLFACTOMETER, frozen=True, title="Type of Harp device"
     )

--- a/src/aind_data_schema/components/devices.py
+++ b/src/aind_data_schema/components/devices.py
@@ -433,6 +433,7 @@ class Manipulator(Device):
 
     manufacturer: Organization.ONE_OF = Field(..., title="Manufacturer")
 
+
 class FiberPatchCord(Device):
     """Description of a patch cord"""
 

--- a/src/aind_data_schema/components/devices.py
+++ b/src/aind_data_schema/components/devices.py
@@ -599,6 +599,7 @@ class Arena(Device):
 class Monitor(Device, DevicePosition):
     """Description of visual display for visual stimuli"""
 
+    manufacturer: Organization.ONE_OF = Field(..., title="Manufacturer")
     refresh_rate: int = Field(..., title="Refresh rate (Hz)", ge=60)
     width: int = Field(..., title="Width (pixels)")
     height: int = Field(..., title="Height (pixels)")

--- a/src/aind_data_schema/components/subjects.py
+++ b/src/aind_data_schema/components/subjects.py
@@ -117,7 +117,7 @@ class MouseSubject(DataModel):
     breeding_info: Optional[BreedingInfo] = Field(default=None, title="Breeding Info")
     wellness_reports: List[WellnessReport] = Field(default=[], title="Wellness Report")
     housing: Optional[Housing] = Field(default=None, title="Housing")
-    source: Organization.SUBJECT_SOURCES = Field(
+    source: Organization.ONE_OF = Field(
         ...,
         description="Where the subject was acquired from. If bred in-house, use Allen Institute.",
         title="Source",
@@ -159,7 +159,7 @@ class HumanSubject(DataModel):
     species: SpeciesModel = Field(default=Species.HUMAN, title="Species")
     sex: Sex = Field(..., title="Sex")
     year_of_birth: int = Field(..., title="Year of birth")
-    source: Organization.SUBJECT_SOURCES = Field(
+    source: Organization.ONE_OF = Field(
         ...,
         description="Where the subject was acquired from.",
         title="Source",
@@ -181,7 +181,7 @@ class NonHumanPrimateSubject(DataModel):
     date_of_birth: Optional[Annotated[date_type, TimeValidation.BEFORE]] = Field(default=None, title="Date of birth")
     year_of_birth: int = Field(..., title="Year of birth")
     mating_status: MatingStatus = Field(..., title="Mating status")
-    source: Organization.SUBJECT_SOURCES = Field(
+    source: Organization.ONE_OF = Field(
         ...,
         description="Where the subject was acquired from.",
         title="Source",

--- a/src/aind_data_schema/components/surgery_procedures.py
+++ b/src/aind_data_schema/components/surgery_procedures.py
@@ -63,7 +63,7 @@ class HeadframeMaterial(str, Enum):
 class CatheterImplant(DataModel):
     """Description of a catheter implant procedure"""
 
-    where_performed: Organization.CATHETER_IMPLANT_INSTITUTIONS = Field(..., title="Where performed")
+    where_performed: Organization.ONE_OF = Field(..., title="Where performed")
     implanted_device: Catheter = Field(
         ...,
         title="Implanted device",

--- a/src/aind_data_schema/core/data_description.py
+++ b/src/aind_data_schema/core/data_description.py
@@ -25,7 +25,7 @@ from aind_data_schema.components.identifiers import Person
 class Funding(DataModel):
     """Description of funding sources"""
 
-    funder: Organization.FUNDERS = Field(..., title="Funder")
+    funder: Organization.ONE_OF = Field(..., title="Funder")
     grant_number: Optional[str] = Field(default=None, title="Grant number")
     fundee: Optional[List[Person]] = Field(
         default=None, title="Fundee", description="Person(s) funded by this mechanism"
@@ -65,7 +65,7 @@ class DataDescription(DataCoreModel):
         title="Data asset name",
         validate_default=True,
     )
-    institution: Organization.RESEARCH_INSTITUTIONS = Field(
+    institution: Organization.ONE_OF = Field(
         ...,
         description="An established society, corporation, foundation or other organization that collected this data",
         title="Institution",


### PR DESCRIPTION
PR removes all Organization.X groups, which will allow us to remove them from aind-data-schema-models and stop supporting them. This simplifies maintenance of the schema substantially. 

It also makes some Device subclasses like Lens superfluous now that there isn't a LENS_MANUFACTURERS group. We can't remove them until 3.X though for backward compatibility. 