### PR TITLE
feat: add name field to DataAsset (#1787)

### DIFF
--- a/docs/source/aind_data_schema_models/process_names.md
+++ b/docs/source/aind_data_schema_models/process_names.md
@@ -37,6 +37,7 @@ Process names
 | `IMAGE_TILE_ALIGNMENT` | `Image tile alignment` |
 | `IMAGE_TILE_FUSING` | `Image tile fusing` |
 | `IMAGE_TILE_PROJECTION` | `Image tile projection` |
+| `MANUAL_CURATION` | `Manual curation` |
 | `MODEL_EVALUATION` | `Model evaluation` |
 | `MODEL_TRAINING` | `Model training` |
 | `NEURON_SKELETON_PROCESSING` | `Neuron skeleton processing` |

--- a/docs/source/components/identifiers.md
+++ b/docs/source/components/identifiers.md
@@ -50,7 +50,8 @@ Description of a single data asset
 
 | Field | Type | Title (Description) |
 |-------|------|-------------|
-| `url` | `str` | Asset location (URL pointing to the data asset) |
+| `name` | `Optional[str]` | Asset name (Name of the data asset) |
+| `url` | `Optional[str]` | Asset location (URL pointing to the data asset) |
 
 
 ### Database

--- a/src/aind_data_schema/components/identifiers.py
+++ b/src/aind_data_schema/components/identifiers.py
@@ -1,5 +1,6 @@
 """Schema for identifiers"""
 
+import re
 from enum import Enum
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -26,7 +27,21 @@ DatabaseIdentifiers = Dict[Database, List[str]]
 class DataAsset(DataModel):
     """Description of a single data asset"""
 
-    url: str = Field(..., title="Asset location", description="URL pointing to the data asset")
+    name: Optional[str] = Field(default=None, title="Asset name", description="Name of the data asset")
+    url: Optional[str] = Field(default=None, title="Asset location", description="URL pointing to the data asset")
+
+    @model_validator(mode="after")
+    def validate_name(self):
+        """Validator to be sure name or url is provided
+        If name isn't provided, attempt to parse name from url. If url is also not provided, raise error.
+        """
+        if not self.name:
+            if not self.url:
+                raise ValueError("Either 'name' or 'url' must be provided for a DataAsset.")
+            match = re.match("^s3://aind-open-data/([^/]+)(/.*)?$", self.url)
+            if match is not None:
+                self.name = match.group(1)
+        return self
 
 
 class CombinedData(DataModel):

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -4,7 +4,7 @@ import unittest
 
 from pydantic import ValidationError
 
-from aind_data_schema.components.identifiers import Code, Person
+from aind_data_schema.components.identifiers import Code, DataAsset, Person
 
 
 class Testexperimenter(unittest.TestCase):
@@ -52,6 +52,38 @@ class TestGitHash(unittest.TestCase):
             with self.subTest(git_hash=git_hash):
                 with self.assertRaises(ValidationError):
                     Code(url="https://github.com/org/repo", commit_hash=git_hash)
+class TestDataAsset(unittest.TestCase):
+    """Test DataAsset validator"""
+
+    def test_name_provided_directly(self):
+        """Name is kept as-is when explicitly provided"""
+        asset = DataAsset(name="my-dataset")
+        self.assertEqual(asset.name, "my-dataset")
+
+    def test_name_parsed_from_url_no_subpath(self):
+        """Name is inferred from top-level prefix with no nested path"""
+        asset = DataAsset(url="s3://aind-open-data/my-dataset")
+        self.assertEqual(asset.name, "my-dataset")
+
+    def test_name_parsed_from_url_with_subpath(self):
+        """Name is inferred from top-level prefix, ignoring nested path"""
+        asset = DataAsset(url="s3://aind-open-data/my-dataset/sub/path/file.txt")
+        self.assertEqual(asset.name, "my-dataset")
+
+    def test_name_not_overridden_when_provided_with_url(self):
+        """Explicit name takes precedence over URL-inferred name"""
+        asset = DataAsset(name="explicit-name", url="s3://aind-open-data/other-dataset/sub")
+        self.assertEqual(asset.name, "explicit-name")
+
+    def test_neither_name_nor_url_raises(self):
+        """Raises ValidationError when neither name nor url is provided"""
+        with self.assertRaises(ValidationError):
+            DataAsset()
+
+    def test_url_wrong_bucket_leaves_name_none(self):
+        """URL from a different bucket does not set name (remains None)"""
+        asset = DataAsset(url="s3://other-bucket/my-dataset")
+        self.assertIsNone(asset.name)
 
 
 if __name__ == "__main__":

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -52,6 +52,8 @@ class TestGitHash(unittest.TestCase):
             with self.subTest(git_hash=git_hash):
                 with self.assertRaises(ValidationError):
                     Code(url="https://github.com/org/repo", commit_hash=git_hash)
+
+
 class TestDataAsset(unittest.TestCase):
     """Test DataAsset validator"""
 


### PR DESCRIPTION
infers name from url if in s3://aind-open-data/

I chose not to add a validation pattern to the name field since I assume we want to allow inputs matching old or new name patterns. Let me know if that would be preferred instead.