### PR TITLE
fix: dataprocess validator allow name or notes to specify Other

### DIFF
--- a/examples/processing.py
+++ b/examples/processing.py
@@ -3,7 +3,7 @@
 import argparse
 from datetime import datetime, timezone
 
-from aind_data_schema.components.identifiers import Code
+from aind_data_schema.components.identifiers import Code, DataAsset
 from aind_data_schema.core.processing import (
     DataProcess,
     Processing,
@@ -52,6 +52,9 @@ p = Processing.create_with_sequential_process_graph(
             name="Imaging processing pipeline",
             url="https://url/for/pipeline",
             version="0.1.1",
+            input_data=[DataAsset(
+                name="123456_2026-05-20_14-14-14",
+            )]
         ),
     ],
     data_processes=[
@@ -61,7 +64,7 @@ p = Processing.create_with_sequential_process_graph(
             stage=ProcessStage.PROCESSING,
             start_date_time=t,
             end_date_time=t,
-            output_path="/path/to/outputs",
+            output_path="path/to/outputs",
             pipeline_name="Imaging processing pipeline",
             code=example_code.model_copy(
                 update=dict(
@@ -90,7 +93,7 @@ p = Processing.create_with_sequential_process_graph(
             stage=ProcessStage.PROCESSING,
             start_date_time=t,
             end_date_time=t,
-            output_path="/path/to/outputs",
+            output_path="path/to/outputs",
             code=example_code.model_copy(
                 update=dict(
                     parameters={"u": 7, "z": True},
@@ -104,7 +107,7 @@ p = Processing.create_with_sequential_process_graph(
             stage=ProcessStage.PROCESSING,
             start_date_time=t,
             end_date_time=t,
-            output_path="/path/to/output",
+            output_path="path/to/output",
             code=example_code.model_copy(
                 update=dict(
                     parameters={"a": 2, "b": -2},
@@ -112,12 +115,13 @@ p = Processing.create_with_sequential_process_graph(
             ),
         ),
         DataProcess(
+            name="Analysis 1",
             stage=ProcessStage.ANALYSIS,
             experimenters=["Some Analyzer"],
             process_type=ProcessName.ANALYSIS,
             start_date_time=t,
             end_date_time=t,
-            output_path="/path/to/outputs",
+            output_path="path/to/outputs",
             code=example_code.model_copy(
                 update=dict(
                     parameters={"size": 7},
@@ -131,7 +135,7 @@ p = Processing.create_with_sequential_process_graph(
             process_type=ProcessName.ANALYSIS,
             start_date_time=t,
             end_date_time=t,
-            output_path="/path/to/outputs",
+            output_path="path/to/outputs",
             code=example_code.model_copy(
                 update=dict(
                     parameters={"u": 7, "z": True},

--- a/src/aind_data_schema/core/processing.py
+++ b/src/aind_data_schema/core/processing.py
@@ -7,7 +7,7 @@ from typing import Annotated, Dict, List, Literal, Optional
 
 from aind_data_schema_models.process_names import ProcessName
 from aind_data_schema_models.units import MemoryUnit, UnitlessUnit
-from pydantic import Field, SkipValidation, ValidationInfo, field_validator, model_validator
+from pydantic import Field, SkipValidation, model_validator
 
 from aind_data_schema.base import AwareDatetimeWithDefault, DataCoreModel, DataModel, GenericModel
 from aind_data_schema.components.identifiers import Code
@@ -75,13 +75,11 @@ class DataProcess(DataModel):
     notes: Optional[str] = Field(default=None, title="Notes", validate_default=True)
     resources: Optional[ResourceUsage] = Field(default=None, title="Process resource usage")
 
-
     @model_validator(mode="after")
     def validate_generic_processtype(self) -> "DataProcess":
         """Validate to be sure OTHER types are pinned down in name or notes"""
 
-        if (self.process_type in [ProcessName.OTHER, ProcessName.ANALYSIS] and 
-            not (self.notes or self.name)):
+        if self.process_type in [ProcessName.OTHER, ProcessName.ANALYSIS] and not (self.notes or self.name):
             raise ValueError(
                 "If 'process_type' is Other or Analysis, either 'name' or 'notes' must specify process details."
             )

--- a/src/aind_data_schema/core/processing.py
+++ b/src/aind_data_schema/core/processing.py
@@ -75,15 +75,17 @@ class DataProcess(DataModel):
     notes: Optional[str] = Field(default=None, title="Notes", validate_default=True)
     resources: Optional[ResourceUsage] = Field(default=None, title="Process resource usage")
 
-    @field_validator("notes", mode="after")
-    def validate_other(cls, value: Optional[str], info: ValidationInfo) -> Optional[str]:
-        """Validator for other/notes"""
 
-        if info.data.get("process_type") == ProcessName.OTHER and not value:
+    @model_validator(mode="after")
+    def validate_generic_processtype(self) -> "DataProcess":
+        """Validate to be sure OTHER types are pinned down in name or notes"""
+
+        if (self.process_type in [ProcessName.OTHER, ProcessName.ANALYSIS] and 
+            not (self.notes or self.name)):
             raise ValueError(
-                "Notes cannot be empty if 'process_type' is Other. Describe the type of processing in the notes field."
+                "If 'process_type' is Other or Analysis, either 'name' or 'notes' must specify process details."
             )
-        return value
+        return self
 
     @model_validator(mode="after")
     def fill_default_name(self) -> "DataProcess":

--- a/src/aind_data_schema/core/processing.py
+++ b/src/aind_data_schema/core/processing.py
@@ -10,7 +10,7 @@ from aind_data_schema_models.units import MemoryUnit, UnitlessUnit
 from pydantic import Field, SkipValidation, model_validator
 
 from aind_data_schema.base import AwareDatetimeWithDefault, DataCoreModel, DataModel, GenericModel
-from aind_data_schema.components.identifiers import Code
+from aind_data_schema.components.identifiers import Code, DataAsset  # noqa: F401
 from aind_data_schema.components.wrappers import AssetPath
 from aind_data_schema.utils.merge import merge_notes, merge_optional_list, merge_process_graph
 from aind_data_schema.utils.validators import TimeValidation

--- a/tests/test_composability_merge.py
+++ b/tests/test_composability_merge.py
@@ -252,9 +252,9 @@ class TestComposability(unittest.TestCase):
             data_processes=[
                 DataProcess(
                     experimenters=["Dr. Dan"],
-                    process_type=ProcessName.ANALYSIS,
+                    process_type=ProcessName.DENOISING,
                     stage=ProcessStage.PROCESSING,
-                    output_path="/path/to/outputs1",
+                    output_path="path/to/outputs1",
                     start_date_time=t,
                     end_date_time=t,
                     code=Code(
@@ -272,7 +272,7 @@ class TestComposability(unittest.TestCase):
                     experimenters=["Dr. Jane"],
                     process_type=ProcessName.COMPRESSION,
                     stage=ProcessStage.PROCESSING,
-                    output_path="/path/to/outputs2",
+                    output_path="path/to/outputs2",
                     start_date_time=t,
                     end_date_time=t,
                     code=Code(
@@ -289,7 +289,7 @@ class TestComposability(unittest.TestCase):
 
         # Check that the combined object has the correct data_processes and notes
         self.assertEqual(len(combined.data_processes), 2)
-        self.assertEqual(combined.data_processes[0].name, ProcessName.ANALYSIS)
+        self.assertEqual(combined.data_processes[0].name, ProcessName.DENOISING)
         self.assertEqual(combined.data_processes[1].name, ProcessName.COMPRESSION)
         self.assertIn("First processing object", combined.notes)
         self.assertIn("Second processing object", combined.notes)
@@ -313,13 +313,13 @@ class TestComposability(unittest.TestCase):
         with self.assertWarns(Warning) as w:
             combined = p1 + p1
         self.assertIn("Processing objects have repeated processes", str(w.warning))
-        self.assertEqual(combined.data_processes[1].name, "Analysis_1")
+        self.assertEqual(combined.data_processes[1].name, "Denoising_1")
 
         with self.assertWarns(Warning) as w:
             combined = combined + combined
         self.assertIn("Processing objects have repeated processes", str(w.warning))
-        self.assertEqual(combined.data_processes[2].name, "Analysis_2")
-        self.assertEqual(combined.data_processes[3].name, "Analysis_3")
+        self.assertEqual(combined.data_processes[2].name, "Denoising_2")
+        self.assertEqual(combined.data_processes[3].name, "Denoising_3")
 
     def test_merge_dependency_graph(self):
         """Test merging dependency graphs"""
@@ -331,7 +331,7 @@ class TestComposability(unittest.TestCase):
             data_processes=[
                 DataProcess(
                     experimenters=["Dr. Dan"],
-                    process_type=ProcessName.ANALYSIS,
+                    process_type=ProcessName.DENOISING,
                     stage=ProcessStage.PROCESSING,
                     start_date_time=t,
                     code=Code(url="https://example.com", version="1.0"),
@@ -357,20 +357,19 @@ class TestComposability(unittest.TestCase):
         self.assertIsNone(combined.dependency_graph)
 
         # Test both set case
-        p3 = Processing(
+        p3 = Processing.create_with_sequential_process_graph(
             data_processes=[
                 DataProcess(
                     experimenters=["Dr. Dan"],
-                    process_type=ProcessName.ANALYSIS,
+                    process_type=ProcessName.DENOISING,
                     stage=ProcessStage.PROCESSING,
                     start_date_time=t,
                     code=Code(url="https://example.com", version="1.0"),
                 )
             ],
-            dependency_graph={"Analysis": []},
         )
 
-        p4 = Processing(
+        p4 = Processing.create_with_sequential_process_graph(
             data_processes=[
                 DataProcess(
                     experimenters=["Dr. Jane"],
@@ -380,20 +379,19 @@ class TestComposability(unittest.TestCase):
                     code=Code(url="https://example.com", version="1.0"),
                 )
             ],
-            dependency_graph={"Compression": []},
         )
 
         combined = p3 + p4
         self.assertIsNotNone(combined.dependency_graph)
         self.assertEqual(len(combined.dependency_graph), 2)
-        self.assertIn("Analysis", combined.dependency_graph)
+        self.assertIn("Denoising", combined.dependency_graph)
         self.assertIn("Compression", combined.dependency_graph)
-        self.assertEqual(combined.dependency_graph["Compression"], ["Analysis"])
+        self.assertEqual(combined.dependency_graph["Compression"], ["Denoising"])
 
         # Test self has graph, other doesn't
         combined = p3 + p2
         self.assertIsNotNone(combined.dependency_graph)
-        self.assertIn("Analysis", combined.dependency_graph)
+        self.assertIn("Denoising", combined.dependency_graph)
 
         # Test other has graph, self doesn't
         combined = p2 + p4

--- a/tests/test_imaging.py
+++ b/tests/test_imaging.py
@@ -113,7 +113,7 @@ class ImagingTests(unittest.TestCase):
             experimenters=["Dr. Dan"],
             start_date_time=datetime.now(tz=timezone.utc),
             end_date_time=datetime.now(tz=timezone.utc),
-            output_path="/some/path",
+            output_path="some/path",
             code=Code(
                 url="https://github.com/abcd",
                 parameters=parameters,

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -97,9 +97,10 @@ class TestMetadata(unittest.TestCase):
             data_processes=[
                 DataProcess(
                     experimenters=["Dr. Dan"],
+                    name="My Analysis",
                     process_type=ProcessName.ANALYSIS,
                     stage=ProcessStage.ANALYSIS,
-                    output_path="/path/to/outputs",
+                    output_path="path/to/outputs",
                     start_date_time=t,
                     end_date_time=t,
                     code=Code(
@@ -826,9 +827,10 @@ class TestMetadata(unittest.TestCase):
             data_processes=[
                 DataProcess(
                     experimenters=["Dr. Dan"],
+                    name="My Analysis",
                     process_type=ProcessName.ANALYSIS,
                     stage=ProcessStage.ANALYSIS,
-                    output_path="/path/to/outputs",
+                    output_path="path/to/outputs",
                     start_date_time=datetime(2023, 4, 3, 20, 0, 0, tzinfo=timezone.utc),  # After acquisition
                     end_date_time=datetime(2023, 4, 3, 21, 0, 0, tzinfo=timezone.utc),
                     code=Code(
@@ -853,9 +855,10 @@ class TestMetadata(unittest.TestCase):
             data_processes=[
                 DataProcess(
                     experimenters=["Dr. Dan"],
+                    name="My Analysis",
                     process_type=ProcessName.ANALYSIS,
                     stage=ProcessStage.ANALYSIS,
-                    output_path="/path/to/outputs",
+                    output_path="path/to/outputs",
                     start_date_time=datetime(2023, 4, 3, 17, 0, 0, tzinfo=timezone.utc),  # Before acquisition start
                     end_date_time=datetime(2023, 4, 3, 21, 0, 0, tzinfo=timezone.utc),
                     code=Code(

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -475,6 +475,7 @@ class TestDataProcessValidateOther(unittest.TestCase):
     """Tests for DataProcess.validate_other"""
 
     def _make(self, process_type, **kwargs):
+        """Helper method to create a DataProcess with default values and override with kwargs"""
         return DataProcess(
             process_type=process_type,
             stage=ProcessStage.PROCESSING,

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -55,7 +55,6 @@ class ProcessingTest(unittest.TestCase):
         self.assertIsNotNone(p)
         self.assertEqual(p.data_processes[0].name, ProcessName.ANALYSIS)
 
-
     def test_resource_usage(self):
         """Test the ResourceUsage class"""
 

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -55,12 +55,6 @@ class ProcessingTest(unittest.TestCase):
         self.assertIsNotNone(p)
         self.assertEqual(p.data_processes[0].name, ProcessName.ANALYSIS)
 
-        with self.assertRaises(pydantic.ValidationError) as e:
-            DataProcess(process_type=ProcessName.OTHER, notes="")
-        self.assertIn("stage", repr(e.exception))
-        self.assertIn("code", repr(e.exception))
-        self.assertIn("start_date_time", repr(e.exception))
-        self.assertIn("notes", repr(e.exception))
 
     def test_resource_usage(self):
         """Test the ResourceUsage class"""
@@ -476,6 +470,68 @@ class ProcessingTest(unittest.TestCase):
         p4 = Processing(data_processes=[], dependency_graph={})
         self.assertEqual(len(p4.data_processes), 0)
         self.assertIsNone(p4.notes)
+
+
+class TestDataProcessValidateOther(unittest.TestCase):
+    """Tests for DataProcess.validate_other"""
+
+    def _make(self, process_type, **kwargs):
+        return DataProcess(
+            process_type=process_type,
+            stage=ProcessStage.PROCESSING,
+            experimenters=["Dr. Dan"],
+            code=code,
+            start_date_time=t,
+            **kwargs,
+        )
+
+    # --- ProcessName.OTHER ---
+
+    def test_other_with_name_passes(self):
+        """OTHER is allowed when a custom name is provided"""
+        dp = self._make(ProcessName.OTHER, name="my custom step")
+        self.assertEqual(dp.process_type, ProcessName.OTHER)
+
+    def test_other_with_notes_passes(self):
+        """OTHER is allowed when notes describe the process"""
+        dp = self._make(ProcessName.OTHER, notes="some detail")
+        self.assertEqual(dp.process_type, ProcessName.OTHER)
+
+    def test_other_with_name_and_notes_passes(self):
+        """OTHER is allowed when both name and notes are provided"""
+        dp = self._make(ProcessName.OTHER, name="step", notes="detail")
+        self.assertEqual(dp.process_type, ProcessName.OTHER)
+
+    def test_other_without_name_or_notes_fails(self):
+        """OTHER without name or notes should raise a ValidationError"""
+        with self.assertRaises(pydantic.ValidationError) as ctx:
+            self._make(ProcessName.OTHER)
+        self.assertIn("name' or 'notes' must specify process details", str(ctx.exception))
+
+    # --- ProcessName.ANALYSIS ---
+
+    def test_analysis_with_name_passes(self):
+        """ANALYSIS is allowed when a custom name is provided"""
+        dp = self._make(ProcessName.ANALYSIS, name="my analysis")
+        self.assertEqual(dp.process_type, ProcessName.ANALYSIS)
+
+    def test_analysis_with_notes_passes(self):
+        """ANALYSIS is allowed when notes are provided"""
+        dp = self._make(ProcessName.ANALYSIS, notes="analysis detail")
+        self.assertEqual(dp.process_type, ProcessName.ANALYSIS)
+
+    def test_analysis_without_name_or_notes_fails(self):
+        """ANALYSIS without name or notes should raise a ValidationError"""
+        with self.assertRaises(pydantic.ValidationError) as ctx:
+            self._make(ProcessName.ANALYSIS)
+        self.assertIn("name' or 'notes' must specify process details", str(ctx.exception))
+
+    # --- Other process types are not affected ---
+
+    def test_compression_without_name_or_notes_passes(self):
+        """Non-OTHER/ANALYSIS types do not require name or notes"""
+        dp = self._make(ProcessName.COMPRESSION)
+        self.assertEqual(dp.process_type, ProcessName.COMPRESSION)
 
 
 if __name__ == "__main__":

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -42,8 +42,8 @@ class ProcessingTest(unittest.TestCase):
             data_processes=[
                 DataProcess(
                     experimenters=["Dr. Dan"],
-                    process_type=ProcessName.ANALYSIS,
-                    stage=ProcessStage.ANALYSIS,
+                    process_type=ProcessName.DENOISING,
+                    stage=ProcessStage.PROCESSING,
                     code=code,
                     output_path="./path/to/outputs",
                     start_date_time=t,
@@ -53,7 +53,7 @@ class ProcessingTest(unittest.TestCase):
         )
 
         self.assertIsNotNone(p)
-        self.assertEqual(p.data_processes[0].name, ProcessName.ANALYSIS)
+        self.assertEqual(p.data_processes[0].name, ProcessName.DENOISING)
 
     def test_resource_usage(self):
         """Test the ResourceUsage class"""
@@ -120,16 +120,16 @@ class ProcessingTest(unittest.TestCase):
                 data_processes=[
                     DataProcess(
                         experimenters=["Dr. Dan"],
-                        process_type=ProcessName.ANALYSIS,
-                        stage=ProcessStage.ANALYSIS,
+                        process_type=ProcessName.DENOISING,
+                        stage=ProcessStage.PROCESSING,
                         start_date_time=t,
                         end_date_time=t,
                         code=code,
                     ),
                     DataProcess(
                         experimenters=["Dr. Dan"],
-                        process_type=ProcessName.ANALYSIS,
-                        stage=ProcessStage.ANALYSIS,
+                        process_type=ProcessName.DENOISING,
+                        stage=ProcessStage.PROCESSING,
                         start_date_time=t,
                         end_date_time=t,
                         code=code,
@@ -146,6 +146,7 @@ class ProcessingTest(unittest.TestCase):
             data_processes=[
                 DataProcess(
                     experimenters=["Dr. Dan"],
+                    name="My Analysis",
                     process_type=ProcessName.ANALYSIS,
                     stage=ProcessStage.ANALYSIS,
                     output_path="./path/to/outputs",
@@ -164,6 +165,7 @@ class ProcessingTest(unittest.TestCase):
                     [
                         DataProcess(
                             experimenters=["Dr. Dan"],
+                            name="My Analysis",
                             process_type=ProcessName.ANALYSIS,
                             stage=ProcessStage.ANALYSIS,
                             output_path="./path/to/outputs",
@@ -172,8 +174,7 @@ class ProcessingTest(unittest.TestCase):
                             code=code,
                         ),
                     ]
-                ],
-                dependency_graph={ProcessName.ANALYSIS: []},
+                ]
             )
 
     def test_rename_process(self):


### PR DESCRIPTION
The DataProcess validator required specifying additional details if process_type took the generic value 'Other', in the notes field - this was a relic of v1 because name was a controlled field, while now name is separate from process_type, so specifying the details of generic processes in the name should be preferred. Providing details in notes is still allowed for backwards compatibility.
This also adds the same behavior for process_type 'Analysis' which is also intended as a generic type - this is technically breaking, but the only records that use that type currently were created by the upgrader, and they have details in notes already.